### PR TITLE
update .gitattributes to ignore docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 /phpunit.xml export-ignore
 /README.md export-ignore
 /body-params.png export-ignore
+/docs/** export-ignore


### PR DESCRIPTION
I think its safe to ignore the `docs` folder on `.gitattributes` file as it happends to save some space when installing scribe.

It will save approximately `1.4 MB` of disk space

![image](https://user-images.githubusercontent.com/20186786/120057419-1159d400-c06d-11eb-9264-0148f445d1e6.png)

Note: I also found that `pastel` also ignore the docs folder, see https://github.com/knuckleswtf/pastel/blob/476e86cd237c7256b5365efd844084a49075543a/.gitattributes#L1-L4

