### PR TITLE
format form data params properly

### DIFF
--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -144,14 +144,7 @@ class PostmanCollectionWriter
 
         switch ($inputMode) {
             case 'formdata':
-                foreach ($endpoint['cleanBodyParameters'] as $key => $value) {
-                    $params = [
-                        'key' => $key,
-                        'value' => $value,
-                        'type' => 'text',
-                    ];
-                    $body[$inputMode][] = $params;
-                }
+                $body[$inputMode] = $this->getFormDataParams($endpoint['cleanBodyParameters']);
                 foreach ($endpoint['fileParameters'] as $key => $value) {
                     while (is_array($value)) { // For arrays of files, just send the first one
                         $key .= '[]';
@@ -171,6 +164,35 @@ class PostmanCollectionWriter
         }
         return $body;
     }
+
+    /**
+	 * This formats the Form Paramaters correctly for Arrays eg. data[item][index] = value
+	 * @param array $array
+	 * @param string|null $key
+	 * @return array
+	 */
+	protected function getFormDataParams(array $array, ?string $key = null): array
+	{
+		$body = [];
+
+		foreach ($array as $index => $value) {
+			$index = $key ? ($key . '[' . $index . ']') : $index;
+
+			if (!is_array($value)) {
+				$body[] = [
+					'key'   => $index,
+					'value' => $value,
+					'type'  => 'text',
+				];
+
+				continue;
+			}
+
+			$body = array_merge($body, $this->getFormDataParams($value, $index));
+		}
+
+		return $body;
+	}
 
     protected function resolveHeadersForEndpoint($route)
     {


### PR DESCRIPTION
This PR will format the form params properly in Postman.

Currently an object would be formatted eg. patient = [Object object] in Postman

This PR corrects that by formatting it as patient[key] = value instead
