### PR TITLE
Group radio buttons when setting query parameters

### DIFF
--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -178,10 +178,12 @@ async function executeTryOut(endpointId, form) {
     const query = {};
     const queryParameters = form.querySelectorAll('input[data-component=query]');
     queryParameters.forEach(el => _.set(query, el.name, el.value));
+    
+    // Group radio buttons by their name, and then set the checked value from that group
     Array.from(queryParameters)
         .filter(el => el.type === "radio")
         .reduce(
-            (entryMap, e) => entryMap.set(e.name, [...(entryMap.get(e.name) || []), e]),
+            (entryMap, el) => entryMap.set(el.name, [...(entryMap.get(el.name) || []), el]),
             new Map()
         )
         .forEach((v, k) => {

--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -178,6 +178,19 @@ async function executeTryOut(endpointId, form) {
     const query = {};
     const queryParameters = form.querySelectorAll('input[data-component=query]');
     queryParameters.forEach(el => _.set(query, el.name, el.value));
+    Array.from(queryParameters)
+        .filter(el => el.type === "radio")
+        .reduce(
+            (entryMap, e) => entryMap.set(e.name, [...(entryMap.get(e.name) || []), e]),
+            new Map()
+        )
+        .forEach((v, k) => {
+            v.forEach(el => {
+                if (el.checked) {
+                    _.set(query, k, el.value);
+                }
+            });
+        });
 
     let path = form.dataset.path;
     const urlParameters = form.querySelectorAll('input[data-component=url]');


### PR DESCRIPTION
Radio buttons would call `_.set` for each of them, meaning that the value of the parameter would always be the set to the same as the last added. (`false` in the case of `boolean` validations)

With this change, the selected value is set instead.
