### PR TITLE
Show boolean examples properly

### DIFF
--- a/resources/views/components/field-details.blade.php
+++ b/resources/views/components/field-details.blade.php
@@ -58,9 +58,12 @@
 @endif
 <br>
 @php
-if($example !== null && $example !== '' && !is_array($example)) {
-    $exampleAsString = $example === false ? "false" : $example;
-    $description .= " Example: `$example`";
+    if($example !== null && $example !== '' && !is_array($example)) {
+        $exampleAsString = $example;
+        if (is_bool($example)) {
+            $exampleAsString = $example ? "true" : "false";
+        }
+        $description .= " Example: `$exampleAsString`";
     }
 @endphp
 {!! Parsedown::instance()->text(trim($description)) !!}


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

I noticed that my boolean fields were documented with "Example: ``". So I investigated and found that it attempts to document `false`, but not `true`. And it didn't actually use the right variable.