### PR TITLE
Adjust PHP language example to allow the display of explicit set Cont…

### DIFF
--- a/resources/views/partials/example-requests/php.md.blade.php
+++ b/resources/views/partials/example-requests/php.md.blade.php
@@ -8,12 +8,8 @@ $client = new \GuzzleHttp\Client();
 $response = $client->{{ strtolower($endpoint->httpMethods[0]) }}(
     '{{ rtrim($baseUrl, '/') . '/' . ltrim($endpoint->boundUri, '/') }}',
     [
-@if(!empty($endpoint->headers))@php
-// We don't need the Content-Type header because Guzzle sets it automatically when you use json or multipart.
-$headers = $endpoint->headers;
-unset($headers['Content-Type']);
-@endphp
-        'headers' => {!! u::printPhpValue($headers, 8) !!},
+@if(!empty($endpoint->headers))
+        'headers' => {!! u::printPhpValue($endpoint->headers, 8) !!},
 @endif
 @if(!empty($endpoint->cleanQueryParameters))
         'query' => {!! u::printQueryParamsAsKeyValue($endpoint->cleanQueryParameters, "'", "=>", 12, "[]", 8) !!},


### PR DESCRIPTION
Would you consider allowing the Content-Type header to be displayed in the PHP example? This slipped through the cracks on the last PR and I apologize for that.

PHP Before
![image](https://user-images.githubusercontent.com/18044230/134932423-f87c8dfd-4d78-4867-8f71-0fca30cafe13.png)

PHP After
![php-after](https://user-images.githubusercontent.com/18044230/134930751-a495c657-4292-4e42-a775-22bf1e505df5.png)

Thanks again!