### PR TITLE
Breaking changes due to Overrides update

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -360,7 +360,7 @@ class OpenAPISpecWriter
                     if (isset($endpoint['responseFields'][$key]['description'])) {
                         $spec['description'] = $endpoint['responseFields'][$key]['description'];
                     }
-                    if ($spec['type'] === 'array') {
+                    if ($spec['type'] === 'array' && !empty($value)) {
                         $spec['items']['type'] = $this->convertScribeOrPHPTypeToOpenAPIType(gettype($value[0]));
                     }
 

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -237,7 +237,7 @@ class Writer
         );
 
         $spec = $writer->generateSpecContent($groupedEndpoints);
-        $overrides = $this->config->get('openapi.overrides');
+        $overrides = $this->config->get('openapi.overrides', []);
         if (count($overrides)) {
             foreach ($overrides as $key => $value) {
                 data_set($spec, $key, $value);

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -219,7 +219,7 @@ class Writer
         );
 
         $collection = $writer->generatePostmanCollection();
-        $overrides = $this->config->get('postman.overrides');
+        $overrides = $this->config->get('postman.overrides', []);
         if (count($overrides)) {
             foreach ($overrides as $key => $value) {
                 data_set($collection, $key, $value);


### PR DESCRIPTION
Had some things broken due to no checks for empty values in 1.4. No changes to my config generated with 1.3 (using the default config with the exception of a custom Serializer).

<code>
🔊 info Generating Postman collection

   ErrorException 

  count(): Parameter must be an array or an object that implements Countable

  at vendor/knuckleswtf/scribe/src/Writing/Writer.php:223
    219|         );
    220| 
    221|         $collection = $writer->generatePostmanCollection();
    222|         $overrides = $this->config->get('postman.overrides');
  > 223|         if (count($overrides)) {
    224|             foreach ($overrides as $key => $value) {
    225|                 data_set($collection, $key, $value);
    226|             }
    227|         }

      +18 vendor frames 
  19  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
</code>

and

<code>
 info Generating OpenAPI specification

   ErrorException 

  Undefined offset: 0

  at vendor/knuckleswtf/scribe/src/Writing/OpenAPISpecWriter.php:365
    361|                         $spec['description'] = $endpoint['responseFields'][$key]['description'];
    362|                     }
    363|                     
    364|                     if ($spec['type'] === 'array') {
  > 365|                         $spec['items']['type'] = $this->convertScribeOrPHPTypeToOpenAPIType(gettype($value[0]));
    366|                     }
    367| 
    368|                     return [
    369|                         $key => $spec,

      +28 vendor frames 
  29  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
</code>