### PR TITLE
Adjusted language examples to properly display application/x-www-form…

### DIFF
--- a/resources/views/partials/example-requests/bash.md.blade.php
+++ b/resources/views/partials/example-requests/bash.md.blade.php
@@ -23,7 +23,11 @@ curl --request {{$endpoint->httpMethods[0]}} \
 @endforeach
 @endforeach
 @elseif(count($endpoint->cleanBodyParameters))
+@if ($endpoint->headers['Content-Type'] == 'application/x-www-form-urlencoded')
+    --data "{!! http_build_query($endpoint->cleanBodyParameters, '', '&') !!}"
+@else
     --data "{!! addslashes(json_encode($endpoint->cleanBodyParameters, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) !!}"
+@endif
 @endif
 
 ```

--- a/resources/views/partials/example-requests/javascript.md.blade.php
+++ b/resources/views/partials/example-requests/javascript.md.blade.php
@@ -37,7 +37,11 @@ body.append('{!! $key !!}', document.querySelector('input[name="{!! $key !!}"]')
 @endforeach
 @endforeach
 @elseif(count($endpoint->cleanBodyParameters))
-let body = {!! json_encode($endpoint->cleanBodyParameters, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) !!}
+@if ($endpoint->headers['Content-Type'] == 'application/x-www-form-urlencoded')
+let body = "{!! http_build_query($endpoint->cleanBodyParameters, '', '&') !!}";
+@else
+let body = {!! json_encode($endpoint->cleanBodyParameters, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE) !!};
+@endif
 @endif
 
 fetch(url, {
@@ -48,7 +52,11 @@ fetch(url, {
 @if($endpoint->hasFiles())
     body,
 @elseif(count($endpoint->cleanBodyParameters))
+@if ($endpoint->headers['Content-Type'] == 'application/x-www-form-urlencoded')
+    body: body,
+@else
     body: JSON.stringify(body),
+@endif
 @endif
 }).then(response => response.json());
 ```

--- a/resources/views/partials/example-requests/php.md.blade.php
+++ b/resources/views/partials/example-requests/php.md.blade.php
@@ -38,7 +38,11 @@ unset($headers['Content-Type']);
 @endforeach
         ],
 @elseif(!empty($endpoint->cleanBodyParameters))
+@if ($endpoint->headers['Content-Type'] == 'application/x-www-form-urlencoded')
+        'form_params' => {!! u::printPhpValue($endpoint->cleanBodyParameters, 8) !!},
+@else
         'json' => {!! u::printPhpValue($endpoint->cleanBodyParameters, 8) !!},
+@endif
 @endif
     ]
 );

--- a/resources/views/partials/example-requests/python.md.blade.php
+++ b/resources/views/partials/example-requests/python.md.blade.php
@@ -38,7 +38,7 @@ headers = {
 $optionalArguments = [];
 if (count($endpoint->headers)) $optionalArguments[] = "headers=headers";
 if (count($endpoint->fileParameters)) $optionalArguments[] = "files=files";
-if (count($endpoint->cleanBodyParameters)) $optionalArguments[] = (count($endpoint->fileParameters) ? "data=payload" : "json=payload");
+if (count($endpoint->cleanBodyParameters)) $optionalArguments[] = (count($endpoint->fileParameters) || $endpoint->headers['Content-Type'] == 'application/x-www-form-urlencoded' ? "data=payload" : "json=payload");
 if (count($endpoint->cleanQueryParameters)) $optionalArguments[] = "params=params";
 $optionalArguments = implode(', ',$optionalArguments);
 @endphp


### PR DESCRIPTION
This PR provides support for application/x-www-form-urlencoded requests to be displayed properly within the various language examples. The app I'm working with is using Laravel Passport and I was needing a way to display to users how to obtain an access token via the following URL (which uses application/x-www-form-urlencoded under the hood).

https://laravel.com/docs/8.x/passport#retrieving-tokens

I'm not exactly proficient in all of the languages but used my best judgement. Below are some of the before/after screenshots. With the exception of python, application/x-www-form-urlencoded expects parameters instead of json so those are what the adjustments are focused on.

bash (before)
![image](https://user-images.githubusercontent.com/18044230/134788447-4a8d3172-9c37-493a-a052-39dc1f5568c9.png)

bash (after)
![image](https://user-images.githubusercontent.com/18044230/134788331-c864562f-60bc-4089-9b99-abd6046b2ec6.png)

javascript (before)
![image](https://user-images.githubusercontent.com/18044230/134788485-f4477bc3-9f35-4d9a-97e3-c6aff69c3376.png)

javascript (after)
![image](https://user-images.githubusercontent.com/18044230/134788378-6586a98b-1547-43d9-ad60-1ca79a096e5f.png)

php (before)
![image](https://user-images.githubusercontent.com/18044230/134788492-f28c676a-3e9a-42d6-8815-50db598121f4.png)

php (after)
![image](https://user-images.githubusercontent.com/18044230/134788394-1a2684c6-7f79-4ae2-bbf5-364802456e8e.png)

The php demo was hiding the Content-Type header, and I know you (@shalvah) mentioned here (https://github.com/knuckleswtf/scribe/issues/330) that this is because the Grizzly library that the examples are using automatically add those for you, but I still believe it'd be best to explicitly display those to the users integrating with the documentation. Anything to make it easier right? Plus, the Guzzle docs just mention that Content-Type headers are only set when no Content-Type header is already present. Well in this case one is being explicitly provided and should be displayed. Another part of the issue here, and maybe the bigger part of the issue, was that there was no way to display the body type of "form_params" instead of "json" (which the oauth/token example doesn't work when using json).

https://docs.guzzlephp.org/en/stable/request-options.html#form-params

python (before)
![image](https://user-images.githubusercontent.com/18044230/134788649-631f4db4-2b13-47e8-99ae-a390ae6c57e0.png)

python (after)
![image](https://user-images.githubusercontent.com/18044230/134788406-a53ba2a4-c00c-41b7-be7f-f349a3259b0e.png)

Not a python user so I hope is correct.

Thanks for your time!