### PR TITLE
Support for spatie/data-transfer-object 3

### DIFF
--- a/camel/BaseDTOCollection.php
+++ b/camel/BaseDTOCollection.php
@@ -2,22 +2,36 @@
 
 namespace Knuckles\Camel;
 
+use ArrayAccess;
 use ArrayIterator;
+use Countable;
 use Illuminate\Support\Arr;
-use Spatie\DataTransferObject\DataTransferObjectCollection;
+use Iterator;
+use Spatie\DataTransferObject\DataTransferObject;
 
 /**
  * @template T of \Spatie\DataTransferObject\DataTransferObject
  */
-class BaseDTOCollection extends DataTransferObjectCollection
+abstract class BaseDTOCollection implements
+    ArrayAccess,
+    Iterator,
+    Countable
 {
+    protected ArrayIterator $iterator;
+
     /**
      * @var string The name of the base DTO class.
      */
     public static string $base = '';
 
-    public function __construct(array $collection = [])
+    /**
+     * @param BaseDTOCollection|array $collection
+     */
+    public function __construct($collection = [])
     {
+        if (is_null($collection)) $collection = [];
+        if (!is_array($collection)) $collection = $collection->toArray();
+
         // Manually cast nested arrays
         $collection = array_map(
             function ($item) {
@@ -26,7 +40,91 @@ class BaseDTOCollection extends DataTransferObjectCollection
             $collection
         );
 
-        parent::__construct($collection);
+        $this->iterator = new ArrayIterator($collection);
+    }
+
+    public function __get($name)
+    {
+        if ($name === 'collection') {
+            return $this->iterator->getArrayCopy();
+        }
+    }
+
+    public function current()
+    {
+        return $this->iterator->current();
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->iterator[$offset] ?? null;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->iterator[] = $value;
+        } else {
+            $this->iterator[$offset] = $value;
+        }
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return $this->iterator->offsetExists($offset);
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->iterator[$offset]);
+    }
+
+    public function next()
+    {
+        $this->iterator->next();
+    }
+
+    public function key()
+    {
+        return $this->iterator->key();
+    }
+
+    public function valid(): bool
+    {
+        return $this->iterator->valid();
+    }
+
+    public function rewind()
+    {
+        $this->iterator->rewind();
+    }
+
+    public function toArray(): array
+    {
+        $collection = $this->iterator->getArrayCopy();
+
+        foreach ($collection as $key => $item) {
+            if (
+                ! $item instanceof DataTransferObject
+                && ! $item instanceof BaseDTOCollection
+            ) {
+                continue;
+            }
+
+            $collection[$key] = $item->toArray();
+        }
+
+        return $collection;
+    }
+
+    public function items(): array
+    {
+        return $this->iterator->getArrayCopy();
+    }
+
+    public function count(): int
+    {
+        return count($this->iterator);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "nunomaduro/collision": "^3.0|^4.0|^5.0",
     "ramsey/uuid": "^3.8|^4.0",
     "shalvah/clara": "^3.0.2",
-    "spatie/data-transfer-object": "^2.6",
+    "spatie/data-transfer-object": "^2.6|^3.0",
     "symfony/var-exporter": "^4.0|^5.0",
     "symfony/yaml": "^4.0|^5.0"
   },


### PR DESCRIPTION
As `spatie/data-transfer-object` dropped support for `DataTransferCollection`, which was used to iterate `ResponseCollection` I decided to reimplement iterator functionality dirrectly in `BaseDTOCollection`. I still not sure this is the best sollution as now `BaseDTOCollection` looks a bit messy, but this will resolve #241.

There was issues with constructor for `BaseDTOCollection` on `dto@3`. On some tests given collection was an instance of `ResponseCollection` or null. So the type checks in 32 and 33 lines of `BaseDTOCollection` are necessary.

Tested with `dto@2` and `dto@3` - all tests pass successfully.