### PR TITLE
Fixed: bad csrf URL for sanctum

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -194,7 +194,7 @@ return [
         /**
          * The URL to fetch the CSRF token from (if `use_csrf` is true).
          */
-        'csrf_url' => '/sanctum/csrf-token',
+        'csrf_url' => '/sanctum/csrf-cookie',
     ],
 
     /*


### PR DESCRIPTION
This is annoying but I screwed up the sanctum URL. It was `csrf-cookie` not `csrf-token`.

I was testing 3.10 when I found this error