### PR TITLE
Update endpoint.blade.php

### DIFF
--- a/resources/views/themes/default/endpoint.blade.php
+++ b/resources/views/themes/default/endpoint.blade.php
@@ -44,7 +44,7 @@
 @else
 @php($parsed = json_decode($response->content))
 {{-- If response is a JSON string, prettify it. Otherwise, just print it --}}
-<code class="language-json">{!! htmlentities($parsed != null ? json_encode($parsed, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) : $response->content) !!}</code>
+<code class="language-json">{!! htmlentities($parsed != null ? json_encode($parsed, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : $response->content) !!}</code>
 @endif </pre>
     @endforeach
 @endif


### PR DESCRIPTION
Added JSON_UNESCAPED_SLASHES to prettify json output. Strings with slashes (for example a url: https://www.google.com) was rendering with back slashes added https:\/\/www.google.com\/

<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

