### PR TITLE
[Feature] apiResourceAdditional tag, for documenting responses that using addtional function

### DIFF
--- a/src/Extracting/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Extracting/Strategies/Responses/UseApiResourceTags.php
@@ -183,11 +183,9 @@ class UseApiResourceTags extends Strategy
      */
     private function getAdditionalData(?Tag $tag): array
     {
-        if (!$tag) {
-            return [];
-        }
-
-        return a::parseIntoAttributes($tag->getContent());
+        return $tag
+            ? a::parseIntoAttributes($tag->getContent())
+            : [];
     }
 
     /**

--- a/src/Extracting/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Extracting/Strategies/Responses/UseApiResourceTags.php
@@ -55,7 +55,7 @@ class UseApiResourceTags extends Strategy
     }
 
     /**
-     * Get a response from the @apiResource/@apiResourceCollection and @apiResourceModel tags.
+     * Get a response from the @apiResource/@apiResourceCollection, @apiResourceModel and @apiResourceAdditional tags.
      *
      * @param Tag $apiResourceTag
      * @param Tag[] $allTags
@@ -68,6 +68,7 @@ class UseApiResourceTags extends Strategy
     {
         [$statusCode, $apiResourceClass] = $this->getStatusCodeAndApiResourceClass($apiResourceTag);
         [$model, $factoryStates, $relations, $pagination] = $this->getClassToBeTransformedAndAttributes($allTags);
+        $additionalData = $this->getAdditionalData($this->getApiResourceAdditionalTag($allTags));
         $modelInstance = $this->instantiateApiResourceModel($model, $factoryStates, $relations);
 
         try {
@@ -106,6 +107,9 @@ class UseApiResourceTags extends Strategy
                 ? new $apiResourceClass($list)
                 : $apiResourceClass::collection($list);
         }
+
+        // Adding additional meta information for our resource response
+        $resource = $resource->additional($additionalData);
 
         $uri = Utils::getUrlWithBoundParameters($endpointData->route->uri(), $endpointData->cleanUrlParameters);
         $method = $endpointData->route->methods()[0];
@@ -172,6 +176,21 @@ class UseApiResourceTags extends Strategy
     }
 
     /**
+     * Returns data for simulating JsonResource additional() function
+     *
+     * @param Tag|null $tag
+     * @return array
+     */
+    private function getAdditionalData(?Tag $tag): array
+    {
+        if (!$tag) {
+            return [];
+        }
+
+        return a::parseIntoAttributes($tag->getContent());
+    }
+
+    /**
      * @param string $type
      *
      * @param array $relations
@@ -228,5 +247,12 @@ class UseApiResourceTags extends Strategy
         );
 
         return Arr::first($apiResourceTags);
+    }
+
+    public function getApiResourceAdditionalTag(array $tags): ?Tag
+    {
+        return Arr::first($tags, function ($tag) {
+            return ($tag instanceof Tag) && strtolower($tag->getName()) == 'apiresourceadditional';
+        });
     }
 }

--- a/src/Tools/AnnotationParser.php
+++ b/src/Tools/AnnotationParser.php
@@ -30,4 +30,29 @@ class AnnotationParser
             'attributes' => $parsedAttributes
         ];
     }
+
+    /**
+     * Parse an annotation like 'status=400 when="things go wrong"' to key-value array
+     * All non key-value fields will be ignored
+     *
+     * @param string $annotationContent
+     * @return array
+     */
+    public static function parseIntoAttributes(string $annotationContent): array
+    {
+        $attributes = $matches = [];
+
+        preg_match_all(
+            '/([^\s\'"]+|".+?"|\'.+?\')=([^\s\'"]+|".+?"|\'.+?\')/',
+            $annotationContent,
+            $matches,
+            PREG_SET_ORDER,
+        );
+
+        foreach ($matches as $match) {
+            $attributes[trim($match[1], '"\' ')] = trim($match[2], '"\' ');
+        }
+
+        return $attributes;
+    }
 }

--- a/tests/Unit/AnnotationParserTest.php
+++ b/tests/Unit/AnnotationParserTest.php
@@ -9,7 +9,7 @@ class AnnotationParserTest extends TestCase
 {
     /**
      * @test
-     * @dataProvider annotations
+     * @dataProvider contentAttributesAnnotations
      */
     public function can_parse_annotation_into_content_and_attributes(string $annotation, array $expected)
     {
@@ -18,7 +18,7 @@ class AnnotationParserTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function annotations()
+    public function contentAttributesAnnotations()
     {
         return [
             "when attributes come first" => [
@@ -49,6 +49,42 @@ class AnnotationParserTest extends TestCase
                     'content' => '{"message": "failed"}',
                 ],
             ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider attributesAnnotations
+     */
+    public function can_parse_annotation_into_attributes(string $annotation, array $expected)
+    {
+        $result = AnnotationParser::parseIntoAttributes($annotation);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function attributesAnnotations()
+    {
+        return [
+            "when attributes filled" => [
+                'status=400 scenario="things go wrong" "dummy field"="dummy data", "snaked_data"=value',
+                [
+                    'status' => '400',
+                    'scenario' => 'things go wrong',
+                    'dummy field' => 'dummy data',
+                    'snaked_data' => 'value'
+                ]
+            ],
+            "when attributes not filled" => [
+                '{"message": "failed"}',
+                []
+            ],
+            "when attributes wrong" => [
+                'status= scenario="things go wrong"',
+                [
+                    'scenario' => 'things go wrong'
+                ]
+            ]
         ];
     }
 }


### PR DESCRIPTION
ref: https://github.com/knuckleswtf/scribe/issues/413

### Description
When user send Resource with additional function, we can use `@apiResourceAdditional` tag for simultating constants for it

```
/**
 * @apiResource App\Http\Resources\EventResource
 * @apiResourceModel App\Models\Event
 * @apiResourceAdditional title="Event created" message="Event successful created"
 */
public function store(StoreEventRequest $request): JsonResponse
{
    // ... some create code ...
    return EventResource::make($event)->additional([
        'title' => 'Event created',
        'message' => 'Event successful created',
    ]);
}
```