### PR TITLE
fix for validating digits_between rule

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -344,7 +344,7 @@ trait ParsesValidationRules
                     break;
                 case 'digits_between':
                     $parameterData['description'] .= ' ' . $this->getDescription($rule, [':min' => $arguments[0], ':max' => $arguments[1]]);
-                    $parameterData['setter'] = fn() => $this->getFaker()->randomNumber($this->getFaker()->numberBetween(...$arguments), true);
+                    $parameterData['setter'] = fn() => $this->getFaker()->numberBetween(...$arguments);
                     $parameterData['type'] = 'number';
                     break;
 


### PR DESCRIPTION
### Hi i found out that generating docs with `digits_between:min,max` rule is not working right

Example rules from `Request:Class`
```php
class CopyProductRequest extends FormRequest
{
    /**
     * Determine if the user is authorized to make this request.
     *
     * @return bool
     */
    public function authorize()
    {
        return true;
    }
    /**
     * Get the validation rules that apply to the request.
     *
     * @return array
     */
    public function rules()
    {
        return [
              'gtin' => 'nullable|digits_between:0,20',
        ];
    }
}
```
Is throwing a error:
```
Failed processing route: [POST] api/v1/projects/{project}/products - Exception encountered.

   Knuckles\Scribe\Exceptions\ProblemParsingValidationRules 

  Problem processing validation rules for the param `gtin`

  at D:\app\vendor\knuckleswtf\scribe\src\Exceptions\ProblemParsingValidationRules.php:11
      7▕ class ProblemParsingValidationRules extends \RuntimeException implements ScribeException
      8▕ {
      9▕     public static function forParam(string $paramName,  Throwable $innerException): ProblemParsingValidationRules
     10▕     {
  ➜  11▕         return new self(
     12▕             "Problem processing validation rules for the param `$paramName`",
     13▕             0, $innerException);
     14▕     }
     15▕ }

  1   D:\app\vendor\knuckleswtf\scribe\src\Extracting\ParsesValidationRules.php:107
      Knuckles\Scribe\Exceptions\ProblemParsingValidationRules::forParam("gtin", Object(InvalidArgumentException))

  2   D:\app\vendor\fakerphp\faker\src\Faker\Provider\Base.php:86
      InvalidArgumentException::("randomNumber() can only generate numbers up to mt_getrandmax()")
```

Faker `numberBetween` method is already creating random number in specified range.
Faker `randomNumber` is generating a number but first arg is length of generated number.

So if first you generate number between 0 and 20 you can get 20, and `randomNumber` method will try to generate random number with length of 20.  
( and that is throwing this error because `randomNumber` cannot generate number bigger than `mt_getrandmax() = 2147483647` )