### PR TITLE
Add ability to define custom names for languages in config, by using the array key

### DIFF
--- a/resources/js/theme-default.js
+++ b/resources/js/theme-default.js
@@ -105,7 +105,11 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    const languages = JSON.parse(document.body.getAttribute('data-languages'));
+    let languages = JSON.parse(document.body.getAttribute('data-languages'));
+    // Support a key => value object where the key is the name, or an array of strings where the value is the name
+    if (!Array.isArray(languages)) {
+        languages = Object.values(languages);
+    }
     // if there is no language use the first one
     const currentLanguage = window.localStorage.getItem('language') || languages[0];
     const languageStyle = document.getElementById('language-style');

--- a/resources/views/themes/default/index.blade.php
+++ b/resources/views/themes/default/index.blade.php
@@ -62,8 +62,9 @@
     <div class="dark-box">
         @if(isset($metadata['example_languages']))
             <div class="lang-selector">
-                @foreach($metadata['example_languages'] as $lang)
-                    <button type="button" class="lang-button" data-language-name="{{$lang}}">{{$lang}}</button>
+                @foreach($metadata['example_languages'] as $name => $lang)
+                    @php if (is_numeric($name)) $name = $lang; @endphp
+                    <button type="button" class="lang-button" data-language-name="{{$lang}}">{{$name}}</button>
                 @endforeach
             </div>
         @endif

--- a/resources/views/themes/default/sidebar.blade.php
+++ b/resources/views/themes/default/sidebar.blade.php
@@ -11,8 +11,9 @@
 
     @isset($metadata['example_languages'])
         <div class="lang-selector">
-            @foreach($metadata['example_languages'] as $lang)
-                <a href="#" data-language-name="{{ $lang }}">{{ $lang }}</a>
+            @foreach($metadata['example_languages'] as $name => $lang)
+                @php if (is_numeric($name)) $name = $lang; @endphp
+                <button type="button" class="lang-button" data-language-name="{{ $lang }}">{{ $name }}</button>
             @endforeach
         </div>
     @endisset


### PR DESCRIPTION
This allows you to define custom language names which will be used in the output docs language switcher buttons, e.g.:

```php
# File: config/scribe.php
'example_languages' => [
    'bash',
    'javascript',
    'TS' => 'typescript',
],
```

Also fixes the language switcher on mobile which was broken (wouldn't switch language and would always send you to the top of the page).