### PR TITLE
[#53] Fixed issue where purposeful head requests aren't rendered

### DIFF
--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -43,7 +43,13 @@ class Generator
      */
     public function getMethods(Route $route)
     {
-        return array_diff($route->methods(), ['HEAD']);
+        $methods = $route->methods();
+
+        if (count($methods) === 1) {
+            return $methods;
+        }
+
+        return array_diff($methods, ['HEAD']);
     }
 
     /**

--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -45,6 +45,8 @@ class Generator
     {
         $methods = $route->methods();
 
+        // Laravel adds an automatic "HEAD" endpoint for each GET request, so we'll strip that out,
+        // but not if there's only one method (means it was intentional)
         if (count($methods) === 1) {
             return $methods;
         }

--- a/src/Tools/ConsoleOutputUtils.php
+++ b/src/Tools/ConsoleOutputUtils.php
@@ -61,7 +61,12 @@ class ConsoleOutputUtils
      */
     public static function getRouteRepresentation(Route $route): string
     {
-        $routeMethods = implode(',', array_diff($route->methods(), ['HEAD']));
+        $methods = $route->methods();
+        if (count($methods) > 1) {
+            $methods = array_diff($route->methods(), ['HEAD']);
+        }
+
+        $routeMethods = implode(',', $methods);
         $routePath = $route->uri();
         return "[$routeMethods] $routePath";
     }

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -70,6 +70,20 @@ class GenerateDocumentationTest extends TestCase
     }
 
     /** @test */
+    public function can_process_traditional_laravel_head_routes()
+    {
+        RouteFacade::addRoute('HEAD', '/api/test', TestController::class . '@withEndpointDescription');
+
+        config(['scribe.routes.0.match.prefixes' => ['api/*']]);
+        $output = $this->artisan('scribe:generate');
+
+        $this->assertStringContainsString('Processed route: [HEAD] api/test', $output);
+    }
+
+    /**
+     * @test
+     * @see https://github.com/knuckleswtf/scribe/issues/53
+     */
     public function can_process_closure_routes()
     {
         RouteFacade::get('/api/closure', function () {


### PR DESCRIPTION
> **Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.

When a route that uses the `HEAD` verb exclusively is encountered, the `Writer` causes an `Undefined Offset` exception to be thrown as `HEAD` verbs are filtered out of the list of methods for an endpoint.

This solution makes an exception for `HEAD` where it is the **only** method specified by the developer. This is so that the original functionality is retained.

As per my comments on #53, I think that filtering out `HEAD` obfuscates what is actually happening; and Laravel should probably provide guidance/configurability for what appears to be a widely undesired behaviour; therefore making this functionality surplus to requirement.

/fixes #53 