### PR TITLE
[WIP] [#48] Added defensive code for DatabaseConnection drivers that don't support transactions

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -331,4 +331,9 @@ INTRO
      *
      */
     'routeMatcher' => \Knuckles\Scribe\Matching\RouteMatcher::class,
+
+    /**
+     * [Advanced usage] If a database driver does not support transactions, you can list it here to allow it to run.
+     */
+    'run_without_database_transactions' => [],
 ];

--- a/src/Exceptions/DbTransactionSupportException.php
+++ b/src/Exceptions/DbTransactionSupportException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Knuckles\Scribe\Exceptions;
+
+use Knuckles\Scribe\Exceptions\ScribeException;
+use RuntimeException;
+
+class DbTransactionSupportException extends RuntimeException implements ScribeException
+{
+    public static function create(string $connection_name, string $driver_name)
+    {
+        return new self(
+            "Database Driver [{$driver_name}] for connection [{$connection_name}] does not support transactions. " .
+            "Changes to your database will be persistent. " .
+            "To allow this, add \"{$connection_name}\" to the \"run_without_database_transactions\" config."
+        );
+    }
+}

--- a/src/Exceptions/ScribeException.php
+++ b/src/Exceptions/ScribeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Knuckles\Scribe\Exceptions;
+
+interface ScribeException
+{
+}

--- a/src/Extracting/Strategies/Strategy.php
+++ b/src/Extracting/Strategies/Strategy.php
@@ -25,6 +25,16 @@ abstract class Strategy
     }
 
     /**
+     * Returns an instance of the documentation config
+     *
+     * @return DocumentationConfig
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
      * @param Route $route The route which we are currently extracting information for.
      * @param ReflectionClass $controller The class handling the current route.
      * @param ReflectionFunctionAbstract $method The method/closure handling the current route.


### PR DESCRIPTION
Some third-party database drivers don't support transactions *cough* Jenssegers *cough*. I'm sure there are probably some more out there.

Thought I'd throw this out there as a possible solution, and get guidance from maintainers before writing the relevant Unit tests. 

Potentially fixes #48 
> **Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.