### PR TITLE
Added: support for csrf tokens that apply automatically

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -187,11 +187,6 @@ return [
         'base_url' => null,
 
         /**
-         * Set the referrer, mode, and credentials, values in the fetch calls
-         */
-        'use_cors' => true,
-
-        /**
          * Fetch the CSRF token before each request. This is required if you are using Laravel Sanctum
          */
         'use_csrf' => false,

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -176,7 +176,6 @@ return [
     'try_it_out' => [
         /**
          * Add a Try It Out button to your endpoints so consumers can test endpoints right from their browser.
-         * Don't forget to enable CORS headers for your endpoints.
          */
         'enabled' => true,
 
@@ -185,6 +184,28 @@ return [
          * Leave as null to use the current app URL (config(app.url)).
          */
         'base_url' => null,
+
+        /**
+         * Set the referrer, mode, and credentials, values in the fetch calls
+         */
+        'use_cors' => true,
+
+        /**
+         * Fetch the CSRF token before each request. This is required if you are using Laravel Sanctum
+         */
+        'use_csrf' => false,
+
+        /**
+         * The URL to set the sessions CSRF token for the application
+         * Only used when 'use_csrf' is not set to false
+         */
+        'csrf_url' => '/sanctum/csrf-token',
+
+        /**
+         * The name of the cookie to set when making requests
+         * Only used when 'use_csrf' is not set to false
+         */
+        'csrf_cookie_name' => 'X-XSRF-TOKEN',
     ],
 
     /*

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -176,6 +176,7 @@ return [
     'try_it_out' => [
         /**
          * Add a Try It Out button to your endpoints so consumers can test endpoints right from their browser.
+         * Don't forget to enable CORS headers for your endpoints.
          */
         'enabled' => true,
 

--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -98,11 +98,9 @@ function makeAPICall(method, path, body, query, headers, endpointId) {
         headers,
         body: method === 'GET' ? undefined : body,
         signal: window.abortControllers[endpointId].signal,
-        ...window.useCors ? {
-            referrer: window.baseUrl,
-            mode: 'cors',
-            credentials: 'same-origin',
-        } : {},
+        referrer: window.baseUrl,
+        mode: 'cors',
+        credentials: 'same-origin',
     })
         .then(response => Promise.all([response.status, response.text(), response.headers]));
 }

--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -1,5 +1,21 @@
 window.abortControllers = {};
 
+function getCookie(name) {
+    if (!document.cookie) {
+        return null;
+    }
+
+    const xsrfCookies = document.cookie.split(';')
+        .map(c => c.trim())
+        .filter(c => c.startsWith(name + '='));
+
+    if (xsrfCookies.length === 0) {
+        return null;
+    }
+
+    return decodeURIComponent(xsrfCookies[0].split('=')[1]);
+}
+
 function tryItOut(endpointId) {
     document.querySelector(`#btn-tryout-${endpointId}`).hidden = true;
     document.querySelector(`#btn-executetryout-${endpointId}`).hidden = false;
@@ -81,7 +97,12 @@ function makeAPICall(method, path, body, query, headers, endpointId) {
         method,
         headers,
         body: method === 'GET' ? undefined : body,
-        signal: window.abortControllers[endpointId].signal
+        signal: window.abortControllers[endpointId].signal,
+        ...window.useCors ? {
+            referrer: window.baseUrl,
+            mode: 'cors',
+            credentials: 'same-origin',
+        } : {},
     })
         .then(response => Promise.all([response.status, response.text(), response.headers]));
 }
@@ -178,7 +199,7 @@ async function executeTryOut(endpointId, form) {
     const query = {};
     const queryParameters = form.querySelectorAll('input[data-component=query]');
     queryParameters.forEach(el => _.set(query, el.name, el.value));
-    
+
     // Group radio buttons by their name, and then set the checked value from that group
     Array.from(queryParameters)
         .filter(el => el.type === "radio")
@@ -216,7 +237,13 @@ async function executeTryOut(endpointId, form) {
         }
     }
 
-    makeAPICall(method, path, body, query, headers, endpointId)
+    const preflightPromise = window.useCsrf && window.csrfUrl ? makeAPICall('GET', window.csrfUrl, {}, {}, {}, null).then(() => {
+            headers['X-XSRF-TOKEN'] = getCookie(window.csrfCookieName);
+
+            return makeAPICall(method, path, body, query, headers, endpointId);
+        }) : makeAPICall(method, path, body, query, headers, endpointId);
+
+    preflightPromise
         .then(([responseStatus, responseContent, responseHeaders]) => {
             handleResponse(endpointId, responseContent, responseStatus, responseHeaders)
         })

--- a/resources/views/themes/default/index.blade.php
+++ b/resources/views/themes/default/index.blade.php
@@ -24,7 +24,6 @@
     <script src="//cdn.jsdelivr.net/npm/lodash@4.17.10/lodash.min.js"></script>
     <script>
         var baseUrl = "{{ $tryItOut['base_url'] ?? config('app.url') }}";
-        var useCors = Boolean({{ $tryItOut['use_cors'] ?? null }});
         var useCsrf = Boolean({{ $tryItOut['use_csrf'] ?? null }});
         var csrfUrl = "{{ $tryItOut['csrf_url'] ?? null }}";
         var csrfCookieName = "{{ $tryItOut['csrf_cookie_name'] ?? "XSRF-TOKEN" }}";

--- a/resources/views/themes/default/index.blade.php
+++ b/resources/views/themes/default/index.blade.php
@@ -24,6 +24,10 @@
     <script src="//cdn.jsdelivr.net/npm/lodash@4.17.10/lodash.min.js"></script>
     <script>
         var baseUrl = "{{ $tryItOut['base_url'] ?? config('app.url') }}";
+        var useCors = Boolean({{ $tryItOut['use_cors'] ?? null }});
+        var useCsrf = Boolean({{ $tryItOut['use_csrf'] ?? null }});
+        var csrfUrl = "{{ $tryItOut['csrf_url'] }}";
+        var csrfCookieName = "{{ $tryItOut['csrf_cookie_name'] ?? "XSRF-TOKEN" }}";
     </script>
     <script src="{{ u::getVersionedAsset($assetPathPrefix.'js/tryitout.js') }}"></script>
 @endif

--- a/resources/views/themes/default/index.blade.php
+++ b/resources/views/themes/default/index.blade.php
@@ -26,7 +26,7 @@
         var baseUrl = "{{ $tryItOut['base_url'] ?? config('app.url') }}";
         var useCors = Boolean({{ $tryItOut['use_cors'] ?? null }});
         var useCsrf = Boolean({{ $tryItOut['use_csrf'] ?? null }});
-        var csrfUrl = "{{ $tryItOut['csrf_url'] }}";
+        var csrfUrl = "{{ $tryItOut['csrf_url'] ?? null }}";
         var csrfCookieName = "{{ $tryItOut['csrf_cookie_name'] ?? "XSRF-TOKEN" }}";
     </script>
     <script src="{{ u::getVersionedAsset($assetPathPrefix.'js/tryitout.js') }}"></script>


### PR DESCRIPTION
These additions allow supporting CSRF tokens for apps using Laravel Sanctum. You can provide a URL that gives you the token, which it then applies, to each URL being called.

This should address #243.

There are probably some docs updates here just to call this feature out, but I can do these when/if this is accepted.