### PR TITLE
Fix ErrorHandlingUtils for Laravel 6

### DIFF
--- a/src/Tools/ErrorHandlingUtils.php
+++ b/src/Tools/ErrorHandlingUtils.php
@@ -33,7 +33,7 @@ class ErrorHandlingUtils
         $output = new ConsoleOutput(OutputInterface::VERBOSITY_VERBOSE);
         try {
             $handler = new \NunoMaduro\Collision\Handler(new \NunoMaduro\Collision\Writer(null, $output));
-        } catch (\Exception $e) {
+        } catch (\Throwable $error) {
             // Version 3 used a different API
             // todo remove when Laravel 7 is minimum supported
             $handler = new \NunoMaduro\Collision\Handler(new \NunoMaduro\Collision\Writer($output));


### PR DESCRIPTION
Type: Bug
Tested on: PHP 7.4, Laravel 6.18.1

Instance of Symfony\Component\Debug\Exception\FatalThrowableError cannot be caught as Exception, use Throwable instead. 