### PR TITLE
Feature/add context for route being processed

### DIFF
--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -32,7 +32,7 @@ class Generator
     }
 
     /**
-     * @return Route|null
+     * External interface that allows users to know what route is currently being processed
      */
     public static function getRouteBeingProcessed(): ?Route
     {

--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -20,12 +20,23 @@ class Generator
      */
     private $config;
 
-    public static $routeBeingProcessed = null;
+    /**
+     * @var Route|null
+     */
+    private static $routeBeingProcessed = null;
 
     public function __construct(DocumentationConfig $config = null)
     {
         // If no config is injected, pull from global
         $this->config = $config ?: new DocumentationConfig(config('scribe'));
+    }
+
+    /**
+     * @return Route|null
+     */
+    public static function getRouteBeingProcessed(): ?Route
+    {
+        return self::$routeBeingProcessed;
     }
 
     /**

--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -20,6 +20,8 @@ class Generator
      */
     private $config;
 
+    public static $routeBeingProcessed = null;
+
     public function __construct(DocumentationConfig $config = null)
     {
         // If no config is injected, pull from global
@@ -64,6 +66,8 @@ class Generator
      */
     public function processRoute(Route $route, array $routeRules = [])
     {
+        self::$routeBeingProcessed = $route;
+
         [$controllerName, $methodName] = u::getRouteClassAndMethodNames($route);
         $controller = new ReflectionClass($controllerName);
         $method = u::getReflectedRouteMethod([$controllerName, $methodName]);
@@ -112,6 +116,8 @@ class Generator
 
         $responseFields = $this->fetchResponseFields($controller, $method, $route, $routeRules, $parsedRoute);
         $parsedRoute['responseFields'] = $responseFields;
+
+        self::$routeBeingProcessed = null;
 
         return $parsedRoute;
     }


### PR DESCRIPTION
I think this would be a useful feature for those who need to contextually know what controller + action + middlware belongs to a route when documentation is being auto-generated using request classes. For instance, I dynamically generate bodyParams in request classes based on what middleware the route uses.