### PR TITLE
Fixed a bug in normalizing URL parameters

### DIFF
--- a/camel/Extraction/ExtractedEndpointData.php
+++ b/camel/Extraction/ExtractedEndpointData.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Camel\Extraction;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Str;
 use Knuckles\Camel\BaseDTO;
@@ -81,11 +82,12 @@ class ExtractedEndpointData extends BaseDTO
 
     public function __construct(array $parameters = [])
     {
-        $parameters['uri'] = $this->normalizeResourceParamName($parameters['uri'], $parameters['route']);
         $parameters['metadata'] = $parameters['metadata'] ?? new Metadata([]);
         $parameters['responses'] = $parameters['responses'] ?? new ResponseCollection([]);
 
         parent::__construct($parameters);
+
+        $this->uri = $this->normalizeResourceParamName($this->uri, $this->route, $this->getTypeHintedArguments());
     }
 
     public static function fromRoute(Route $route, array $extras = []): self
@@ -131,7 +133,7 @@ class ExtractedEndpointData extends BaseDTO
         return $this->httpMethods[0] . str_replace(['/', '?', '{', '}', ':', '\\', '+', '|'], '-', $this->uri);
     }
 
-    public function normalizeResourceParamName(string $uri, Route $route): string
+    public function normalizeResourceParamName(string $uri, Route $route, array $typeHintedArguments): string
     {
         $params = [];
         preg_match_all('#\{(\w+?)}#', $uri, $params);
@@ -157,9 +159,11 @@ class ExtractedEndpointData extends BaseDTO
                     "{$pluralResource}/{{$singularResource}?}"
                 ];
 
-                // We'll replace with {id} by default, but if the user is using a different key,
-                // like /users/{user:uuid}, use that instead
-                $binding = static::getFieldBindingForUrlParam($route, $singularResource, 'id');
+                // If there is an inline binding in the route, like /users/{user:uuid}, use that key,
+                // Else, search for a type-hinted variable in the action, whose name matches the route segment name,
+                // If there is such variable (like User $user), call getRouteKeyName() on the model,
+                // Otherwise, use the id
+                $binding = static::getFieldBindingForUrlParam($route, $singularResource, $typeHintedArguments, 'id');
 
                 if (!$foundResourceParam) {
                     // Only the last resource param should be {id}
@@ -179,8 +183,8 @@ class ExtractedEndpointData extends BaseDTO
         }
 
         foreach ($params[1] as $param) {
-            // For non-resource parameters, if there's a field binding, replace that too:
-            if ($binding = static::getFieldBindingForUrlParam($route, $param)) {
+            // For non-resource parameters, if there's a field binding/type-hinted variable, replace that too:
+            if ($binding = static::getFieldBindingForUrlParam($route, $param, $typeHintedArguments)) {
                 $search = ["{{$param}}", "{{$param}?}"];
                 $replace = ["{{$param}_{$binding}}", "{{$param}_{$binding}?}"];
                 $uri = str_replace($search, $replace, $uri);
@@ -206,7 +210,8 @@ class ExtractedEndpointData extends BaseDTO
         return $copy;
     }
 
-    public static function getFieldBindingForUrlParam(Route $route, string $paramName, string $default = null): ?string
+    public static function getFieldBindingForUrlParam(Route $route, string $paramName, array $typeHintedArguments = [],
+                                                      string $default = null): ?string
     {
         $binding = null;
         // Was added in Laravel 7.x
@@ -214,6 +219,48 @@ class ExtractedEndpointData extends BaseDTO
             $binding = $route->bindingFieldFor($paramName);
         }
 
+        // Search for a type-hinted variable whose name matches the route segment name
+        if (is_null($binding) && array_key_exists($paramName, $typeHintedArguments)) {
+            $argumentType = $typeHintedArguments[$paramName]->getType();
+            $argumentClassName = $argumentType->getName();
+            $argumentInstance = new $argumentClassName;
+            $binding = $argumentInstance->getRouteKeyName();
+        }
+
         return $binding ?: $default;
+    }
+
+    /**
+     * Return the type-hinted method arguments in the action that have a Model type,
+     * The arguments will be returned as an array of the form: $arguments[<variable_name>] = $argument
+     */
+    protected function getTypeHintedArguments(): array
+    {
+        $arguments = [];
+        if ($this->method) {
+            foreach ($this->method->getParameters() as $argument) {
+                if ($this->argumentHasModelType($argument)) {
+                    $arguments[$argument->getName()] = $argument;
+                }
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Determine whether the argument has a Model type
+     */
+    protected function argumentHasModelType(\ReflectionParameter $argument): bool
+    {
+        $argumentType = $argument->getType();
+        if (!$argumentType) {
+            // The argument does not have a type-hint
+            return false;
+        } else {
+            $argumentClassName = $argumentType->getName();
+            $argumentInstance = new $argumentClassName;
+            return ($argumentInstance instanceof Model);
+        }
     }
 }

--- a/tests/Fixtures/TestPost.php
+++ b/tests/Fixtures/TestPost.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestPost extends Model
+{
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
+}

--- a/tests/Fixtures/TestPostController.php
+++ b/tests/Fixtures/TestPostController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+class TestPostController
+{
+    public function update(TestPost $post)
+    {
+    }
+}

--- a/tests/Fixtures/TestPostUserController.php
+++ b/tests/Fixtures/TestPostUserController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+class TestPostUserController
+{
+    public function update(TestPost $post, TestUser $user)
+    {
+    }
+}


### PR DESCRIPTION
This pull request fixes #275. The bug is that Scribe uses the `id` as the default URL parameter when no inline binding is applied, but the user might be using another column by overriding the `getRouteKeyName()` method in the model.

## Behavior
#### Old behavior with API resource routes
1. If there is an inline binding in the route, use it.
2. Else, if it is a resource route parameter, use the `id`.
3. Otherwise, keep the same parameter name.
#### New behavior for API resource routes
1. If there is an inline binding in the route, use it.
2. Else, If there is a type-hinted variable in the controller action, with the same name as the route segment name, use it to call `getRouteKeyName()`.
3. Else, if it is a resource route parameter, use the `id`.
4. Otherwise, keep the same parameter name.

Examples of the differences can be found in a [previous discussion](https://github.com/knuckleswtf/scribe/pull/489#discussion_r914571572).

## Code
#### Before
`Camel\Extraction\ExtractedEndpointData@normalizeResourceParamName` is called in the constructor before calling the parent constructor and initializing the object, so you cannot access the `method` property in the normalization process, as it has not been initialized yet.
#### After
`Camel\Extraction\ExtractedEndpointData@normalizeResourceParamName` is called after calling the parent constructor.
If there was no inline binding in the route, `Camel\Extraction\ExtractedEndpointData@getFieldBindingForUrlParam` will search for a type-hinted variable whose name matches the route segment name, and will use it to call `getRouteKeyName()` on the model.

## Testing
Created two feature tests in `Knuckles\Scribe\Tests\GenerateDocumentationTest` to test generating URL params from resource and non-resource routes with model binding. Created some fixtures to achieve that: A `TestPost` model that overrides `getRouteKeyName()` to return `slug`, A partial resource controller with an injected `TestPost` argument, and another partial resource controller for a nested resource `(posts.users)` with injected `TestPost` and `TestUser` models.

## Possible Refactor
Maybe we can create a new class `Src\Extracting\UrlParamsNormalizer` and move the normalization logic into it. We can use that class inside the constructor of `Camel\Extraction\ExtractedEndpointData`.