### PR TITLE
Fixed a bug in binding the URL parameters for API resource routes

### DIFF
--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -415,6 +415,19 @@ class GenerateDocumentationTest extends BaseLaravelTest
     }
 
     /** @test */
+    public function generates_correct_url_params_using_bound_models()
+    {
+        RouteFacade::get('users/{user}', [TestController::class, 'withInjectedModel']);
+        config(['scribe.routes.0.match.prefixes' => ['*']]);
+        config(['scribe.routes.0.apply.response_calls.methods' => []]);
+
+        $this->artisan('scribe:generate');
+
+        $group = Yaml::parseFile('.scribe/endpoints/00.yaml');
+        $this->assertEquals('users/{id}', $group['endpoints'][0]['uri']);
+    }
+
+    /** @test */
     public function will_generate_without_extracting_if_noExtraction_flag_is_set()
     {
         config(['scribe.routes.0.exclude' => ['*']]);

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -409,9 +409,9 @@ class GenerateDocumentationTest extends BaseLaravelTest
         $this->artisan('scribe:generate');
 
         $groupA = Yaml::parseFile('.scribe/endpoints/00.yaml');
-        $this->assertEquals('providers/{provider_slug}/users/{user_id}/addresses', $groupA['endpoints'][0]['uri']);
+        $this->assertEquals('providers/{provider_slug}/users/{user}/addresses', $groupA['endpoints'][0]['uri']);
         $groupB = Yaml::parseFile('.scribe/endpoints/01.yaml');
-        $this->assertEquals('providers/{provider_slug}/users/{user_id}/addresses/{uuid}', $groupB['endpoints'][0]['uri']);
+        $this->assertEquals('providers/{provider_slug}/users/{user}/addresses/{uuid}', $groupB['endpoints'][0]['uri']);
     }
 
     /** @test */

--- a/tests/Strategies/UrlParameters/GetFromLaravelAPITest.php
+++ b/tests/Strategies/UrlParameters/GetFromLaravelAPITest.php
@@ -145,10 +145,10 @@ class GetFromLaravelAPITest extends BaseLaravelTest
         $results = $strategy($endpoint, []);
 
         $this->assertArraySubset([
-            "name" => "user",
+            "name" => "id",
             "description" => "The ID of the user.",
             "required" => true,
             "type" => "integer",
-        ], $results['user']);
+        ], $results['id']);
     }
 }

--- a/tests/Unit/ExtractedEndpointDataTest.php
+++ b/tests/Unit/ExtractedEndpointDataTest.php
@@ -13,6 +13,12 @@ class ExtractedEndpointDataTest extends BaseLaravelTest
     /** @test */
     public function will_normalize_resource_url_params()
     {
+        if (version_compare($this->app->version(), '7.0.0', '<')) {
+            $this->markTestSkipped("Laravel < 7.x doesn't support field binding syntax.");
+
+            return;
+        }
+
         Route::apiResource('things', TestController::class)
             ->only('show')
             ->parameters([
@@ -58,6 +64,12 @@ class ExtractedEndpointDataTest extends BaseLaravelTest
     /** @test */
     public function will_normalize_resource_url_params_with_hyphens()
     {
+        if (version_compare($this->app->version(), '7.0.0', '<')) {
+            $this->markTestSkipped("Laravel < 7.x doesn't support field binding syntax.");
+
+            return;
+        }
+
         Route::apiResource('audio-things', TestController::class)
             ->only('show')
             ->parameters([

--- a/tests/Unit/ExtractedEndpointDataTest.php
+++ b/tests/Unit/ExtractedEndpointDataTest.php
@@ -14,7 +14,10 @@ class ExtractedEndpointDataTest extends BaseLaravelTest
     public function will_normalize_resource_url_params()
     {
         Route::apiResource('things', TestController::class)
-            ->only('show');
+            ->only('show')
+            ->parameters([
+                'things' => 'thing:id',
+            ]);
         $routeRules[0]['match'] = ['prefixes' => '*', 'domains' => '*'];
 
         $matcher = new RouteMatcher();
@@ -32,7 +35,11 @@ class ExtractedEndpointDataTest extends BaseLaravelTest
         }
 
         Route::apiResource('things.otherthings', TestController::class)
-            ->only( 'destroy');
+            ->only( 'destroy')
+            ->parameters([
+                'things' => 'thing:id',
+                'otherthings' => 'otherthing:id',
+            ]);
 
         $routeRules[0]['match'] = ['prefixes' => '*/otherthings/*', 'domains' => '*'];
         $matchedRoutes = $matcher->getRoutes($routeRules);
@@ -52,7 +59,10 @@ class ExtractedEndpointDataTest extends BaseLaravelTest
     public function will_normalize_resource_url_params_with_hyphens()
     {
         Route::apiResource('audio-things', TestController::class)
-            ->only('show');
+            ->only('show')
+            ->parameters([
+                'audio-things' => 'audio_thing:id',
+            ]);
         $routeRules[0]['match'] = ['prefixes' => '*', 'domains' => '*'];
 
         $matcher = new RouteMatcher();


### PR DESCRIPTION
This pull request fixes #275. The bug is that Scribe uses the `id` as the default URL parameter when no inline binding is applied, but the user might be using other column by overriding the `getRouteKeyName()` method in the model.

### Before:
`\Camel\Extraction\ExtractedEndpointData@normalizeResourceParamName` will apply the inline binding if it exists, otherwise it will use the `id` as the default URL parameter.

### After:
1. `Camel\Extraction\ExtractedEndpointData@normalizeResourceParamName` will apply the inline binding if it exists, otherwise it will not alter the URL parameter name, as it is not its responsibility to guess the proper name.
2. Then, as the `UrlParameters\GetFromLaravelAPI` strategy will iterate over the method arguments, it can use the type-hinted variables to call the `getRouteKeyName()` method in the desired model. Then, it will bind the URL parameter name and set the parameter description.

**Note**: The current logic if there are neither inline binding nor type-hinted variables is to use the id, but the new logic in that case is to not alter the URL parameters. I updated the tests to use the new logic.