### PR TITLE
Document objects

### DIFF
--- a/src/Extracting/ParamHelpers.php
+++ b/src/Extracting/ParamHelpers.php
@@ -105,7 +105,7 @@ trait ParamHelpers
 
         if ($type === 'array' && is_string($value)) {
             $value = trim($value);
-            if ($value[0] == '[' && $value[strlen($value) - 1] == ']') {
+            if (($value[0] == '[' && $value[strlen($value) - 1] == ']') || ($value[0] == '{' && $value[strlen($value) - 1] == '}')) {
                 return json_decode($value, true);
             }
         }

--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -208,7 +208,7 @@ class OpenAPISpecWriter
                     ];
                     if ($fieldData['type'] === 'array') {
                         $fieldData['items'] = [
-                            'type' => empty($details['value'] ?? null) ? 'object' : $this->convertScribeOrPHPTypeToOpenAPIType(gettype($details['value'][0])),
+                            'type' => empty($details['value'] ?? null) ? 'object' : $this->convertScribeOrPHPTypeToOpenAPIType(gettype($details['value'][0] ?? $details['value'])),
                         ];
                     }
                 }


### PR DESCRIPTION
Right now the following syntax for array's is allowed :
```
@bodyParam data array required The import payload in JSON. Example: [{"order":{"unique_id":"1838473","order_date":20201007,"order_time":94945,"user_company_number":29}}]
```
I would like to also document objects, this change would make the following example valid :
```
@bodyParam data array required The import payload in JSON. Example: {"order":{"unique_id":"1838473","order_date":20201007,"order_time":94945,"user_company_number":29}}
```