### PR TITLE
Feat: base url contain protocol

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -280,6 +280,15 @@ INTRO
         'overrides' => [
             // 'info.version' => '2.0.0',
         ],
+
+        /*
+         * Generate baseUrl variable contain protocol (http/https).
+         *
+         * Example :
+         * `true` -> baseUrl = http://localhost
+         * `false` -> baseUrl = localhost
+         */
+        'is_base_url_contain_protocol' => false,
     ],
 
     /*

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -280,15 +280,6 @@ INTRO
         'overrides' => [
             // 'info.version' => '2.0.0',
         ],
-
-        /*
-         * Generate baseUrl variable contain protocol (http/https).
-         *
-         * Example :
-         * `true` -> baseUrl = http://localhost
-         * `false` -> baseUrl = localhost
-         */
-        'is_base_url_contain_protocol' => false,
     ],
 
     /*

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -34,10 +34,6 @@ class PostmanCollectionWriter
      */
     public function generatePostmanCollection(array $groupedEndpoints): array
     {
-        $baseUrl = !$this->config->get('postman.is_base_url_contain_protocol')
-            ? (parse_url($this->baseUrl, PHP_URL_HOST) ?: $this->baseUrl) // if there's no protocol, parse_url might fail
-            : $this->baseUrl;
-
         $collection = [
             'variable' => [
                 [
@@ -45,7 +41,7 @@ class PostmanCollectionWriter
                     'key' => 'baseUrl',
                     'type' => 'string',
                     'name' => 'string',
-                    'value' => $baseUrl,
+                    'value' => $this->baseUrl,
                 ],
             ],
             'info' => [
@@ -234,10 +230,6 @@ class PostmanCollectionWriter
             }, $endpointData->uri),
         ];
 
