### PR TITLE
Fix the boundary is missing in the headers.

### DIFF
--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -193,6 +193,9 @@ async function executeTryOut(endpointId, form) {
         const authHeaderEl = form.querySelector('input[data-component=header]');
         if (authHeaderEl) headers[authHeaderEl.name] = authHeaderEl.dataset.prefix + authHeaderEl.value;
     }
+    if (headers['Content-Type'] === "multipart/form-data") {
+        delete headers['Content-Type'];
+    }
 
     makeAPICall(form.dataset.method, path, body, query, headers)
         .then(([responseStatus, responseContent, responseHeaders]) => {


### PR DESCRIPTION
Hi! I fixed #232.
When I sent FormData without setting the Content-type, the Content-type was automatically set with boundary.
But I'm not sure it's best way to fix. So If you don't like it, feel free to ignore it.
