### PR TITLE
Allow queryParam array paramter for tryout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "knuckleswtf/scribe",
-  "version": "2.0.2",
   "license": "MIT",
   "description": "Generate API documentation for humans from your Laravel codebase.✍",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "knuckleswtf/scribe",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "Generate API documentation for humans from your Laravel codebase.✍",
   "keywords": [

--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -51,6 +51,17 @@ function cancelTryOut(endpointId) {
     }
 }
 
+function recursiveAddSearchParams(url, previousAppend, previousKey, obj) {
+    if (typeof obj === 'object') {
+        Object.keys(obj).forEach(objKey => {
+            const nextParam = !previousKey ? previousAppend : `${previousAppend}[${previousKey}]`;
+            recursiveAddSearchParams(url, nextParam, objKey, obj[objKey]);
+        });
+    } else {
+        url.searchParams.append(`${previousAppend}[${previousKey}]`, obj);
+    }
+}
+
 function makeAPICall(method, path, body, query, headers) {
     console.log({path, body, query, headers});
 
@@ -61,9 +72,7 @@ function makeAPICall(method, path, body, query, headers) {
     const url = new URL(window.baseUrl + '/' + path.replace(/^\//, ''));
     Object.keys(query).forEach(key => {
         if (typeof query[key] === 'object') {
-            Object.keys(query[key]).forEach(objKey => {
-                url.searchParams.append(`${key}[${objKey}]`, query[key][objKey]);
-            });
+            recursiveAddSearchParams(url, key, null, query[key]);
         } else {
             url.searchParams.append(key, query[key]);
         }

--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -59,8 +59,15 @@ function makeAPICall(method, path, body, query, headers) {
     }
 
     const url = new URL(window.baseUrl + '/' + path.replace(/^\//, ''));
-    Object.keys(query)
-        .forEach(key => url.searchParams.append(key, query[key]));
+    Object.keys(query).forEach(key => {
+        if (typeof query[key] === 'object') {
+            Object.keys(query[key]).forEach(objKey => {
+                url.searchParams.append(`${key}[${objKey}]`, query[key][objKey]);
+            });
+        } else {
+            url.searchParams.append(key, query[key]);
+        }
+    });
 
     return fetch(url, {
         method,


### PR DESCRIPTION
Previously there was a bug where executing an "tryitout"-request with an queryParameter like fields[users]=name was not working. It executed it as `fields=[object Object]`. To fix this, i created another Loop which resolves these objects and adds them to the searchParams.