### PR TITLE
Add prepend functionality

### DIFF
--- a/resources/views/themes/default/index.blade.php
+++ b/resources/views/themes/default/index.blade.php
@@ -72,6 +72,8 @@
     <div class="content">
         {!! $intro !!}
 
+        {!! $prepend !!}
+
         {!! $auth !!}
 
         @include("scribe::themes.default.groups")

--- a/src/Writing/HtmlWriter.php
+++ b/src/Writing/HtmlWriter.php
@@ -39,6 +39,8 @@ class HtmlWriter
         $intro = $this->transformMarkdownFileToHTML($sourceFolder . '/intro.md');
         $auth = $this->transformMarkdownFileToHTML($sourceFolder . '/auth.md');
 
+        $prependFile = rtrim($sourceFolder, '/') . '/' . 'prepend.md';
+        $prepend = file_exists($prependFile) ? $this->transformMarkdownFileToHTML($prependFile) : '';
         $appendFile = rtrim($sourceFolder, '/') . '/' . 'append.md';
         $append = file_exists($appendFile) ? $this->transformMarkdownFileToHTML($appendFile) : '';
 
@@ -50,6 +52,7 @@ class HtmlWriter
             'intro' => $intro,
             'auth' => $auth,
             'groupedEndpoints' => $groupedEndpoints,
+            'prepend' => $prepend,
             'append' => $append,
             'assetPathPrefix' => $this->assetPathPrefix,
         ])->render();


### PR DESCRIPTION
Hello!

I read in the documentation about [prepending content](https://scribe.readthedocs.io/en/latest/customization.html#specifying-content-to-be-added-to-the-beginning-or-end-of-the-documentation), but it didn't work. After checking it out it seemed that the functionality was missing!

So this PR adds that functionality. Nothing special, it's just a copy of the already existing append functionality, but with changed names/values.

If you have any comments/questions, let me know!