### PR TITLE
Use of public directory by laravel app helper function

### DIFF
--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -260,17 +260,18 @@ class Writer
         if (!is_dir($this->laravelTypeOutputPath)) {
             mkdir($this->laravelTypeOutputPath, 0777, true);
         }
-        if (!is_dir("public/vendor/scribe")) {
-            mkdir("public/vendor/scribe", 0777, true);
+        $publicDirectory = app()->get('public_path');
+        if (!is_dir("$publicDirectory/vendor/scribe")) {
+            mkdir("$publicDirectory/vendor/scribe", 0777, true);
         }
 
         // Transform output HTML to a Blade view
         rename("{$this->staticTypeOutputPath}/index.html", "$this->laravelTypeOutputPath/index.blade.php");
 
-        // Move assets from public/docs to public/vendor/scribe
+        // Move assets from public/docs to $publicDirectory/vendor/scribe
         // We need to do this delete first, otherwise move won't work if folder exists
-        Utils::deleteDirectoryAndContents("public/vendor/scribe/", getcwd());
-        rename("{$this->staticTypeOutputPath}/", "public/vendor/scribe/");
+        Utils::deleteDirectoryAndContents("$publicDirectory/vendor/scribe/", getcwd());
+        rename("{$this->staticTypeOutputPath}/", "$publicDirectory/vendor/scribe/");
 
         $contents = file_get_contents("$this->laravelTypeOutputPath/index.blade.php");
 


### PR DESCRIPTION
Hello, 
I've notticed that using this package, you cannot overwrite name of public directory.  Most of apps that I am developing has changed public directory to public_html. 
Overwritting is possible and described in this issue: [https://github.com/laravel/framework/issues/18550](https://github.com/laravel/framework/issues/18550)
When you configure scribe to return laravel views the name "public" is provided from string, not from laravel helper function.

I made change to use laravel helper function, and test it manually. Then I've ran composer test and everything seems working well. 

Please let me know if this change is good enough.

Regards,