### PR TITLE
Removed the check that prevented GET endpoint handlers from supportin…

### DIFF
--- a/src/Extracting/Extractor.php
+++ b/src/Extracting/Extractor.php
@@ -161,9 +161,6 @@ class Extractor
 
     protected function fetchBodyParameters(ExtractedEndpointData $endpointData, array $rulesToApply): void
     {
-        if (in_array('GET', $endpointData->httpMethods)) {
-            return;
-        }
         $this->iterateThroughStrategies('bodyParameters', $endpointData, $rulesToApply, function ($results) use ($endpointData) {
             foreach ($results as $key => $item) {
                 if (empty($item['name'])) {

--- a/tests/Unit/ExtractorPluginSystemTest.php
+++ b/tests/Unit/ExtractorPluginSystemTest.php
@@ -65,6 +65,7 @@ class ExtractorPluginSystemTest extends TestCase
     {
         $config = [
             'strategies' => [
+                'bodyParameters' => [],
                 'responses' => [DummyResponseStrategy200::class, DummyResponseStrategy400::class],
             ],
         ];
@@ -94,6 +95,7 @@ class ExtractorPluginSystemTest extends TestCase
         $config = [
             'strategies' => [
                 'metadata' => [PartialDummyMetadataStrategy1::class, PartialDummyMetadataStrategy2::class],
+                'bodyParameters' => [],
                 'responses' => [],
             ],
         ];
@@ -117,6 +119,7 @@ class ExtractorPluginSystemTest extends TestCase
         $config = [
             'strategies' => [
                 'metadata' => [PartialDummyMetadataStrategy2::class],
+                'bodyParameters' => [],
                 'responses' => [],
             ],
         ];

--- a/tests/Unit/ExtractorPluginSystemTest.php
+++ b/tests/Unit/ExtractorPluginSystemTest.php
@@ -140,6 +140,7 @@ class ExtractorPluginSystemTest extends TestCase
         $config = [
             'strategies' => [
                 'metadata' => [NotDummyMetadataStrategy::class, PartialDummyMetadataStrategy1::class],
+                'bodyParameters' => [],
                 'responses' => [],
             ],
         ];


### PR DESCRIPTION
Removed the check that prevented GET endpoint handlers from supporting the `@bodyParams` annotation.

I'm afraid this seems to have caused the following test to fail:
```
1) Knuckles\Scribe\Tests\Unit\ExtractorPluginSystemTest::responses_from_different_strategies_get_added
Illuminate\Contracts\Container\BindingResolutionException: Target class [validator] does not exist.
```

I don't understand the project well enough to fix the test myself although the change has produced the desired result for me in practice.

Closes #316 