### PR TITLE
fix: 🐛 empty query parameter sent even if input is empty

### DIFF
--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -219,6 +219,11 @@ async function executeTryOut(endpointId, form) {
     const queryParameters = form.querySelectorAll('input[data-component=query]');
     queryParameters.forEach(el => {
         if (el.type !== 'radio' || (el.type === 'radio' && el.checked)) {
+            if (el.value === '' && el.required === false) {
+                // Don't include empty optional values in the request
+                return;
+            }
+
             _.set(query, el.name, el.value);
         }
     });


### PR DESCRIPTION
## Description

This PR fixes #490 

## Related Issue

- #490 

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I couldn't find E2E test of the JS client on the generated documentation so I tested the option parameter on the generated documentation with an empty value to make sure no query parameter was appended to the actual request being sent.

If you want E2E testing with Jest or others, including JS clients, please let me know. I don't know if it should be included in this PR or not.


## Screenshots

If I put value on optional parameter, then query parameter appended.

![image](https://user-images.githubusercontent.com/1641039/177692749-ecb445c4-e05d-4593-9df6-75e4014ed20c.png)

![image](https://user-images.githubusercontent.com/1641039/177692774-637f9a7c-1b8a-4304-9e7f-98123dca5e7f.png)

If I put empty value, then query parameter will be not appended.

![image](https://user-images.githubusercontent.com/1641039/177691185-3b1d6745-e4d6-41bb-ad97-734667917733.png)

![image](https://user-images.githubusercontent.com/1641039/177691260-d091ea80-8641-40d9-8574-b1b632b6bbc9.png)