-        if (!$this->config->get('postman.is_base_url_contain_protocol')) {
-            $base['protocol'] = Str::startsWith($this->baseUrl, 'https') ? 'https' : 'http';
-        }
-
         $query = [];
         [$where, $authParam] = $this->getAuthParamToExclude();
         /**
@@ -280,10 +272,7 @@ class PostmanCollectionWriter
         $queryString = collect($base['query'] ?? [])->map(function ($queryParamData) {
             return $queryParamData['key'] . '=' . $queryParamData['value'];
         })->implode('&');
-        $baseHost = !$this->config->get('postman.is_base_url_contain_protocol')
-            ? sprintf('%s://%s', $base['protocol'], $base['host'])
-            : $base['host'];
-        $base['raw'] = sprintf('%s/%s%s', $baseHost, $base['path'], $queryString ? "?{$queryString}" : null);
+        $base['raw'] = sprintf('%s/%s%s', $base['host'], $base['path'], $queryString ? "?{$queryString}" : null);
 
         $urlParams = collect($endpointData->urlParameters);
         if ($urlParams->isEmpty()) {

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -5,14 +5,14 @@
       "key": "baseUrl",
       "type": "string",
       "name": "string",
-      "value": "localhost"
+      "value": "http://localhost"
     }
   ],
   "info": {
     "name": "GREAT API!",
     "_postman_id": "",
     "description": "",
-    "schema": "https:\/\/schema.getpostman.com\/json\/collection\/v2.1.0\/collection.json",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "version": "3.9.9"
   },
   "item": [
@@ -24,11 +24,10 @@
           "name": "Endpoint with body parameters as array.",
           "request": {
             "url": {
-              "protocol": "http",
               "host": "{{baseUrl}}",
               "path": "api/withBodyParametersAsArray",
               "query": [],
-              "raw": "http://{{baseUrl}}/api/withBodyParametersAsArray"
+              "raw": "{{baseUrl}}/api/withBodyParametersAsArray"
             },
             "method": "POST",
             "header": [
@@ -60,11 +59,10 @@
           "name": "Endpoint with body form data parameters.",
           "request": {
             "url": {
-              "protocol": "http",
               "host": "{{baseUrl}}",
-              "path": "api\/withFormDataParams",
+              "path": "api/withFormDataParams",
               "query": [],
-              "raw": "http:\/\/{{baseUrl}}\/api\/withFormDataParams"
+              "raw": "{{baseUrl}}/api/withFormDataParams"
             },
             "method": "POST",
             "header": [
@@ -74,11 +72,11 @@
               },
               {
                 "key": "Content-Type",
-                "value": "multipart\/form-data"
+                "value": "multipart/form-data"
               },
               {
                 "key": "Accept",
-                "value": "application\/json"
+                "value": "application/json"
               }
             ],
             "body": {
@@ -107,11 +105,10 @@
           "name": "Endpoint with body parameters.",
           "request": {
             "url": {
-              "protocol": "http",
               "host": "{{baseUrl}}",
-              "path": "api\/withBodyParameters",
+              "path": "api/withBodyParameters",
               "query": [],
-              "raw": "http:\/\/{{baseUrl}}\/api\/withBodyParameters"
+              "raw": "{{baseUrl}}/api/withBodyParameters"
             },
             "method": "POST",
             "header": [
@@ -121,11 +118,11 @@
               },
               {
                 "key": "Content-Type",
-                "value": "application\/json"
+                "value": "application/json"
               },
               {
                 "key": "Accept",
-                "value": "application\/json"
+                "value": "application/json"
               }
             ],
             "body": {
@@ -140,12 +137,11 @@
           "response": []
         },
         {
-          "name": "api\/withQueryParameters",
+          "name": "api/withQueryParameters",
           "request": {
             "url": {
-              "protocol": "http",
               "host": "{{baseUrl}}",
-              "path": "api\/withQueryParameters",
+              "path": "api/withQueryParameters",
               "query": [
                 {
                   "key": "location_id",
@@ -178,7 +174,7 @@
                   "disabled": false
                 }
               ],
-              "raw": "http:\/\/{{baseUrl}}\/api\/withQueryParameters?location_id=consequatur&user_id=me&page=4&filters=consequatur&url_encoded=%2B+%5B%5D%26%3D"
+              "raw": "{{baseUrl}}/api/withQueryParameters?location_id=consequatur&user_id=me&page=4&filters=consequatur&url_encoded=%2B+%5B%5D%26%3D"
             },
             "method": "GET",
             "header": [
@@ -188,7 +184,7 @@
               },
               {
                 "key": "Accept",
-                "value": "application\/json"
+                "value": "application/json"
               }
             ],
             "body": null,
@@ -216,14 +212,13 @@
           ]
         },
         {
-          "name": "api\/withAuthTag",
+          "name": "api/withAuthTag",
           "request": {
             "url": {
-              "protocol": "http",
               "host": "{{baseUrl}}",
-              "path": "api\/withAuthTag",
+              "path": "api/withAuthTag",
               "query": [],
-              "raw": "http:\/\/{{baseUrl}}\/api\/withAuthTag"
+              "raw": "{{baseUrl}}/api/withAuthTag"
             },
             "method": "GET",
             "header": [
@@ -233,7 +228,7 @@
               },
               {
                 "key": "Accept",
-                "value": "application\/json"
+                "value": "application/json"
               }
             ],
             "body": null,
@@ -264,12 +259,11 @@
       "description": "",
       "item": [
         {
-          "name": "api\/echoesUrlParameters\/{param}\/{param2}\/{param3?}\/{param4?}",
+          "name": "api/echoesUrlParameters/{param}/{param2}/{param3?}/{param4?}",
           "request": {
             "url": {
-              "protocol": "http",
               "host": "{{baseUrl}}",
-              "path": "api\/echoesUrlParameters\/:param\/:param2\/:param3\/:param4",
+              "path": "api/echoesUrlParameters/:param/:param2/:param3/:param4",
               "query": [
                 {
                   "key": "something",
@@ -278,7 +272,7 @@
                   "disabled": false
                 }
               ],
-              "raw": "http:\/\/{{baseUrl}}\/api\/echoesUrlParameters\/:param\/:param2\/:param3\/:param4?something=consequatur",
+              "raw": "{{baseUrl}}/api/echoesUrlParameters/:param/:param2/:param3/:param4?something=consequatur",
               "variable": [
                 {
                   "id": "param",
@@ -314,7 +308,7 @@
               },
               {
                 "key": "Accept",
-                "value": "application\/json"
+                "value": "application/json"
               }
             ],
             "body": null,

--- a/tests/Unit/PostmanCollectionWriterTest.php
+++ b/tests/Unit/PostmanCollectionWriterTest.php
@@ -42,7 +42,6 @@ class PostmanCollectionWriterTest extends TestCase
 
         $item = data_get($collection, 'item.0.item.0');
         $this->assertSame('some/path', $item['name'], 'Name defaults to path');
-        $this->assertSame('http', data_get($item, 'request.url.protocol'), 'Protocol defaults to http');
         $this->assertSame('fake.localhost', data_get($collection, 'variable.0.value'));
         $this->assertSame('{{baseUrl}}', data_get($item, 'request.url.host'));
         $this->assertSame('some/path', data_get($item, 'request.url.path'), 'Path is set correctly');
@@ -265,39 +264,6 @@ class PostmanCollectionWriterTest extends TestCase
         ], $collection['auth']);
         $this->assertArrayNotHasKey('auth', $collection['item'][0]['item'][0]['request']);
         $this->assertEquals(['type' => 'noauth'], $collection['item'][0]['item'][1]['request']['auth']);
-    }
-
-    /** @test */
-    public function base_url_contain_protocol()
-    {
-        $endpointData = $this->createMockEndpointData('some/path');
-        $endpoints = $this->createMockEndpointGroup([$endpointData], 'Group');
-
-        $config = [
-            'base_url' => 'http://localhost',
-            'title' => 'Test API',
-            'postman' => [
-                'enabled' => true,
-                'is_base_url_contain_protocol' => true,
-            ],
-        ];
-        $writer = new PostmanCollectionWriter(new DocumentationConfig($config));
-        $collection = $writer->generatePostmanCollection([$endpoints]);
-
-        $this->assertSame('Group', data_get($collection, 'item.0.name'), 'Group name exists');
-        
-        $item = data_get($collection, 'item.0.item.0');
-        $this->assertSame('some/path', $item['name'], 'Name defaults to path');
-        $this->assertArrayNotHasKey('protocol', data_get($item, 'request.url'), 'Protocol not exists when base url contain protocol');
-        $this->assertSame('http://localhost', data_get($collection, 'variable.0.value'));
-        $this->assertSame('{{baseUrl}}', data_get($item, 'request.url.host'));
-        $this->assertSame('some/path', data_get($item, 'request.url.path'), 'Path is set correctly');
-        $this->assertEmpty(data_get($item, 'request.url.query'), 'Query parameters are empty');
-        $this->assertSame('GET', data_get($item, 'request.method'), 'Method is correctly resolved');
-        $this->assertContains([
-            'key' => 'Accept',
-            'value' => 'application/json',
-        ], data_get($item, 'request.header'), 'JSON Accept header is added');
     }
 
     protected function createMockEndpointData(string $path, string $title = ''): OutputEndpointData

