### PR TITLE
Skip FormRequest if instanciation isn't possible

### DIFF
--- a/src/Extracting/Strategies/BodyParameters/GetFromFormRequest.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromFormRequest.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies\BodyParameters;
 
+use ArgumentCountError;
 use Dingo\Api\Http\FormRequest as DingoFormRequest;
 use Illuminate\Foundation\Http\FormRequest as LaravelFormRequest;
 use Illuminate\Http\Request;

--- a/src/Extracting/Strategies/BodyParameters/GetFromFormRequest.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromFormRequest.php
@@ -66,8 +66,14 @@ class GetFromFormRequest extends Strategy
             if (
                 (class_exists(LaravelFormRequest::class) && $parameterClass->isSubclassOf(LaravelFormRequest::class))
                 || (class_exists(DingoFormRequest::class) && $parameterClass->isSubclassOf(DingoFormRequest::class))) {
-                /** @var LaravelFormRequest|DingoFormRequest $formRequest */
-                $formRequest = new $parameterClassName;
+                try {
+                    /** @var LaravelFormRequest|DingoFormRequest $formRequest */
+                    $formRequest = new $parameterClassName;
+                } catch (ArgumentCountError $e) {
+                    c::info('Skipping instanciation of ' . $parameterClassName . ' because of dependency injection. Use manual @bodyParam to describe this request.');
+                    continue;
+                }
+                
                 // Set the route properly so it works for users who have code that checks for the route.
                 $formRequest->setRouteResolver(function () use ($formRequest, $route) {
                     // Also need to bind the request to the route in case their code tries to inspect current request

--- a/src/Extracting/Strategies/BodyParameters/GetFromFormRequest.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromFormRequest.php
@@ -71,7 +71,7 @@ class GetFromFormRequest extends Strategy
                     /** @var LaravelFormRequest|DingoFormRequest $formRequest */
                     $formRequest = new $parameterClassName;
                 } catch (ArgumentCountError $e) {
-                    c::info('Skipping instanciation of ' . $parameterClassName . ' because of dependency injection. Use manual @bodyParam to describe this request.');
+                    c::info('Skipping instantiation of ' . $parameterClassName . ' because of dependency injection. Use manual @bodyParam to describe this request.');
                     continue;
                 }
                 
@@ -536,4 +536,3 @@ class GetFromFormRequest extends Strategy
         return $results;
     }
 }
-


### PR DESCRIPTION
Hi @shalvah !

I don't know if this is acceptable but I found a solution to my problem and I think it can help some of us :)

In case FormRequest class needs dependency injection, instanciation throws an ArgumentCountError exception.
By catching it, we can simply skip this class and the developer can use `@bodyParam` annotation to add documentation on the params.

See https://github.com/knuckleswtf/scribe/issues/189
