### PR TITLE
feat(config): ability to set postman base_url independently

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -123,6 +123,13 @@ INTRO
         'enabled' => true,
 
         /*
+         * The base URL to be used in the Postman collection.
+         * This will override the base_url settings above only for Postman.
+         * If this is null, Scribe will use the value of config('app.url').
+         */
+        'base_url' => null,
+
+        /*
          * The description for the exported Postman collection.
          */
         'description' => null,

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -24,6 +24,11 @@ class Writer
     private $baseUrl;
 
     /**
+     * @var string
+     */
+    private $postmanBaseUrl;
+
+    /**
      * @var bool
      */
     private $shouldOverwrite;
@@ -73,6 +78,7 @@ class Writer
         // If no config is injected, pull from global. Makes testing easier.
         $this->config = $config ?: new DocumentationConfig(config('scribe'));
         $this->baseUrl = $this->config->get('base_url') ?? config('app.url');
+        $this->postmanBaseUrl = $this->config->get('postman.base_url') ?? $this->baseUrl;
         $this->shouldOverwrite = $shouldOverwrite;
         $this->shouldGeneratePostmanCollection = $this->config->get('postman.enabled', false);
         $this->pastel = new Pastel();
@@ -180,7 +186,7 @@ class Writer
         /** @var PostmanCollectionWriter $writer */
         $writer = app()->makeWith(
             PostmanCollectionWriter::class,
-            ['routeGroups' => $routes, 'baseUrl' => $this->baseUrl]
+            ['routeGroups' => $routes, 'baseUrl' => $this->postmanBaseUrl]
         );
 
         return $writer->makePostmanCollection();

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -264,7 +264,7 @@ class GenerateDocumentationTest extends TestCase
     /** @test */
     public function generated_postman_collection_can_have_custom_url()
     {
-        Config::set('scribe.base_url', 'http://yourapp.app');
+        Config::set('scribe.postman.base_url', 'http://yourapp.app');
         RouteFacade::get('/api/test', TestController::class . '@withEndpointDescription');
         RouteFacade::post('/api/responseTag', TestController::class . '@withResponseTag');
 


### PR DESCRIPTION
In the [document](https://github.com/knuckleswtf/scribe/blob/6863189588e4a9a1269c5c9b41de6a9905d80131/docs/generating-documentation.md#L26) mentioned that a `postman.base_url` can be specified for postman collection generated.
However after reviewing the code, I find only the `base_url` in the outer array can be changed and by changing it will change both the postman collection's `base_url` and the examples.

Since I think many users might preferred having different customization of page and postman, I've tried to implement this feature.
