### PR TITLE
Explicitly specify the disk for openapi.yaml file

### DIFF
--- a/src/Http/Controller.php
+++ b/src/Http/Controller.php
@@ -30,6 +30,6 @@ class Controller
      */
     public function openapi()
     {
-        return response()->file(Storage::path('scribe/openapi.yaml'));
+        return response()->file(Storage::disk('local')->path('scribe/openapi.yaml'));
     }
 }


### PR DESCRIPTION
Hello All,

I had an issue opening the URL for OpenApi specification, it responds with `500 Internal Server Error` with exception message `The file "scribe/openapi.yaml" does not exist` if the default disk is not `local`.

After investigating I have found that the disk does not explicitly defined for `scribe/openapi.yaml` file.

This PR specifies the `local` disk for responding with `scribe/openapi.yaml` file as it happens for `scribe/collection.json` file.



