### PR TITLE
Updated OpenAPISpecWriter & Parameter classes to allow for the optional 'format' modifier field to be included in the output schema.

### DIFF
--- a/camel/Extraction/Parameter.php
+++ b/camel/Extraction/Parameter.php
@@ -12,6 +12,7 @@ class Parameter extends BaseDTO
     public bool $required = false;
     public $example = null;
     public string $type = 'string';
+    public ?string $format = null;
 
     public function __construct(array $parameters = [])
     {

--- a/camel/Output/Parameter.php
+++ b/camel/Output/Parameter.php
@@ -19,6 +19,9 @@ class Parameter extends \Knuckles\Camel\Extraction\Parameter
     /** @var string */
     public string $type = 'string';
 
+    /** @var string|null */
+    public ?string $format = null;
+
     /** @var array */
     public $__fields = [];
 

--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -541,11 +541,15 @@ class OpenAPISpecWriter
                 })->all(),
             ];
         } else {
-            return [
+            $optionalSchema =  [];
+            if (!is_null($field->format)) {
+                $optionalSchema['format'] = $field->format;
+            }
+            return array_merge([
                 'type' => $this->normalizeTypeName($field->type),
                 'description' => $field->description ?: '',
                 'example' => $field->example,
-            ];
+            ], $optionalSchema);
         }
     }
 }

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -336,6 +336,7 @@ class GenerateDocumentationTest extends BaseLaravelTest
             'required' => true,
             'example' => 6,
             'type' => 'integer',
+            'format' => null,
         ];
         $group['endpoints'][0]['urlParameters']['a_param'] = $extraParam;
         file_put_contents($group1FilePath, Yaml::dump(


### PR DESCRIPTION
### What does this change do?

Updates the output openapi.yml file to allow the optional 'format' modifier as per the swagger data-types spec:
https://swagger.io/docs/specification/data-models/data-types/

### How does it work?
- Both of the Parameter classes have a new "public ?string $field = null;" property which can be optionally set to a string.
- The OpenAPISpecWriter class will include the above optional property in the 'schema' when it is set to a valid string.