### PR TITLE
Fix validation rule accepted

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -443,9 +443,7 @@ trait ParsesValidationRules
                     break;
                 case 'accepted_if':
                     $parameterData['type'] = 'boolean';
-                    $parameterData['description'] .= ' ' . $this->getDescription(
-                            $rule, [':other' => "<code>{$arguments[0]}</code>", ':value' => w::getListOfValuesAsFriendlyHtmlString(array_slice($arguments, 1))]
-                        ) . ' ';
+                    $parameterData['description'] .= " Must be accepted when <code>$arguments[0]</code> is " . w::getListOfValuesAsFriendlyHtmlString(array_slice($arguments, 1));
                     $parameterData['setter'] = fn() => true;
                     break;
                 case 'same':

--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -188,6 +188,12 @@ trait ParsesValidationRules
                 case 'required':
                     $parameterData['required'] = true;
                     break;
+                case 'accepted':
+                    $parameterData['required'] = true;
+                    $parameterData['type'] = 'boolean';
+                    $parameterData['description'] .= ' Must be accepted.';
+                    $parameterData['setter'] = fn() => true;
+                    break;
 
                 /*
                  * Primitive types. No description should be added
@@ -434,6 +440,13 @@ trait ParsesValidationRules
                     $parameterData['description'] .= ' ' . $this->getDescription(
                             $rule, [':values' => w::getListOfValuesAsFriendlyHtmlString($arguments, "and")]
                         ) . ' ';
+                    break;
+                case 'accepted_if':
+                    $parameterData['type'] = 'boolean';
+                    $parameterData['description'] .= ' ' . $this->getDescription(
+                            $rule, [':other' => "<code>{$arguments[0]}</code>", ':value' => w::getListOfValuesAsFriendlyHtmlString(array_slice($arguments, 1))]
+                        ) . ' ';
+                    $parameterData['setter'] = fn() => true;
                     break;
                 case 'same':
                 case 'different':

--- a/tests/Unit/ValidationRuleParsingTest.php
+++ b/tests/Unit/ValidationRuleParsingTest.php
@@ -367,5 +367,21 @@ class ValidationRuleParsingTest extends BaseLaravelTest
             [],
             ['description' => "Must be a file. Must not be greater than 6 kilobytes."],
         ];
+        yield 'accepted' => [
+            ['accepted_param' => 'accepted'],
+            [],
+            [
+                'type' => 'boolean',
+                'description' => 'Must be accepted.',
+            ]
+        ];
+        yield 'accepted_if' => [
+            ['accepted_if_param' => 'accepted_if:another_field,a_value'],
+            [],
+            [
+                'type' => 'boolean',
+                'description' => "Must be accepted when <code>another_field</code> is <code>a_value</code>.",
+            ]
+        ];
     }
 }

--- a/tests/Unit/ValidationRuleParsingTest.php
+++ b/tests/Unit/ValidationRuleParsingTest.php
@@ -375,13 +375,15 @@ class ValidationRuleParsingTest extends BaseLaravelTest
                 'description' => 'Must be accepted.',
             ]
         ];
-        yield 'accepted_if' => [
-            ['accepted_if_param' => 'accepted_if:another_field,a_value'],
-            [],
-            [
-                'type' => 'boolean',
-                'description' => "Must be accepted when <code>another_field</code> is <code>a_value</code>.",
-            ]
-        ];
+        if (version_compare(Application::VERSION, '8.53', '>=')) {
+            yield 'accepted_if' => [
+                ['accepted_if_param' => 'accepted_if:another_field,a_value'],
+                [],
+                [
+                    'type' => 'boolean',
+                    'description' => "Must be accepted when <code>another_field</code> is <code>a_value</code>.",
+                ]
+            ];
+        }
     }
 }


### PR DESCRIPTION
When using `accepted` or `accepted_if` validation rules on a field, the generated body parameters documentation hints that the value is an optional string. This is not true, as you can see in the Laravel Validation documentation: [https://laravel.com/docs/9.x/validation#rule-accepted](https://laravel.com/docs/9.x/validation#rule-accepted)

This PR aims to change the type, description and requirement of fields with those rules.

Documentation and example request generated before the changes:
![image](https://user-images.githubusercontent.com/74194396/153875649-95c4768c-8a5f-4071-91d0-01c34346b721.png)
![image](https://user-images.githubusercontent.com/74194396/153876121-6fc509e1-343e-4329-bbd6-5492e9ecbb77.png)

Documentation and example request generated after the changes:
![image](https://user-images.githubusercontent.com/74194396/153875818-634d3991-5354-46f0-9b14-bd354dca8da5.png)
![image](https://user-images.githubusercontent.com/74194396/153876629-27daff89-0384-48cf-900b-6b1acc55a20f.png)
