### PR TITLE
Move blademd registration to boot method of service provider

### DIFF
--- a/src/ScribeServiceProvider.php
+++ b/src/ScribeServiceProvider.php
@@ -13,15 +13,6 @@ use Knuckles\Scribe\Tools\Utils;
 
 class ScribeServiceProvider extends ServiceProvider
 {
-    public function register()
-    {
-        // Register custom Markdown Blade compiler so we can automatically have MD views converted to HTML
-        $app = $this->app;
-        $app->view->getEngineResolver()
-            ->register('blademd', fn() => new BladeMarkdownEngine($app['blade.compiler']));
-        $app->view->addExtension('md.blade.php', 'blademd');
-    }
-
     /**
      * Bootstrap the application events.
      *
@@ -29,6 +20,12 @@ class ScribeServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // Register custom Markdown Blade compiler so we can automatically have MD views converted to HTML
+        $app = $this->app;
+        $app->view->getEngineResolver()
+            ->register('blademd', fn() => new BladeMarkdownEngine($app['blade.compiler']));
+        $app->view->addExtension('md.blade.php', 'blademd');
+
         $this->loadViewsFrom(__DIR__ . '/../resources/views/', 'scribe');
 
         // Publish views in separate, smaller groups for ease of end-user modifications

--- a/src/ScribeServiceProvider.php
+++ b/src/ScribeServiceProvider.php
@@ -21,10 +21,9 @@ class ScribeServiceProvider extends ServiceProvider
     public function boot()
     {
         // Register custom Markdown Blade compiler so we can automatically have MD views converted to HTML
-        $app = $this->app;
-        $app->view->getEngineResolver()
-            ->register('blademd', fn() => new BladeMarkdownEngine($app['blade.compiler']));
-        $app->view->addExtension('md.blade.php', 'blademd');
+        $this->app->view->getEngineResolver()
+            ->register('blademd', fn() => new BladeMarkdownEngine($this->app['blade.compiler']));
+        $this->app->view->addExtension('md.blade.php', 'blademd');
 
         $this->loadViewsFrom(__DIR__ . '/../resources/views/', 'scribe');
 


### PR DESCRIPTION
Fixes #253 

Registering `blademd` in the register method of the service provider causes problems because it uses other service providers that may not have been registered yet. This moves that code to the boot method instead.

https://laravel.com/docs/8.x/providers#the-register-method
https://laravel.com/docs/8.x/providers#the-boot-method

