### PR TITLE
Logo image is partly covered by scrollbar 

### DIFF
--- a/resources/views/themes/default/sidebar.blade.php
+++ b/resources/views/themes/default/sidebar.blade.php
@@ -6,7 +6,7 @@
 </a>
 <div class="tocify-wrapper">
     @if($metadata['logo'] != false)
-        <img src="{{ $metadata['logo'] }}" alt="logo" class="logo" style="padding-top: 10px;" width="230px"/>
+        <img src="{{ $metadata['logo'] }}" alt="logo" class="logo" style="padding-top: 10px;" width="100%"/>
     @endif
 
     @isset($metadata['example_languages'])


### PR DESCRIPTION
This PR fixes [#436](https://github.com/knuckleswtf/scribe/issues/436) Logo image is partly covered by scrollbar
