### PR TITLE
hide pre tag instead code tag on switching the language

### DIFF
--- a/resources/js/theme-default.js
+++ b/resources/js/theme-default.js
@@ -103,9 +103,9 @@ document.addEventListener('DOMContentLoaded', function() {
         const newStyle = languages.map((language) => {
             return language === newLanguage
                 // the current one should be visible
-                ? `body .content .${language}-example code { display: block; }`
+                ? `body .content .${language}-example pre { display: block; }`
                 // the inactive one should be hidden
-                : `body .content .${language}-example code { display: none; }`;
+                : `body .content .${language}-example pre { display: none; }`;
         }).join(`\n`);
 
         Array.from(langSelector).forEach((elem) => {


### PR DESCRIPTION
Because the style have padding top and bottom for `pre` tag, it will be better on switching the example code, we hide the `pre` tag instead `code` tag. 
With `code` tag, it create a big gap between `example request` title and the code

This is before fix
<img width="876" alt="image" src="https://user-images.githubusercontent.com/861110/174484830-47095179-a945-44e2-8420-48afb3f7a6b2.png">


This is after fix
<img width="856" alt="image" src="https://user-images.githubusercontent.com/861110/174484842-39f69924-6751-4d08-b709-c86e0f914f21.png">
