### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "knuckleswtf/pastel": "^1.3.3",
         "league/flysystem": "^1.0",
         "mpociot/reflection-docblock": "^1.0.1",
-        "nunomaduro/collision": "^3.0|^4.0",
+        "nunomaduro/collision": "^3.0|^4.0|^5.0",
         "ramsey/uuid": "^3.8|^4.0",
         "shalvah/clara": "^2.6",
         "symfony/var-exporter": "^4.0|^5.0"
@@ -37,7 +37,7 @@
         "league/fractal": "^0.19.0",
         "orchestra/testbench": "^3.7|^4.0|^5.0",
         "phpstan/phpstan": "^0.12.19",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "suggest": {
         "league/fractal": "Required for transformers support"


### PR DESCRIPTION
update dependency version issues, causing issues w/ using https://pestphp.com/ which requires collision version 5.0, and phpunit 9.

**Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR is likely to be turned down.
