### PR TITLE
Fixed two bugs in inferring the URL parameter type

### DIFF
--- a/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
+++ b/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
@@ -101,11 +101,14 @@ class GetFromLaravelAPI extends Strategy
             $urlThing = $this->getNameOfUrlThing($endpointData->uri, $name);
             if ($urlThing) {
                 $rootNamespace = app()->getNamespace();
-                if (class_exists($class = "{$rootNamespace}Models\\" . Str::title($urlThing))
+                $className = $this->urlThingToClassName($urlThing);
+                if (class_exists($class = "{$rootNamespace}Models\\" . $className)
                     // For the heathens that don't use a Models\ directory
-                    || class_exists($class = $rootNamespace . Str::title($urlThing))) {
+                    || class_exists($class = $rootNamespace . $className)) {
                     $argumentInstance = new $class;
-                    $type = $this->normalizeTypeName($argumentInstance->getKeyType());
+                    if ($argumentInstance->getKeyName() === $argumentInstance->getRouteKeyName()) {
+                        $type = $this->normalizeTypeName($argumentInstance->getKeyType());
+                    }
                 }
             }
 
@@ -157,5 +160,12 @@ class GetFromLaravelAPI extends Strategy
         } catch (\Throwable $e) {
             return null;
         }
+    }
+
+    protected function urlThingToClassName(string $urlThing): string
+    {
+        $className = Str::title($urlThing);
+        $className = str_replace(['-', '_'], '', $className);
+        return $className;
     }
 }


### PR DESCRIPTION
## How to reproduce
#### First bug: Using the primary key as a type when there is neither inline-binding nor model binding
Assuming that `Company` model exists with overridden `getRouteKeyName()` to return `slug`.
```
Route::get('company/{handle}', function($handle) {});
```
The inferred type for `handle` is `integer` instead of `string`.

#### Second bug: Failing to guess the class name when the model name consists of multiple words
Assuming that `AdminUser` model exists
```
Route::get('admin_users/{id}', function($id) {});
```
The inferred type for `id` is `string` instead of `integer`.

## How to fix the two bugs
#### The current logic is as follows
1. For type-hinted arguments that have a Model type, if `getRouteKeyName()` is the same as the primary key name (`getKeyName()`), use the type of the primary key (`getKeyType()`).
2. For parameters that do not satisfy the previous condition, try to guess their class, and then use `getKeyType()` immediately.

#### First bug
In step 2, after we guessed the class, we are immediately using `getKeyType()` which will return the primary key type. But the user might have overridden `getRouteKeyName()` so he may not be using the primary key.
To fix it, we should first check that `getRouteKeyName()` is the primary key before we call `getKeyType()` (as we did in step 1).

#### Second bug
In step 2, `GetFromLaravelAPI` strategy fails to guess the class name when it consists of multiple words. I fixed that by creating a new method in it.

## Testing
The default models' namespace in a laravel app (`app()->getNamespace()`) is different from the fixtures' namespace in the package, and `GetFromLaravelAPI` guesses the classpath by concatenating the default models' namespace with the class name. Because of that, I did not manage to write a test case since `GetFromLaravelAPI` will always fail to guess the class.