### PR TITLE
Set current relative path for html assets

### DIFF
--- a/resources/views/themes/default/index.blade.php
+++ b/resources/views/themes/default/index.blade.php
@@ -11,9 +11,9 @@
 
     <link href="https://fonts.googleapis.com/css?family=PT+Sans&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="../docs/css/theme-default.style.css" media="screen">
-    <link rel="stylesheet" href="../docs/css/theme-default.print.css" media="print">
-    <script src="{{ u::getVersionedAsset('../docs/js/theme-default.js') }}"></script>
+    <link rel="stylesheet" href="./css/theme-default.style.css" media="screen">
+    <link rel="stylesheet" href="./css/theme-default.print.css" media="print">
+    <script src="{{ u::getVersionedAsset('./js/theme-default.js') }}"></script>
 
     <link rel="stylesheet"
           href="//unpkg.com/@highlightjs/cdn-assets@10.7.2/styles/obsidian.min.css">
@@ -25,7 +25,7 @@
     <script>
         var baseUrl = "{{ $tryItOut['base_url'] ?? config('app.url') }}";
     </script>
-    <script src="{{ u::getVersionedAsset('../docs/js/tryitout.js') }}"></script>
+    <script src="{{ u::getVersionedAsset('./js/tryitout.js') }}"></script>
 @endif
 
 </head>
@@ -34,7 +34,7 @@
 <a href="#" id="nav-button">
       <span>
         MENU
-        <img src="../docs/images/navbar.png" alt="navbar-image" />
+        <img src="./images/navbar.png" alt="navbar-image" />
       </span>
 </a>
 <div class="tocify-wrapper">


### PR DESCRIPTION
If `output_path` set different value than `public/docs` - for example `public/docs/api` assets will not be loaded because aseets url will be https://my.site/docs/docs/<asset path>. After replace `../docs/` to simple `./` browse will loads correct relative path https://my.site/docs/api/<asset path> . Thus, there is no need to change the blade template.