### PR TITLE
Update UseApiResourceTags (fix invalid type error)

### DIFF
--- a/src/Extracting/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Extracting/Strategies/Responses/UseApiResourceTags.php
@@ -141,7 +141,7 @@ class UseApiResourceTags extends Strategy
     {
         $content = $tag->getContent();
         preg_match('/^(\d{3})?\s?([\s\S]*)$/', $content, $result);
-        $status = $result[1] ?: 0;
+        $status = (int)($result[1] ?: 0);
         $apiResourceClass = $result[2];
 
         return [$status, $apiResourceClass];


### PR DESCRIPTION
This comment:
```
* @apiResource 201 \App\Http\Resources\Advertisers\UserManagement\StaffResource
```
Throw error:
```
 Spatie\DataTransferObject\DataTransferObjectError 
 Invalid type: expected `Knuckles\Camel\Extraction\Response::status` to be of type `integer`, instead got value `201`, which is string..
```
So, to fix the added cast to integer status

<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

