### PR TITLE
More flexible responses file location

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -118,6 +118,8 @@ INTRO
 
     'description' => '',
 
+    'responses_base_dir' => storage_path('responses/'),
+
     /*
      * Generate a Postman collection in addition to HTML docs.
      * For 'static' docs, the collection will be generated to public/docs/collection.json.

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -118,7 +118,7 @@ INTRO
 
     'description' => '',
 
-    'responses_base_dir' => storage_path('responses/'),
+    'responses_base_dir' => storage_path() . '/',
 
     /*
      * Generate a Postman collection in addition to HTML docs.

--- a/src/Extracting/Strategies/Responses/UseResponseFileTag.php
+++ b/src/Extracting/Strategies/Responses/UseResponseFileTag.php
@@ -69,7 +69,6 @@ class UseResponseFileTag extends Strategy
             $filePath = $baseResponsePath . $relativeFilePath;
             if (! file_exists($filePath)) {
                 c::warn("@responseFile {$relativeFilePath} does not exist");
-                return false;
             }
             $content = file_get_contents($filePath, true);
             if ($json) {

--- a/src/Extracting/Strategies/Responses/UseResponseFileTag.php
+++ b/src/Extracting/Strategies/Responses/UseResponseFileTag.php
@@ -65,9 +65,11 @@ class UseResponseFileTag extends Strategy
             $status = $attributes['status'] ?: ($status ?: 200);
             $description = $attributes['scenario'] ? "$status, {$attributes['scenario']}" : "$status";
 
-            $filePath = storage_path($relativeFilePath);
+            $baseResponsePath = config('responses_base_dir');
+            $filePath = $baseResponsePath . $relativeFilePath;
             if (! file_exists($filePath)) {
                 c::warn("@responseFile {$relativeFilePath} does not exist");
+                return false;
             }
             $content = file_get_contents($filePath, true);
             if ($json) {

--- a/tests/Strategies/Responses/UseResponseFileTagTest.php
+++ b/tests/Strategies/Responses/UseResponseFileTagTest.php
@@ -33,8 +33,10 @@ class UseResponseFileTagTest extends TestCase
         $filePath =  __DIR__ . '/../../Fixtures/response_test.json';
         $filePath2 =  __DIR__ . '/../../Fixtures/response_error_test.json';
 
-        copy($filePath, storage_path('response_test.json'));
-        copy($filePath2, storage_path('response_error_test.json'));
+        $baseResponsesPath = config('scribe.responses_base_dir', storage_path() . '/');
+
+        copy($filePath, $baseResponsesPath . 'response_test.json');
+        copy($filePath2, $baseResponsesPath . 'response_error_test.json');
 
         $strategy = new UseResponseFileTag(new DocumentationConfig([]));
         $results = $strategy->getFileResponses($tags);
@@ -52,8 +54,8 @@ class UseResponseFileTagTest extends TestCase
             ],
         ], $results);
 
-        unlink(storage_path('response_test.json'));
-        unlink(storage_path('response_error_test.json'));
+        unlink($baseResponsesPath . 'response_test.json');
+        unlink($baseResponsesPath . 'response_error_test.json');
     }
 
     /** @test */
@@ -61,7 +63,9 @@ class UseResponseFileTagTest extends TestCase
     {
 
         $filePath = __DIR__ . '/../../Fixtures/response_test.json';
-        copy($filePath, storage_path('response_test.json'));
+        $baseResponsesPath = config('scribe.responses_base_dir', storage_path() . '/');
+        copy($filePath, $baseResponsesPath . 'response_test.json');
+
 
         $strategy = new UseResponseFileTag(new DocumentationConfig([]));
         $tags = [


### PR DESCRIPTION
So, because we are using Envoyer and it skips the whole storage folder on deployment we had to slightly modify this great package. Now you can set the base response files dir in the configuration.