### PR TITLE
Respect interactive config for tryitoutjs

### DIFF
--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -289,8 +289,11 @@ class Writer
         ConsoleOutputUtils::info('Transforming Markdown docs to HTML...');
 
         $this->pastel->generate($this->sourceOutputPath . '/index.md', $this->staticTypeOutputPath);
+
         // Add our custom JS
-        copy(__DIR__.'/../../resources/js/tryitout.js', $this->staticTypeOutputPath . '/js/tryitout-'.Globals::SCRIBE_VERSION.'.js');
+        if (config('scribe.interactive')) {
+            copy(__DIR__.'/../../resources/js/tryitout.js', $this->staticTypeOutputPath . '/js/tryitout-'.Globals::SCRIBE_VERSION.'.js');
+        }
 
         if (!$this->isStatic) {
             $this->performFinalTasksForLaravelType();


### PR DESCRIPTION
In scribe configfile there is `interactive` options to toggle tryitout feature.
Currently when we toggle `interactive` to `false`, the `tryitout.js` file still copied into static folder.

This PR makes the copy file respect the interactive configuration.

