### PR TITLE
Fix condition when value is null and type is array

### DIFF
--- a/src/Extracting/ParamHelpers.php
+++ b/src/Extracting/ParamHelpers.php
@@ -183,7 +183,7 @@ trait ParamHelpers
             case 'bool':
                 return str_replace($base, 'boolean', $typeName);
             case 'array':
-                return array_keys($value)[0] === 0 ? 'array' : 'object';
+                return is_null($value) || array_keys($value)[0] === 0 ? 'array' : 'object';
             default:
                 return $typeName;
         }


### PR DESCRIPTION
This PR fixes the scenario when the value is null and the type is array.
I encountered this error but can't find which specific data that caused that. The value is null that's why it errors.

![image](https://user-images.githubusercontent.com/4918318/125655559-d31eb5d9-561c-4bf3-b847-36cf759fd720.png)
