### PR TITLE
Adding support of global bearer token variable.

### DIFF
--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -77,6 +77,13 @@ class PostmanCollectionWriter
             ],
             "bearer" => [
                 'type' => 'bearer',
+                'bearer' => [
+                    [
+                        'key'   => $this->config->get('auth.name'),
+                        'value' => $this->config->get('auth.use_value'),
+                        'type'  => 'string',
+                    ],
+                ],
             ],
             default => [
                 'type' => 'apikey',

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -340,6 +340,13 @@
     }
   ],
   "auth": {
-    "type": "bearer"
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "key",
+        "value": null,
+        "type": "string"
+      }
+    ]
   }
 }

--- a/tests/Unit/PostmanCollectionWriterTest.php
+++ b/tests/Unit/PostmanCollectionWriterTest.php
@@ -224,7 +224,18 @@ class PostmanCollectionWriterTest extends TestCase
         $config['auth']['in'] = 'bearer';
         $collection = $this->generate($config, [$endpoints]);
 
-        $this->assertEquals(['type' => 'bearer'], $collection['auth']);
+        $expected = [
+            'type'   => 'bearer',
+            'bearer' => [
+                [
+                    'key'   => null,
+                    'value' => null,
+                    'type'  => 'string',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $collection['auth']);
         $this->assertArrayNotHasKey('auth', $collection['item'][0]['item'][0]['request']);
         $this->assertEquals(['type' => 'noauth'], $collection['item'][0]['item'][1]['request']['auth']);
 


### PR DESCRIPTION
This update brings global bearer token setter in the postman file. If you set `use_value` as `{{token}}` in the scribe config file it'll automatically populate it when postman file is generated.

In you postman variables you can set that token automatically when sending login request using Postman's `Tests`. You can set this JS code in Tests tab and JWT token will be automatically populated and used globally by the API.
```javascript
var jsonData = JSON.parse(responseBody);
pm.environment.set("token", jsonData.login.access_token);
```

<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

