### PR TITLE
Generating form data with more complex arrays and objects

### DIFF
--- a/src/Tools/WritingUtils.php
+++ b/src/Tools/WritingUtils.php
@@ -111,23 +111,35 @@ class WritingUtils
      *
      * @return array
      */
-    public static function getParameterNamesAndValuesForFormData(string $parameter, $value): array
+    public static function getParameterNamesAndValuesForFormData($parameter, $value)
     {
-        if (!is_array($value)) {
-            return [$parameter => $value];
+        $results = [];
+
+        if (is_array($value) && ! empty($value)) {
+            foreach ($value as $key => $v) {
+                if (is_numeric($key)) {
+                    $key = '';
+                }
+
+                if (is_array($v) && ! empty($v)) {
+                    $results = array_merge($results, static::getParameterNamesAndValuesForFormData($parameter.'['.$key.'][', $v));
+                } else {
+                    if ($v != null) {
+                        if (substr($parameter, -1) === '[') {
+                            $results[$parameter . $key . ']'] = $v;
+                        } else {
+                            $results[$parameter . '[' . $key . ']'] = $v;
+                        }
+                    }
+                }
+            }
+        } else {
+            if ($value != null) {
+                $results[$parameter] = $value;
+            }
         }
 
-        if (array_keys($value)[0] === 0) {
-            // We assume it's a list if its first key is 0
-            return [$parameter . '[]' => $value[0]];
-        }
-
-        // Transform maps
-        $params = [];
-        foreach ($value as $item => $itemValue) {
-            $params[$parameter . "[$item]"] = $itemValue;
-        }
-        return $params;
+        return $results;
     }
 
     /**

--- a/src/Tools/WritingUtils.php
+++ b/src/Tools/WritingUtils.php
@@ -122,7 +122,10 @@ class WritingUtils
                 }
 
                 if (is_array($v) && ! empty($v)) {
-                    $results = array_merge($results, static::getParameterNamesAndValuesForFormData($parameter.'['.$key.'][', $v));
+                    $results = array_merge(
+                        $results,
+                        static::getParameterNamesAndValuesForFormData($parameter.'['.$key.'][', $v)
+                    );
                 } else {
                     if ($v != null) {
                         if (substr($parameter, -1) === '[') {

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -5,6 +5,7 @@ namespace Knuckles\Scribe\Writing;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
+use Knuckles\Scribe\Tools\WritingUtils;
 use Ramsey\Uuid\Uuid;
 use ReflectionMethod;
 
@@ -104,12 +105,14 @@ class PostmanCollectionWriter
         switch ($mode) {
             case 'formdata':
                 foreach ($route['cleanBodyParameters'] as $key => $value) {
-                    $params = [
-                        'key' => $key,
-                        'value' => $value,
-                        'type' => 'text'
-                    ];
-                    $body[$mode][] = $params;
+                    foreach (WritingUtils::getParameterNamesAndValuesForFormData($key, $value) as $key => $actualValue) {
+                        $params = [
+                            'key' => $key,
+                            'value' => $actualValue,
+                            'type' => 'text'
+                        ];
+                        $body[$mode][] = $params;
+                    }
                 }
                 foreach ($route['fileParameters'] as $key => $value) {
                     $params = [

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -105,9 +105,9 @@ class PostmanCollectionWriter
         switch ($mode) {
             case 'formdata':
                 foreach ($route['cleanBodyParameters'] as $key => $value) {
-                    foreach (WritingUtils::getParameterNamesAndValuesForFormData($key, $value) as $key => $actualValue) {
+                    foreach (WritingUtils::getParameterNamesAndValuesForFormData($key, $value) as $k => $actualValue) {
                         $params = [
-                            'key' => $key,
+                            'key' => $k,
                             'value' => $actualValue,
                             'type' => 'text'
                         ];


### PR DESCRIPTION
Hi,

form data processing added in https://github.com/knuckleswtf/scribe/pull/13 does not count with more complex objects like this:

![image](https://user-images.githubusercontent.com/12200234/91864049-17528e00-ec70-11ea-8e74-dcafc92b2624.png)

and results with error on creating documentation:

```
Facade\Ignition\Exceptions\ViewException 

  Array to string conversion (View: /Users/mnagy/AMCEF/Git/mapujme-new/backend/resources/views/vendor/scribe/partials/example-requests/bash.blade.php)

  at resources/views/vendor/scribe/partials/example-requests/bash.blade.php:12
     8| @endif
     9| @if(count($route['fileParameters']))
    10| @foreach($route['cleanBodyParameters'] as $parameter => $value)
    11| @foreach( \Knuckles\Scribe\Tools\WritingUtils::getParameterNamesAndValuesForFormData($parameter,$value) as $key => $actualValue)
  > 12|     -F "{!! "$key=".$actualValue !!}" \
    13| @endforeach
    14| @endforeach
    15| @foreach($route['fileParameters'] as $parameter => $file)
    16|     -F "{!! "$parameter=@".$file->path() !!}" @if(! ($loop->last))\@endif

      +2 vendor frames 
  3   [internal]:0
      Knuckles\Scribe\Writing\Writer::Knuckles\Scribe\Writing\{closure}()

  4   [internal]:0
      Knuckles\Scribe\Writing\Writer::Knuckles\Scribe\Writing\{closure}(Object(Illuminate\Support\Collection), "Maps")
```

WritingUtils and PostmanWriter were changed to remove error and create correct postman collection:

![image](https://user-images.githubusercontent.com/12200234/91864479-84662380-ec70-11ea-8ee1-c28b58ea4f01.png)

If there are any problems with PR, just comment out, I will try to fix them, contributing first time :)