--- a/tests/Unit/PostmanCollectionWriterTest.php
+++ b/tests/Unit/PostmanCollectionWriterTest.php
@@ -267,6 +267,39 @@ class PostmanCollectionWriterTest extends TestCase
         $this->assertEquals(['type' => 'noauth'], $collection['item'][0]['item'][1]['request']['auth']);
     }
 
+    /** @test */
+    public function base_url_contain_protocol()
+    {
+        $endpointData = $this->createMockEndpointData('some/path');
+        $endpoints = $this->createMockEndpointGroup([$endpointData], 'Group');
+
+        $config = [
+            'base_url' => 'http://localhost',
+            'title' => 'Test API',
+            'postman' => [
+                'enabled' => true,
+                'is_base_url_contain_protocol' => true,
+            ],
+        ];
+        $writer = new PostmanCollectionWriter(new DocumentationConfig($config));
+        $collection = $writer->generatePostmanCollection([$endpoints]);
+
+        $this->assertSame('Group', data_get($collection, 'item.0.name'), 'Group name exists');
+        
+        $item = data_get($collection, 'item.0.item.0');
+        $this->assertSame('some/path', $item['name'], 'Name defaults to path');
+        $this->assertArrayNotHasKey('protocol', data_get($item, 'request.url'), 'Protocol not exists when base url contain protocol');
+        $this->assertSame('http://localhost', data_get($collection, 'variable.0.value'));
+        $this->assertSame('{{baseUrl}}', data_get($item, 'request.url.host'));
+        $this->assertSame('some/path', data_get($item, 'request.url.path'), 'Path is set correctly');
+        $this->assertEmpty(data_get($item, 'request.url.query'), 'Query parameters are empty');
+        $this->assertSame('GET', data_get($item, 'request.method'), 'Method is correctly resolved');
+        $this->assertContains([
+            'key' => 'Accept',
+            'value' => 'application/json',
+        ], data_get($item, 'request.header'), 'JSON Accept header is added');
+    }
+
     protected function createMockEndpointData(string $path, string $title = ''): OutputEndpointData
     {
         return OutputEndpointData::create([


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->
# Overview

For now `baseUrl` not include protocol, only `localhost` or `example.com`, and in postman will be like this : 

```
http://{{baseUrl}}/some/other
```

It makes difficult when we want to change baseUrl from `http` to `https`, for example in local we use `http://localhost` but in staging we use `https://staging.example.com`. So, we must change environment variable in postman, then change `http` to `https` manually.

We can't only change environment variable, because `baseUrl` not contains protocol (http or https). It will be helpful when we can set `baseUrl` is http://localhost (including protocol).

So, I'm change baseUrl contain protocol, and also remove `protocol` attribute on `url` json.

# Example

## Before

```json
"variable": [
    {
        "id": "baseUrl",
        "key": "baseUrl",
        "type": "string",
        "name": "string",
        "value": "localhost"
    }
],
```

```json
"url": {
    "protocol": "http",
    "host": "{{baseUrl}}",
    "path": "api/withBodyParametersAsArray",
    "query": [],
    "raw": "http://{{baseUrl}}/api/withBodyParametersAsArray"
},
```
![Screenshot (14)](https://user-images.githubusercontent.com/39640211/145956161-1ac50538-3c70-4625-bc40-3d4c519ca4b2.png)

## After

```json
"variable": [
    {
        "id": "baseUrl",
        "key": "baseUrl",
        "type": "string",
        "name": "string",
        "value": "http://localhost"
    }
],
```

```json
"url": {
    "host": "{{baseUrl}}",
    "path": "api/withBodyParametersAsArray",
    "query": [],
    "raw": "{{baseUrl}}/api/withBodyParametersAsArray"
},
```
![Screenshot (13)](https://user-images.githubusercontent.com/39640211/145956113-16896bc3-36a0-4eff-9383-329ec7595c26.png)
