### PR TITLE
Support routes with regex

### DIFF
--- a/camel/Extraction/ExtractedEndpointData.php
+++ b/camel/Extraction/ExtractedEndpointData.php
@@ -128,7 +128,7 @@ class ExtractedEndpointData extends BaseDTO
 
     public function endpointId()
     {
-        return $this->httpMethods[0] . str_replace(['/', '?', '{', '}', ':'], '-', $this->uri);
+        return $this->httpMethods[0] . str_replace(['/', '?', '{', '}', ':', '\\', '+', '|'], '-', $this->uri);
     }
 
     public function normalizeResourceParamName(string $uri, Route $route): string

--- a/camel/Output/OutputEndpointData.php
+++ b/camel/Output/OutputEndpointData.php
@@ -137,7 +137,7 @@ class OutputEndpointData extends BaseDTO
 
     public function endpointId(): string
     {
-        return $this->httpMethods[0] . str_replace(['/', '?', '{', '}', ':'], '-', $this->uri);
+        return $this->httpMethods[0] . str_replace(['/', '?', '{', '}', ':', '\\', '+', '|'], '-', $this->uri);
     }
 
     public function hasResponses(): bool


### PR DESCRIPTION
In lumen it is possible to have regex for parameter validation directly in the route. 

The generated endpoint-ids can contain characters like `\d+`. These are not valid in html. Therefore I have added additional replacements of characters in the endpoint-id generation. 

I haven't added tests, because I am not sure where I should add them. It would be great if you could give me a hint :) 

