### PR TITLE
Fix documentation generation when using binded interfaces instead of model classes as typed arguments

### DIFF
--- a/camel/Extraction/ExtractedEndpointData.php
+++ b/camel/Extraction/ExtractedEndpointData.php
@@ -267,7 +267,7 @@ class ExtractedEndpointData extends BaseDTO
     protected function argumentHasModelType(\ReflectionParameter $argument): bool
     {
         $argumentType = $argument->getType();
-        if (!$argumentType) {
+        if (!$argumentType instanceof \ReflectionNamedType) {
             // The argument does not have a type-hint
             return false;
         } else {

--- a/camel/Extraction/ExtractedEndpointData.php
+++ b/camel/Extraction/ExtractedEndpointData.php
@@ -267,7 +267,7 @@ class ExtractedEndpointData extends BaseDTO
     protected function argumentHasModelType(\ReflectionParameter $argument): bool
     {
         $argumentType = $argument->getType();
-        if (!$argumentType instanceof \ReflectionNamedType) {
+        if (!($argumentType instanceof \ReflectionNamedType)) {
             // The argument does not have a type-hint
             return false;
         } else {

--- a/tests/Fixtures/TestPostBindedInterface.php
+++ b/tests/Fixtures/TestPostBindedInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+interface TestPostBindedInterface
+{
+}

--- a/tests/Fixtures/TestPostBindedInterfaceController.php
+++ b/tests/Fixtures/TestPostBindedInterfaceController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+class TestPostBindedInterfaceController
+{
+    public function update(TestPostBindedInterface $post)
+    {
+    }
+}

--- a/tests/GenerateDocumentationTest.php
+++ b/tests/GenerateDocumentationTest.php
@@ -9,7 +9,9 @@ use Knuckles\Scribe\Tests\Fixtures\TestGroupController;
 use Knuckles\Scribe\Tests\Fixtures\TestIgnoreThisController;
 use Knuckles\Scribe\Tests\Fixtures\TestPartialResourceController;
 use Knuckles\Scribe\Tests\Fixtures\TestPost;
+use Knuckles\Scribe\Tests\Fixtures\TestPostBindedInterface;
 use Knuckles\Scribe\Tests\Fixtures\TestPostController;
+use Knuckles\Scribe\Tests\Fixtures\TestPostBindedInterfaceController;
 use Knuckles\Scribe\Tests\Fixtures\TestPostUserController;
 use Knuckles\Scribe\Tests\Fixtures\TestResourceController;
 use Knuckles\Scribe\Tests\Fixtures\TestUser;
@@ -431,6 +433,24 @@ class GenerateDocumentationTest extends BaseLaravelTest
         $group = Yaml::parseFile('.scribe/endpoints/00.yaml');
         $this->assertEquals('posts/{slug}', $group['endpoints'][0]['uri']);
         $this->assertEquals('posts/{post_slug}/users/{id}', $group['endpoints'][1]['uri']);
+    }
+
+    /** @test */
+    public function generates_correct_url_params_from_resource_routes_and_model_binding_with_binded_interfaces()
+    {
+        $this->app->bind(TestPostBindedInterface::class, function(){
+            return new TestPost();
+        });
+
+        RouteFacade::resource('posts', TestPostBindedInterfaceController::class)->only('update');
+
+        config(['scribe.routes.0.match.prefixes' => ['*']]);
+        config(['scribe.routes.0.apply.response_calls.methods' => []]);
+
+        $this->artisan('scribe:generate');
+
+        $group = Yaml::parseFile('.scribe/endpoints/00.yaml');
+        $this->assertEquals('posts/{slug}', $group['endpoints'][0]['uri']);
     }
 
     /** @test */


### PR DESCRIPTION
Hi,

The version `3.33.1` introduces a breaking change when you are using a type hinted argument that is an interface binded to a model via the service container.

Since an interface is not instantiable, you get this error when generating the documention:

```
 Error 

  Cannot instantiate interface App\Interfaces\YourModelInterface.php

  at vendor/knuckleswtf/scribe/camel/Extraction/ExtractedEndpointData.php:262
    258▕             // The argument does not have a type-hint
    259▕             return false;
    260▕         } else {
    261▕             $argumentClassName = $argumentType->getName();
  ➜ 262▕             $argumentInstance = new $argumentClassName;
    263▕             return ($argumentInstance instanceof Model);
    264▕         }
    265▕     }
    266▕ }

      +21 vendor frames 
  22  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
```

To resolve this issue, we need to use the service container to resolve the instance instead of just `new`.

However, there is a caveat, because when you resolve a form request class using the service container, it also execute the `authorize` method of the `ValidatesWhenResolvedTrait` trait.

That was the first error I found but alongs the way of fixing it, I found that type hinted arguments with builtin types (e.g. `string`) also returns a similar error:

```
 Error 

  Class "string" not found

  at vendor/knuckleswtf/scribe/camel/Extraction/ExtractedEndpointData.php:262
    258▕             // The argument does not have a type-hint
    259▕             return false;
    260▕         } else {
    261▕             $argumentClassName = $argumentType->getName();
  ➜ 262▕             $argumentInstance = new $argumentClassName;
    263▕             return ($argumentInstance instanceof Model);
    264▕         }
    265▕     }
    266▕ }

      +21 vendor frames 
  22  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
```

--------------

This PR fixes these problems by using the `app()` helper to resolve any interfaces that can be used as controller method arguments, `new` for classes (to avoid any side effects of `ValidatesWhenResolvedTrait`).

Althrough this PR also fixes the error for builtin types, it was not its first goal. For now, theses arguments are treated as "not type hinted".

Of course, any improvements are welcome :)

Have a nice day.