### PR TITLE
Properly iterate over all database transactions

### DIFF
--- a/src/Extracting/DatabaseTransactionHelpers.php
+++ b/src/Extracting/DatabaseTransactionHelpers.php
@@ -21,7 +21,7 @@ trait DatabaseTransactionHelpers
                 if (self::driverSupportsTransactions($driver)) {
                     $driver->beginTransaction();
 
-                    return;
+                    continue;
                 }
 
                 $driverClassName = get_class($driver);
@@ -52,7 +52,7 @@ trait DatabaseTransactionHelpers
                 if (self::driverSupportsTransactions($driver)) {
                     $driver->rollBack();
 
-                    return;
+                    continue;
                 }
 
                 $driverClassName = get_class($driver);


### PR DESCRIPTION
I ran into problems where generating documentation would result in data being added to my database.
After investigating I found that a DatabaseTransaction is only started for the first connection in the config.

[This comment](https://github.com/knuckleswtf/scribe/pull/5#pullrequestreview-407382542) on a previous PR makes me believe the intention is to start a transaction for all available connections. 
This PR should fix that

