### PR TITLE
Check and generate ->data on generateResponseContentSpec()

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -378,6 +378,14 @@ class OpenAPISpecWriter
                 ];
 
             case 'object':
+                if (property_exists($decoded, 'data')) {
+                    $decoded = $decoded->data;
+                }
+
+                if (is_array($decoded)) {
+                    $decoded = Arr::first($decoded);
+                }
+
                 $properties = collect($decoded)->mapWithKeys(function ($value, $key) use ($endpoint) {
                     $spec = [
                         // Note that we aren't recursing for nested objects. We stop at one level.


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

Hi scribe,

I found some issue about generate OpenAPI format.

when I use `ResponseFromFile` and write `ResponseField` on my controller 

ResponseFromFile file:
```json
{
    "data": [
        {
            "name": "Maras",
            "id": 1,
        }
    ],
   "status": 200
}
```

ResponseField:
```
#[ResponseField('name', 'string', 'User Name')]
#[ResponseField('id', 'integer', 'User unique number')]
```

and i write columns via ResponseField that will return:
```yaml
                properties:
                  data:
                    type: array
                    example:
                      -
                        name: Maras
                        id: 1
```


but i read [official document](https://scribe.knuckles.wtf/laravel/documenting/responses#response-fields), the document says
```
You don't need to specify the full field path if the field is inside an array of objects or wrapped in pagination data. For instance, the above annotation will work fine for all of these responses:
```

so i think properties should return:
```yaml
 properties:
                  name:
                    type: string
                    example: Maras
                    description: 'User Name'
                  id:
                    type: integer
                    example: 1
                    description: 'User unique number'
```

