### PR TITLE
Set correct base URL protocol for Postman collection

### DIFF
--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -200,9 +200,10 @@ class PostmanCollectionWriter
             return Str::contains($route['uri'], '{' . $key . '}');
         });
 
+        $protocol = Str::startsWith($this->config->get('postman.base_url', $this->config->get('base_url')), 'https') ? 'https' : 'http';
         $baseUrl = $this->getBaseUrl($this->config->get('postman.base_url', $this->config->get('base_url')));
         $base = [
-            'protocol' => Str::startsWith($baseUrl, 'https') ? 'https' : 'http',
+            'protocol' => $protocol,
             'host' => $baseUrl,
             // Change laravel/symfony URL params ({example}) to Postman style, prefixed with a colon
             'path' => preg_replace_callback('/\{(\w+)\??}/', function ($matches) {


### PR DESCRIPTION
The protocol cloud not be correctly resolved and would always default to http. This because $baseUrl would always contain the url witouth http or htpps prefix. Because of this the function `Str::startsWith($baseUrl, 'https') ? 'https' : 'http'` will always return http.

```php
$baseUrl = $this->getBaseUrl($this->config->get('postman.base_url', $this->config->get('base_url')));
$base = [
          'protocol' => Str::startsWith($baseUrl, 'https') ? 'https' : 'http',
];
```

Change the code as bellow. This will resolve the correct prefix for the url (eithet http or https)
```php
$protocol = Str::startsWith($this->config->get('postman.base_url', $this->config->get('base_url')), 'https') ? 'https' : 'http';
$baseUrl = $this->getBaseUrl($this->config->get('postman.base_url', $this->config->get('base_url')));
$base = [
            'protocol' => $protocol,
];
```

