### PR TITLE
Fix body params format

### DIFF
--- a/resources/views/themes/default/endpoint.blade.php
+++ b/resources/views/themes/default/endpoint.blade.php
@@ -63,7 +63,7 @@
 <form id="form-{{ $endpoint->endpointId() }}" data-method="{{ $endpoint->httpMethods[0] }}"
       data-path="{{ $endpoint->uri }}"
       data-authed="{{ $endpoint->metadata->authenticated ? 1 : 0 }}"
-      data-hasfiles="{{ $endpoint->hasFiles() }}"
+      data-hasfiles="{{ $endpoint->hasFiles() ? 1 : 0 }}"
       data-headers='@json($endpoint->headers)'
       onsubmit="event.preventDefault(); executeTryOut('{{ $endpoint->endpointId() }}', this);">
     <h3>


### PR DESCRIPTION
Hi, thank you for such a fantastic library.
I encountered #240 issue.

`tryitout-3.0.2.js` is checking hasFiles attribute is "0".
```javascript
    if (form.dataset.hasfiles === "0") {
        body = {};
        setter = (name, value) => _.set(body, name, value);
    } else {
        body = new FormData();
        setter = (name, value) => body.append(name, value);
    }
```

But generated html has not "0" or "1"
```html
<form id="form-POSTapi-v1-login" data-method="POST" data-path="api/v1/login" data-authed="0" data-hasfiles="" data-headers="{&quot;Content-Type&quot;:&quot;application\/json&quot;,&quot;Accept&quot;:&quot;application\/json&quot;}" onsubmit="event.preventDefault(); executeTryOut('POSTapi-v1-login', this);">
```