### PR TITLE
Catch throwables when instantiating interface

### DIFF
--- a/src/Extracting/UrlParamsNormalizer.php
+++ b/src/Extracting/UrlParamsNormalizer.php
@@ -201,7 +201,11 @@ class UrlParamsNormalizer
         }
 
         if (interface_exists($argumentClassName)) {
-            return app($argumentClassName);
+            try {
+                return app($argumentClassName);
+            } catch (\Throwable $e) {
+                return null;
+            }
         }
 
         return null;


### PR DESCRIPTION
When documenting a laravel-json-api/laravel api I was getting a `Illuminate\Contracts\Container\BindingResolutionException` and the docs were failing to build. This PR catches those exceptions.

To give specifics: one of the arguments in the controller method is `LaravelJsonApi\Contracts\Routing\Route` (an interface). In the context of `knuckleswtf/scribe` that interface is not instantiating because `app()` doesn't have a binding to the interface.

<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

