### PR TITLE
Update the doc url with in config.php

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -247,7 +247,7 @@ INTRO
     /*
      * Example requests for each endpoint will be shown in each of these languages.
      * Supported options are: bash, javascript, php, python
-     * To add a language of your own, see https://scribe.knuckles.wtf/laravel/advanced/adding-example-languages
+     * To add a language of your own, see https://scribe.knuckles.wtf/laravel/advanced/example-requests
      *
      */
     'example_languages' => [


### PR DESCRIPTION
I found the url in comment for `example_languages` in `config.php` is wrong, so I just modify it to the right one.
The url should be `https://scribe.knuckles.wtf/laravel/advanced/example-requests`  in `example_languages` section.