### PR TITLE
only loop over enabled database connections

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -362,7 +362,11 @@ INTRO
     /**
      * [Advanced] If one of your app's database drivers does not support transactions,
      * docs generation (instantiating Eloquent models and making response calls) will likely fail.
-     * To avoid that, you can add the driver class name here. Be warned: that means all database changes will persist.
+     * We loop over all of your database connections and start a transaction if supported.
+     * Here you can list all of the connections you want us to start a transaction on.
+     * Typically you would list the name of every connection your database will connect to while running this command.
      */
-    'continue_without_database_transactions' => [],
+    'enable_transactions_for_database_connections'       => [
+        config('database.default')
+    ],
 ];


### PR DESCRIPTION
We had an issue where we had multiple databases configured in config/database.php - Scribe was looping over each database creating a transaction for this which was causing slow downs and exceptions.

I opted to change continue_without_database_transactions into enable_transactions_for_database_connections where the user can list all database connections that require a transaction, defaulting to whatever database is default.

Our biggest issue was that we use MSSQL in production, but MySQL in testing. So scribe would throw exceptions because the MSSQL driver wasn't installed on our docker image, but this also caused each endpoint to take 10m to respond. Very strange.

Thanks