### PR TITLE
Added support for multiple database connections

### DIFF
--- a/src/Extracting/DatabaseTransactionHelpers.php
+++ b/src/Extracting/DatabaseTransactionHelpers.php
@@ -7,23 +7,27 @@ use Exception;
 trait DatabaseTransactionHelpers
 {
     /**
+     * @param string $connection
+     *
      * @return void
      */
-    private function startDbTransaction()
+    private function startDbTransaction(String $connection = null)
     {
         try {
-            app('db')->beginTransaction();
+            app('db')->connection($connection)->beginTransaction();
         } catch (Exception $e) {
         }
     }
 
     /**
+     * @param string $connection
+     *
      * @return void
      */
-    private function endDbTransaction()
+    private function endDbTransaction(String $connection = null)
     {
         try {
-            app('db')->rollBack();
+            app('db')->connection($connection)->rollBack();
         } catch (Exception $e) {
         }
     }

--- a/src/Extracting/DatabaseTransactionHelpers.php
+++ b/src/Extracting/DatabaseTransactionHelpers.php
@@ -11,11 +11,15 @@ trait DatabaseTransactionHelpers
      *
      * @return void
      */
-    private function startDbTransaction(String $connection = null)
+    private function startDbTransaction()
     {
-        try {
-            app('db')->connection($connection)->beginTransaction();
-        } catch (Exception $e) {
+        $connections = array_keys(config('database.connections', []));
+
+        foreach ($connections as $conn) {
+            try {
+                app('db')->connection($conn)->beginTransaction();
+            } catch (Exception $e) {
+            }
         }
     }
 
@@ -24,11 +28,15 @@ trait DatabaseTransactionHelpers
      *
      * @return void
      */
-    private function endDbTransaction(String $connection = null)
+    private function endDbTransaction()
     {
-        try {
-            app('db')->connection($connection)->rollBack();
-        } catch (Exception $e) {
+        $connections = array_keys(config('database.connections', []));
+
+        foreach ($connections as $conn) {
+            try {
+                app('db')->connection($conn)->rollBack();
+            } catch (Exception $e) {
+            }
         }
     }
 }

--- a/src/Extracting/DatabaseTransactionHelpers.php
+++ b/src/Extracting/DatabaseTransactionHelpers.php
@@ -7,8 +7,6 @@ use Exception;
 trait DatabaseTransactionHelpers
 {
     /**
-     * @param string $connection
-     *
      * @return void
      */
     private function startDbTransaction()
@@ -24,8 +22,6 @@ trait DatabaseTransactionHelpers
     }
 
     /**
-     * @param string $connection
-     *
      * @return void
      */
     private function endDbTransaction()

--- a/src/Extracting/Strategies/Responses/ResponseCalls.php
+++ b/src/Extracting/Strategies/Responses/ResponseCalls.php
@@ -90,11 +90,7 @@ class ResponseCalls extends Strategy
      */
     private function configureEnvironment(array $rulesToApply)
     {
-        // Start transactions for all connections since we don't know wich one is used
-        $connections = array_keys(config('database.connections'));
-        foreach ($connections as $conn) {
-            $this->startDbTransaction($conn);
-        }
+        $this->startDbTransaction();
         $this->setLaravelConfigs($rulesToApply['config'] ?? []);
     }
 
@@ -151,11 +147,7 @@ class ResponseCalls extends Strategy
      */
     private function finish()
     {
-        // Stop transactions for all connections since we started all of them.
-        $connections = array_keys(config('database.connections'));
-        foreach ($connections as $conn) {
-            $this->endDbTransaction($conn);
-        }
+        $this->endDbTransaction();
     }
 
     /**

--- a/src/Extracting/Strategies/Responses/ResponseCalls.php
+++ b/src/Extracting/Strategies/Responses/ResponseCalls.php
@@ -3,12 +3,12 @@
 namespace Knuckles\Scribe\Extracting\Strategies\Responses;
 
 use Dingo\Api\Dispatcher;
+use Dingo\Api\Routing\Route as DingoRoute;
 use Exception;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
-use Dingo\Api\Routing\Route as DingoRoute;
 use Illuminate\Support\Str;
 use Knuckles\Scribe\Extracting\DatabaseTransactionHelpers;
 use Knuckles\Scribe\Extracting\ParamHelpers;

--- a/src/Extracting/Strategies/Responses/ResponseCalls.php
+++ b/src/Extracting/Strategies/Responses/ResponseCalls.php
@@ -90,7 +90,11 @@ class ResponseCalls extends Strategy
      */
     private function configureEnvironment(array $rulesToApply)
     {
-        $this->startDbTransaction();
+        // Start transactions for all connections since we don't know wich one is used
+        $connections = array_keys(config('database.connections'));
+        foreach ($connections as $conn) {
+            $this->startDbTransaction($conn);
+        }
         $this->setLaravelConfigs($rulesToApply['config'] ?? []);
     }
 
@@ -147,7 +151,11 @@ class ResponseCalls extends Strategy
      */
     private function finish()
     {
-        $this->endDbTransaction();
+        // Stop transactions for all connections since we started all of them.
+        $connections = array_keys(config('database.connections'));
+        foreach ($connections as $conn) {
+            $this->endDbTransaction($conn);
+        }
     }
 
     /**

--- a/src/Extracting/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Extracting/Strategies/Responses/UseApiResourceTags.php
@@ -173,9 +173,7 @@ class UseApiResourceTags extends Strategy
      */
     protected function instantiateApiResourceModel(string $type, array $factoryStates = [], array $relations = [])
     {
-        $connection = app($type)->getConnectionName();
-
-        $this->startDbTransaction($connection);
+        $this->startDbTransaction();
         try {
             // Try Eloquent model factory
 
@@ -214,7 +212,7 @@ class UseApiResourceTags extends Strategy
                 }
             }
         } finally {
-            $this->endDbTransaction($connection);
+            $this->endDbTransaction();
         }
 
         return $instance;

--- a/src/Extracting/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Extracting/Strategies/Responses/UseApiResourceTags.php
@@ -13,12 +13,12 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Knuckles\Scribe\Extracting\DatabaseTransactionHelpers;
-use Knuckles\Scribe\Tools\AnnotationParser;
-use League\Fractal\Resource\Collection;
 use Knuckles\Scribe\Extracting\RouteDocBlocker;
 use Knuckles\Scribe\Extracting\Strategies\Strategy;
+use Knuckles\Scribe\Tools\AnnotationParser;
 use Knuckles\Scribe\Tools\Flags;
 use Knuckles\Scribe\Tools\Utils;
+use League\Fractal\Resource\Collection;
 use Mpociot\Reflection\DocBlock;
 use Mpociot\Reflection\DocBlock\Tag;
 use ReflectionClass;
@@ -50,7 +50,6 @@ class UseApiResourceTags extends Strategy
 
         try {
             return $this->getApiResourceResponse($methodDocBlock->getTags());
-
         } catch (Exception $e) {
             clara('knuckleswtf/scribe')->warn('Exception thrown when fetching Eloquent API resource response for [' . implode(',', $route->methods) . "] {$route->uri}.");
             if (Flags::$shouldBeVerbose) {
@@ -101,7 +100,7 @@ class UseApiResourceTags extends Strategy
                     $perPage
                 );
                 $list = $paginator;
-            } else if (count($pagination) == 2 && $pagination[0] == 'simple') {
+            } elseif (count($pagination) == 2 && $pagination[0] == 'simple') {
                 $perPage = $pagination[1];
                 $paginator = new Paginator($models, $perPage);
                 $list = $paginator;
@@ -174,7 +173,9 @@ class UseApiResourceTags extends Strategy
      */
     protected function instantiateApiResourceModel(string $type, array $factoryStates = [], array $relations = [])
     {
-        $this->startDbTransaction();
+        $connection = app($type)->getConnectionName();
+
+        $this->startDbTransaction($connection);
         try {
             // Try Eloquent model factory
 
@@ -213,7 +214,7 @@ class UseApiResourceTags extends Strategy
                 }
             }
         } finally {
-            $this->endDbTransaction();
+            $this->endDbTransaction($connection);
         }
 
         return $instance;

--- a/src/Extracting/Strategies/Responses/UseTransformerTags.php
+++ b/src/Extracting/Strategies/Responses/UseTransformerTags.php
@@ -162,9 +162,7 @@ class UseTransformerTags extends Strategy
 
     protected function instantiateTransformerModel(string $type, array $factoryStates = [], array $relations = [])
     {
-        $connection = app($type)->getConnectionName();
-
-        $this->startDbTransaction($connection);
+        $this->startDbTransaction();
         try {
             // try Eloquent model factory
 
@@ -204,7 +202,7 @@ class UseTransformerTags extends Strategy
                 }
             }
         } finally {
-            $this->endDbTransaction($connection);
+            $this->endDbTransaction();
         }
 
         return $instance;

--- a/tests/Fixtures/TestModel.php
+++ b/tests/Fixtures/TestModel.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
  *
  * @author Tobias van Beek <t.vanbeek@tjvb.nl>
  */
-class TestModel extends Model
+class TestModel
 {
     public $id = 1;
 

--- a/tests/Fixtures/TestModel.php
+++ b/tests/Fixtures/TestModel.php
@@ -2,8 +2,6 @@
 
 namespace Knuckles\Scribe\Tests\Fixtures;
 
-use Illuminate\Database\Eloquent\Model;
-
 /**
  * A demo test model.
  *

--- a/tests/Fixtures/TestModel.php
+++ b/tests/Fixtures/TestModel.php
@@ -2,12 +2,14 @@
 
 namespace Knuckles\Scribe\Tests\Fixtures;
 
+use Illuminate\Database\Eloquent\Model;
+
 /**
  * A demo test model.
  *
  * @author Tobias van Beek <t.vanbeek@tjvb.nl>
  */
-class TestModel
+class TestModel extends Model
 {
     public $id = 1;
 


### PR DESCRIPTION
Closes #4 

For ApiResource and Transformer strategies the model types connection is used to start the transaction. For the ResponseCall strategy a transaction for every database connection is started since we don't know which one is used for a specific route.