### PR TITLE
Update grouped endpoint classes to be easier to extend

### DIFF
--- a/src/GroupedEndpoints/GroupedEndpointsFactory.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFactory.php
@@ -11,13 +11,26 @@ class GroupedEndpointsFactory
     public function make(GenerateDocumentation $command, RouteMatcherInterface $routeMatcher): GroupedEndpointsContract
     {
         if ($command->isForcing()) {
-            return new GroupedEndpointsFromApp($command, $routeMatcher, false);
+            return $this->makeGroupedEndpointsFromApp($command, $routeMatcher, false);
         }
 
         if ($command->shouldExtract()) {
-            return new GroupedEndpointsFromApp($command, $routeMatcher, true);
+            return $this->makeGroupedEndpointsFromApp($command, $routeMatcher, true);
         }
 
-        return new GroupedEndpointsFromCamelDir;
+        return $this->makeGroupedEndpointsFromCamelDir();
+    }
+
+    protected function makeGroupedEndpointsFromApp(
+        GenerateDocumentation $command,
+        RouteMatcherInterface $routeMatcher,
+        bool $preserveUserChanges
+    ): GroupedEndpointsFromApp {
+        return new GroupedEndpointsFromApp($command, $routeMatcher, $preserveUserChanges);
+    }
+
+    protected function makeGroupedEndpointsFromCamelDir(): GroupedEndpointsFromCamelDir
+    {
+        return new GroupedEndpointsFromCamelDir();
     }
 }

--- a/src/GroupedEndpoints/GroupedEndpointsFromApp.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFromApp.php
@@ -90,7 +90,8 @@ class GroupedEndpointsFromApp implements GroupedEndpointsContract
      */
     private function extractEndpointsInfoFromLaravelApp(array $matches, array $cachedEndpoints, array $latestEndpointsData, array $groups): array
     {
-        $generator = new Extractor($this->docConfig);
+        $generator = $this->makeExtractor();
+
         $parsedEndpoints = [];
 
         foreach ($matches as $routeItem) {
@@ -274,7 +275,23 @@ class GroupedEndpointsFromApp implements GroupedEndpointsContract
 
     protected function extractAndWriteApiDetailsToDisk(): void
     {
-        $apiDetails = new ApiDetails($this->docConfig, !$this->command->option('force'));
+        $apiDetails = $this->makeApiDetails();
+
         $apiDetails->writeMarkdownFiles();
+    }
+
+    protected function makeApiDetails(): ApiDetails
+    {
+        return new ApiDetails($this->docConfig, !$this->command->option('force'));
+    }
+
+    /**
+     * Make a new extractor.
+     *
+     * @return Extractor
+     */
+    protected function makeExtractor(): Extractor
+    {
+        return new Extractor($this->docConfig);
     }
 }


### PR DESCRIPTION
Firstly, I love this package makes generating documentation super simple.

In my application I have a custom built base class that generates the majority of my API endpoints, you just have to extend it and it handles most of the functionality. I've also made it so this base class handles generating the documentation rather than me doing it from the controllers. All of this is outside of the scope of scribe so I'd extended some of the base classes and made changes for my use case.

I had this working with v1 of scribe, but I've had to update to v3 as we're upgrading to PHP 8.1. I've got this working now with version 3 by extending some of the classes, however in scribe they're created by doing `new [class name]`. This pull request changes them to use methods to create the classes to make the package more extendable. Without this I'm having to copy and paste code out of the GroupedEndpointsFromApp class as a bunch of the methods are private.
