### PR TITLE
Resolves #22 - Set the correct config key for documentation URL

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -33,7 +33,7 @@ return [
          * URL path to use for the docs endpoint (if `add_routes` is true).
          * By default, `/docs` opens the HTML page, and `/docs.json` downloads the Postman collection.
          */
-        'url' => '/docs',
+        'docs_url' => '/docs',
 
         /*
          * Middleware to attach to the docs endpoint (if `add_routes` is true).


### PR DESCRIPTION
As per #22 - updated base configuration file