### PR TITLE
Add getDocBlocks() in RouteDocBlocker

### DIFF
--- a/src/Extracting/RouteDocBlocker.php
+++ b/src/Extracting/RouteDocBlocker.php
@@ -38,7 +38,6 @@ class RouteDocBlocker
             [$className, $methodName] = $className;
         }
 
-        [$className, $methodName] = u::getRouteClassAndMethodNames($route);
         $normalizedClassName = static::normalizeClassName($className);
         $docBlocks = self::getCachedDocBlock($route, $normalizedClassName, $methodName);
 

--- a/src/Extracting/RouteDocBlocker.php
+++ b/src/Extracting/RouteDocBlocker.php
@@ -32,7 +32,7 @@ class RouteDocBlocker
         return static::getDocBlocks($route, $className, $methodName);
     }
 
-    public static function getDocBlocks(Route $route, $className, $methodName = null)
+    public static function getDocBlocks(Route $route, $className, $methodName = null): array
     {
         if (is_array($className)) {
             [$className, $methodName] = $className;

--- a/src/Extracting/RouteDocBlocker.php
+++ b/src/Extracting/RouteDocBlocker.php
@@ -18,12 +18,7 @@ class RouteDocBlocker
     protected static array $docBlocks = [];
 
     /**
-     * @param Route $route
-     *
-     * @throws \ReflectionException
-     * @throws \Exception
-     *
-     * @return array<"method"|"class", DocBlock> Method and class docblocks
+     * @return array{method: DocBlock, class: DocBlock} Method and class docblocks
      */
     public static function getDocBlocksFromRoute(Route $route): array
     {
@@ -31,7 +26,10 @@ class RouteDocBlocker
 
         return static::getDocBlocks($route, $className, $methodName);
     }
-
+    
+    /**
+     * @return array{method: DocBlock, class: DocBlock} Method and class docblocks
+     */
     public static function getDocBlocks(Route $route, $className, $methodName = null): array
     {
         if (is_array($className)) {

--- a/src/Extracting/RouteDocBlocker.php
+++ b/src/Extracting/RouteDocBlocker.php
@@ -28,6 +28,17 @@ class RouteDocBlocker
     public static function getDocBlocksFromRoute(Route $route): array
     {
         [$className, $methodName] = u::getRouteClassAndMethodNames($route);
+
+        return static::getDocBlocks($route, $className, $methodName);
+    }
+
+    public static function getDocBlocks(Route $route, $className, $methodName = null)
+    {
+        if (is_array($className)) {
+            [$className, $methodName] = $className;
+        }
+
+        [$className, $methodName] = u::getRouteClassAndMethodNames($route);
         $normalizedClassName = static::normalizeClassName($className);
         $docBlocks = self::getCachedDocBlock($route, $normalizedClassName, $methodName);
 


### PR DESCRIPTION
This PR adds a method `getDocBlocks(Route $route, $className, $methodName = null)` in `RouteDocBlocker`. 
The reason behind this so that we can pass a different `className` and `methodName`. In my plugin, [scribe-tdd](https://github.com/ajcastro/scribe-tdd), The docblocks annotations are used in the test classes and methods. 

Therefore, I plan to create a strategy with implementation to use this like so: 
```php
RouteDocBlocker::getDocBlocks($route, 'Tests\Features\Http\UserControllerTest', 'test_users_index');
```
This will parse the docblocks in the test class and its method.

You can check a fork of the `TheSideProjectAPI` where I move the docblock annotations to the test classes:
https://github.com/ajcastro/TheSideProjectAPI/pull/1