### PR TITLE
fix(model factory chain): implode relation chains for bigger relations

### DIFF
--- a/src/Tools/Utils.php
+++ b/src/Tools/Utils.php
@@ -244,7 +244,7 @@ class Utils
 
                 $factoryChain = empty($relationChain)
                     ? call_user_func_array([$relationModel, 'factory'], [])
-                    : Utils::getModelFactory($relationModel, $states, $relationChain);
+                    : Utils::getModelFactory($relationModel, $states, [implode('.', $relationChain)]);
 
                 if ($relationType === BelongsToMany::class) {
                     $pivot = method_exists($factory, 'pivot' . $relationVector)


### PR DESCRIPTION
When using bigger (more than two relations) chains (like event.tag.tagGroup), exploding by dot will be broken: 
It will cast as `event.tag` and `event.tagGroup` not as `event.tag.tagGroup`.