### PR TITLE
add assets prefix functionality

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -168,10 +168,10 @@ return [
         'docs_url' => '/docs',
 
         /*
-         * Prefix for public assets.
+         * Specify directory within `public` in which to store Laravel Scribe assets.
          * By default, assets are stored in `public/vendor/scribe`.
          */
-        'asset_prefix' => null,
+        'assets_directory' => null,
 
         /*
          * Middleware to attach to the docs endpoint (if `add_routes` is true).

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -168,6 +168,12 @@ return [
         'docs_url' => '/docs',
 
         /*
+         * Prefix for public assets.
+         * By default, assets are stored in `public/vendor/scribe`.
+         */
+        'asset_prefix' => null,
+
+        /*
          * Middleware to attach to the docs endpoint (if `add_routes` is true).
          */
         'middleware' => [],

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -42,8 +42,8 @@ class Writer
         $this->isStatic = $this->config->get('type') === 'static';
         $this->staticTypeOutputPath = rtrim($this->config->get('static.output_path', 'public/docs'), '/');
 
-        $this->laravelAssetsPath = $this->config->get('laravel.asset_prefix')
-            ? $this->config->get('laravel.asset_prefix') . '/vendor/scribe'
+        $this->laravelAssetsPath = $this->config->get('laravel.assets_directory')
+            ? '/' . $this->config->get('laravel.assets_directory')
             : '/vendor/scribe';
     }
 
@@ -160,7 +160,7 @@ class Writer
         // Transform output HTML to a Blade view
         rename("{$this->staticTypeOutputPath}/index.html", "$this->laravelTypeOutputPath/index.blade.php");
 
-        // Move assets from public/docs to public/vendor/scribe
+        // Move assets from public/docs to public/vendor/scribe or config('laravel.assets_directory')
         // We need to do this delete first, otherwise move won't work if folder exists
         Utils::deleteDirectoryAndContents($publicDirectory . $this->laravelAssetsPath);
         rename("{$this->staticTypeOutputPath}/", $publicDirectory . $this->laravelAssetsPath);
@@ -199,6 +199,7 @@ class Writer
             c::success("Wrote Blade docs to: $outputPath");
             $this->generatedFiles['blade'] = realpath("{$outputPath}index.blade.php");
             $assetsOutputPath = app()->get('path.public').$this->laravelAssetsPath;
+            c::success("Wrote Laravel assets to: " . realpath($assetsOutputPath));
         }
         $this->generatedFiles['assets']['js'] = realpath("{$assetsOutputPath}js");
         $this->generatedFiles['assets']['css'] = realpath("{$assetsOutputPath}css");


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

Hi! I needed this functionality for a project, and after some thought I concluded that the best way to implement it would be to actually add the functionality directly to Scribe.

This allows you to customize the location of the public assets generated for laravel blade documents. By default, the assets are created in `public/vendor/scribe`. With this feature, if the user defines a `laravel.asset_prefix` value, the path becomes `public/{{ asset_prefix }}/vendor/scribe`. 

I'm unclear how to best test this (my code currently passes all tests) so I'd be curious for ideas. Open to feedback.