### PR TITLE
Add ability to override the default parameter type.

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -307,6 +307,17 @@ INTRO
     'faker_seed' => null,
 
     /**
+     * If Scribe cannot infer the type required for a parameter, it will default to string.
+     * Change this value if you'd like to adapt this behaviour.
+     *
+     * Available values:
+     *  - 'string'
+     *  - 'integer'
+     *  - 'number'
+     */
+    'default_parameter_type' => 'string',
+
+    /**
      * The strategies Scribe will use to extract information about your routes at each stage.
      * If you write or install a custom strategy, add it here.
      */

--- a/docs/documenting/documenting-endpoint-query-parameters.md
+++ b/docs/documenting/documenting-endpoint-query-parameters.md
@@ -94,7 +94,7 @@ Route::get("/post/{id}/{lang?}");
 
 you can use this annotation to describe the `id` and `lang` parameters as shown below. The annotation takes the name of the parameter, an optional type, an optional "required" label, and then its description. Like with `@queryParams`, a random value will be generated, but you can specify the value to be used in examples and response calls using the `Example: ` syntax.
 
-If you don't specify a type, Scribe will assume it's `string`. Valid types are `string`, `integer`, and `number`.
+If you don't specify a type, Scribe will assume it's `string`. You can override this value by changing the `default_parameter_type` within your configuration file. The Valid types are `string`, `integer`, and `number`.
 
 ```php
 /**

--- a/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
+++ b/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
@@ -27,10 +27,15 @@ class GetFromLaravelAPI extends Strategy
         $path = $alreadyExtractedData['uri'];
         preg_match_all('/\{(.*?)\}/', $path, $matches);
 
+        $type = $this->config->get('default_parameter_type');
+
+        if (!in_array($type, ['string', 'integer', 'number'])) {
+            $type = 'string';
+        }
+
         foreach ($matches[1] as $match) {
             $optional = Str::endsWith($match, '?');
             $name = rtrim($match, '?');
-            $type = 'string';
             $parameters[$name] = [
                 'name' => $name,
                 'description' => '',


### PR DESCRIPTION
Tiny PR to add the option to override the default parameter type of `string`.

I couldn't see a way to do this out of the box and I looked over the documentation for it. Really sorry if I've just completely missed it 😅 

I'm aware that config clutter is a pain so please feel free to tear this apart. I'd be happy to go away and implement it a completely different way if needed!

I wasn't really sure what tests I could write for this but if you'd like me to add a specific one, let me know.

There's a tiny documentation change so as requested:

Before
![Before](https://user-images.githubusercontent.com/47351766/116294638-1a1a6a00-a790-11eb-9564-441b8e022a7e.png)

After
![After](https://user-images.githubusercontent.com/47351766/116294656-1f77b480-a790-11eb-97e5-7545daa623f7.png)


