### PR TITLE
Fixed an issue processing body parameters when the request body itself is an array.

### DIFF
--- a/src/Extracting/Generator.php
+++ b/src/Extracting/Generator.php
@@ -314,11 +314,17 @@ class Generator
         }
 
         if (empty($baseNameInOriginalParams)) {
-            // This indicates that the body is an array of objects, so each parameter should be a key in the first object in that array
+            // If this is empty, it indicates that the body is an array of objects. (i.e. "[].param")
+            // Therefore, each parameter should be an element of the first object in that array.
             $results[0][$paramName] = $value;
-        } elseif (array_key_exists(0, $results)) {
-            // The body is an array of objects, so every parameter must be an element of the array object.
-            $dotPath = '0.'.substr($path, 3);
+        } elseif (Str::startsWith($path, '[]')) {
+            // If the body is an array, then any top level parameters (i.e. "[].param") would have been handled by the previous block
+            // Therefore, we assume that this is a child parameter (i.e. "[].parent.child" or "[].parent[].child"
+
+            // Remove the top-level array brackets
+            $dotPath = substr($path, 3);
+            // Use correct dot notation for any child arrays
+            $dotPath = '0.' . str_replace('[]', '.0', $dotPath);
             Arr::set($results, $dotPath, $value);
         } elseif (Arr::has($source, $baseNameInOriginalParams)) {
             $parentData = Arr::get($source, $baseNameInOriginalParams);

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -153,6 +153,14 @@ class GeneratorTest extends TestCase
                 'type' => 'string',
                 'value' => 'hoho',
             ],
+            '[].key3.key2' => [
+                'type' => 'array',
+                'value' => [],
+            ],
+            '[].key3.key2[].subkey1' => [
+                'type' => 'string',
+                'value' => 'haha',
+            ],
         ];
 
         $cleanBodyParameters = Generator::cleanParams($parameters);
@@ -163,8 +171,13 @@ class GeneratorTest extends TestCase
                 'key2' => 77,
                 'key3' => [
                     'key1' => [
-                      'objkey1' => 'hoho',
-                    ]
+                        'objkey1' => 'hoho',
+                    ],
+                    'key2' => [
+                        [
+                            'subkey1' => 'haha',
+                        ]
+                    ],
                 ]
             ],
         ], $cleanBodyParameters);

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -130,6 +130,47 @@ class GeneratorTest extends TestCase
     }
 
     /** @test */
+    public function clean_can_properly_parse_a_body_array()
+    {
+        $parameters = [
+            '[].key1' => [
+                'type' => 'string',
+                'value' => '43',
+            ],
+            '[].key2' => [
+                'type' => 'integer',
+                'value' => 77,
+            ],
+            '[].key3' => [
+                'type' => 'object',
+                'value'=> [],
+            ],
+            '[].key3.key1' => [
+                'type' => 'object',
+                'value' => [],
+            ],
+            '[].key3.key1.objkey1' => [
+                'type' => 'string',
+                'value' => 'hoho',
+            ],
+        ];
+
+        $cleanBodyParameters = Generator::cleanParams($parameters);
+
+        $this->assertEquals([
+            [
+                'key1' => '43',
+                'key2' => 77,
+                'key3' => [
+                    'key1' => [
+                      'objkey1' => 'hoho',
+                    ]
+                ]
+            ],
+        ], $cleanBodyParameters);
+    }
+
+    /** @test */
     public function does_not_generate_values_for_excluded_params_and_excludes_them_from_clean_params()
     {
         $route = $this->createRoute('GET', '/api/test', 'withExcludedExamples');


### PR DESCRIPTION
Fixed a bug where a request body that is an array of objects was not included in the documentation. For example: 
```
* @bodyParam [].row_id string A unique ID. Example: 700
* @bodyParam [].name string required An element name. Example: My item name
* @bodyParam [].description string An optional description of the element.
```

This was being properly parsed by the `GetFromBodyParamTag.php` strategy, but the body content was missing from the documentation and the code samples. Now, in this example, this will be added to the documentation:

![Screenshot 2021-06-07 at 11 47 48](https://user-images.githubusercontent.com/37389796/121004144-398cb580-c786-11eb-98b6-93296bf7ae99.png)


And this. will be added to the code sample (JS example):

```
let body = [
    {
        "row_id": "700",
        "name": "My item name"
    }
]
```