### PR TITLE
Fixed error public/vendor/scribe is not empty

### DIFF
--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -270,7 +270,7 @@ class Writer
 
         // Move assets from public/docs to $publicDirectory/vendor/scribe
         // We need to do this delete first, otherwise move won't work if folder exists
-        Utils::deleteDirectoryAndContents("$publicDirectory/vendor/scribe/", getcwd());
+        Utils::deleteDirectoryAndContents("$publicDirectory/vendor/scribe/", '/');
         rename("{$this->staticTypeOutputPath}/", "$publicDirectory/vendor/scribe/");
 
         $contents = file_get_contents("$this->laravelTypeOutputPath/index.blade.php");


### PR DESCRIPTION
Hello again,
I found error when I generated documentation many times. This occurs on laravel type, when you public/vendor/scribe is not empty.

I fixed it.

Regards, 