### PR TITLE
Check first laravel 8 factory

### DIFF
--- a/src/Tools/Utils.php
+++ b/src/Tools/Utils.php
@@ -145,7 +145,7 @@ class Utils
 
     public static function getModelFactory(string $modelName, array $states = [])
     {
-        if (!function_exists('factory')) { // Laravel 8 type factory
+        if (method_exists($modelName, 'factory')) { // Laravel 8 type factory
             $factory = call_user_func_array([$modelName, 'factory'], []);
             if (count($states)) {
                 foreach ($states as $state) {


### PR DESCRIPTION
Related issue: https://github.com/knuckleswtf/scribe/issues/169

As mentioned on the issue, using package with legacy factories will break the usage of factories when generate de doc.

This PR changes the ability to check if use laravel 8 factories.