### PR TITLE
Fix bug where response status could be given to Response as a string, throwing type error

### DIFF
--- a/camel/Extraction/Response.php
+++ b/camel/Extraction/Response.php
@@ -21,6 +21,10 @@ class Response extends BaseDTO
             $parameters['content'] = json_encode($parameters['content']);
         }
 
+        if (isset($parameters['status'])) {
+            $parameters['status'] = (int) $parameters['status'];
+        }
+
         $hiddenHeaders = [
             'date',
             'Date',


### PR DESCRIPTION
I'm not exactly sure how to reproduce this problem, but I have a bunch of controllers with annotations like this:

```
@transformer 201 \My\Project\Transformers\MyTransformer
```

When I generate documentation it will throw this error:

```
[2021-10-23 01:36:09] local.ERROR: Invalid type: expected `Knuckles\Camel\Extraction\Response::status` to be of type `integer`, instead got value `201`, which is string.. {"exception":"[object] (Spatie\\DataTransferObject\\DataTransferObjectError(code: 0): Invalid type: expected `Knuckles\\Camel\\Extraction\\Response::status` to be of type `integer`, instead got value `201`, which is string.. at /public/api/vendor/spatie/data-transfer-object/src/DataTransferObjectError.php:24)
[stacktrace]
#0 /public/api/vendor/spatie/data-transfer-object/src/DataTransferObject.php(85): Spatie\\DataTransferObject\\DataTransferObjectError::invalidTypes(Array)
#1 /public/api/vendor/knuckleswtf/scribe/camel/Extraction/Response.php(46): Spatie\\DataTransferObject\\DataTransferObject->__construct(Array)
#2 /public/api/vendor/knuckleswtf/scribe/camel/BaseDTOCollection.php(40): Knuckles\\Camel\\Extraction\\Response->__construct(Array)
#3 /public/api/vendor/knuckleswtf/scribe/src/Extracting/Extractor.php(178): Knuckles\\Camel\\BaseDTOCollection->concat(Array)
#4 /public/api/vendor/knuckleswtf/scribe/src/Extracting/Extractor.php(224): Knuckles\\Scribe\\Extracting\\Extractor->Knuckles\\Scribe\\Extracting\\{closure}(Array)
#5 /public/api/vendor/knuckleswtf/scribe/src/Extracting/Extractor.php(179): Knuckles\\Scribe\\Extracting\\Extractor->iterateThroughStrategies('responses', Object(Knuckles\\Camel\\Extraction\\ExtractedEndpointData), Array, Object(Closure))
#6 /public/api/vendor/knuckleswtf/scribe/src/Extracting/Extractor.php(116): Knuckles\\Scribe\\Extracting\\Extractor->fetchResponses(Object(Knuckles\\Camel\\Extraction\\ExtractedEndpointData), Array)
#7 /public/api/vendor/knuckleswtf/scribe/src/GroupedEndpoints/GroupedEndpointsFromApp.php(118): Knuckles\\Scribe\\Extracting\\Extractor->processRoute(Object(Illuminate\\Routing\\Route), Array)
#8 /public/api/vendor/knuckleswtf/scribe/src/GroupedEndpoints/GroupedEndpointsFromApp.php(75): Knuckles\\Scribe\\GroupedEndpoints\\GroupedEndpointsFromApp->extractEndpointsInfoFromLaravelApp(Array, Array, Array, Array)
```

I've scanned the obvious places in this repo that are parsing status codes from annotations like this, and they are all casting as ints. This patch does solve the problem however, and since the property is strongly typed on the Response class it feels like an acceptable solution (to me).
