### PR TITLE
Repaired misspelled path.public argument of app()->get() method

### DIFF
--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -260,7 +260,7 @@ class Writer
         if (!is_dir($this->laravelTypeOutputPath)) {
             mkdir($this->laravelTypeOutputPath, 0777, true);
         }
-        $publicDirectory = app()->get('public_path');
+        $publicDirectory = app()->get('path.public');
         if (!is_dir("$publicDirectory/vendor/scribe")) {
             mkdir("$publicDirectory/vendor/scribe", 0777, true);
         }


### PR DESCRIPTION
Hello @shalvah 

I found I misspelled path.public argument of app()->get() method. In #214. 
You cannot generate documentation with laravel type becouse of this bug 

It is is fixed now

Sorry for complicating.

Regard,