### PR TITLE
If param name contains password set input type to password

### DIFF
--- a/resources/views/components/field-details.blade.php
+++ b/resources/views/components/field-details.blade.php
@@ -3,7 +3,8 @@
 @if(($isInput ?? true) && empty($hasChildren))
 @php
     $isList = Str::endsWith($type, '[]');
-    $fullName =str_replace('[]', '.0', $name);
+    $isPassword = preg_match('/password/', $name);
+    $fullName = str_replace('[]', '.0', $name);
     $baseType = $isList ? substr($type, 0, -2) : $type;
     // Ignore the first '[]': the frontend will take care of it
     while (\Str::endsWith($baseType, '[]')) {
@@ -26,10 +27,10 @@
 <label data-endpoint="{{ $endpointId }}" hidden><input type="radio" name="{{ $fullName }}" value="{{$component === 'body' ? 'true' : 1}}" data-endpoint="{{ $endpointId }}" data-component="{{ $component }}" @if($required)required @endif><code>true</code></label>
 <label data-endpoint="{{ $endpointId }}" hidden><input type="radio" name="{{ $fullName }}" value="{{$component === 'body' ? 'false' : 0}}" data-endpoint="{{ $endpointId }}" data-component="{{ $component }}" @if($required)required @endif><code>false</code></label>
 @elseif($isList)
-<input type="{{ $inputType }}" name="{{ $fullName.".0" }}" data-endpoint="{{ $endpointId }}" data-component="{{ $component }}" @if($required)required @endif hidden>
-<input type="{{ $inputType }}" name="{{ $fullName.".1" }}" data-endpoint="{{ $endpointId }}" data-component="{{ $component }}" hidden>
+<input type="{{ $isPassword ? 'password' : $inputType }}" name="{{ $fullName.".0" }}" data-endpoint="{{ $endpointId }}" data-component="{{ $component }}" @if($required)required @endif hidden>
+<input type="{{ $isPassword ? 'password' : $inputType }}" name="{{ $fullName.".1" }}" data-endpoint="{{ $endpointId }}" data-component="{{ $component }}" hidden>
 @else
-<input type="{{ $inputType }}" name="{{ $fullName }}" data-endpoint="{{ $endpointId }}" data-component="{{ $component }}" @if($required)required @endif hidden>
+<input type="{{ $isPassword ? 'password' : $inputType }}" name="{{ $fullName }}" data-endpoint="{{ $endpointId }}" data-component="{{ $component }}" @if($required)required @endif hidden>
 @endif
 @endif
 <br>


### PR DESCRIPTION
If the param name contains 'password' hide the input text by setting `type="password"` for `input`.

Before:
![image](https://user-images.githubusercontent.com/6934044/113867122-6d5f5500-97ae-11eb-8e76-12293b5f4732.png)
After:
![image](https://user-images.githubusercontent.com/6934044/113867042-5587d100-97ae-11eb-8fa4-197984f8844f.png)
