### PR TITLE
Feature: Add bootstrap hook

### DIFF
--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -86,16 +86,11 @@ class GenerateDocumentation extends Command
         return $this->docConfig;
     }
 
-    public function setDocConfig(DocumentationConfig $config)
+    protected function runBootstrapHook()
     {
-        $this->docConfig = $config;
-    }
-
-    protected function runBeforeGenerateCommandStartsHook()
-    {
-        if (is_callable(Globals::$__beforeGenerateCommandStarts)) {
+        if (is_callable(Globals::$__bootstrap)) {
             c::info("Running `beforeGenerating()` hook...");
-            call_user_func_array(Globals::$__beforeGenerateCommandStarts, [$this]);
+            call_user_func_array(Globals::$__bootstrap, [$this]);
         }
     }
 
@@ -124,7 +119,7 @@ class GenerateDocumentation extends Command
             throw new \InvalidArgumentException("Can't use --force and --no-extraction together.");
         }
 
-        $this->runBeforeGenerateCommandStartsHook();
+        $this->runBootstrapHook();
     }
 
     protected function mergeUserDefinedEndpoints(array $groupedEndpoints, array $userDefinedEndpoints): array

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -89,7 +89,6 @@ class GenerateDocumentation extends Command
     protected function runBootstrapHook()
     {
         if (is_callable(Globals::$__bootstrap)) {
-            c::info("Running `bootstrap()` hook...");
             call_user_func_array(Globals::$__bootstrap, [$this]);
         }
     }

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -40,6 +40,8 @@ class GenerateDocumentation extends Command
 
     public function handle(RouteMatcherInterface $routeMatcher, GroupedEndpointsFactory $groupedEndpointsFactory): void
     {
+        $this->runBeforeGeneratingHook();
+
         $this->bootstrap();
 
         if (!empty($this->docConfig->get("default_group"))) {
@@ -84,6 +86,14 @@ class GenerateDocumentation extends Command
     public function getDocConfig(): DocumentationConfig
     {
         return $this->docConfig;
+    }
+
+    protected function runBeforeGeneratingHook()
+    {
+        if (is_callable(Globals::$__beforeGenerating)) {
+            c::info("Running `beforeGenerating()` hook...");
+            call_user_func_array(Globals::$__beforeGenerating, []);
+        }
     }
 
     public function bootstrap(): void

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -89,7 +89,7 @@ class GenerateDocumentation extends Command
     protected function runBootstrapHook()
     {
         if (is_callable(Globals::$__bootstrap)) {
-            c::info("Running `beforeGenerating()` hook...");
+            c::info("Running `bootstrap()` hook...");
             call_user_func_array(Globals::$__bootstrap, [$this]);
         }
     }

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -40,8 +40,6 @@ class GenerateDocumentation extends Command
 
     public function handle(RouteMatcherInterface $routeMatcher, GroupedEndpointsFactory $groupedEndpointsFactory): void
     {
-        $this->runBeforeGeneratingHook();
-
         $this->bootstrap();
 
         if (!empty($this->docConfig->get("default_group"))) {
@@ -88,11 +86,16 @@ class GenerateDocumentation extends Command
         return $this->docConfig;
     }
 
-    protected function runBeforeGeneratingHook()
+    public function setDocConfig(DocumentationConfig $config)
     {
-        if (is_callable(Globals::$__beforeGenerating)) {
+        $this->docConfig = $config;
+    }
+
+    protected function runBeforeGenerateCommandStartsHook()
+    {
+        if (is_callable(Globals::$__beforeGenerateCommandStarts)) {
             c::info("Running `beforeGenerating()` hook...");
-            call_user_func_array(Globals::$__beforeGenerating, []);
+            call_user_func_array(Globals::$__beforeGenerateCommandStarts, [$this]);
         }
     }
 
@@ -120,6 +123,8 @@ class GenerateDocumentation extends Command
         if ($this->forcing && !$this->shouldExtract) {
             throw new \InvalidArgumentException("Can't use --force and --no-extraction together.");
         }
+
+        $this->runBeforeGenerateCommandStartsHook();
     }
 
     protected function mergeUserDefinedEndpoints(array $groupedEndpoints, array $userDefinedEndpoints): array

--- a/src/Scribe.php
+++ b/src/Scribe.php
@@ -3,6 +3,7 @@
 namespace Knuckles\Scribe;
 
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
+use Knuckles\Scribe\Commands\GenerateDocumentation;
 use Knuckles\Scribe\Tools\Globals;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -24,11 +25,11 @@ class Scribe
     /**
      * Specify a callback that will be executed just before the generate command is executed
      *
-     * @param callable(): mixed $callable
+     * @param callable(GenerateDocumentation): mixed $callable
      */
-    public static function beforeGenerating(callable $callable)
+    public static function beforeGenerateCommandStarts(callable $callable)
     {
-        Globals::$__beforeGenerating = $callable;
+        Globals::$__beforeGenerateCommandStarts = $callable;
     }
 
     /**

--- a/src/Scribe.php
+++ b/src/Scribe.php
@@ -27,9 +27,9 @@ class Scribe
      *
      * @param callable(GenerateDocumentation): mixed $callable
      */
-    public static function beforeGenerateCommandStarts(callable $callable)
+    public static function bootstrap(callable $callable)
     {
-        Globals::$__beforeGenerateCommandStarts = $callable;
+        Globals::$__bootstrap = $callable;
     }
 
     /**

--- a/src/Scribe.php
+++ b/src/Scribe.php
@@ -22,6 +22,16 @@ class Scribe
     }
 
     /**
+     * Specify a callback that will be executed just before the generate command is executed
+     *
+     * @param callable(): mixed $callable
+     */
+    public static function beforeGenerating(callable $callable)
+    {
+        Globals::$__beforeGenerating = $callable;
+    }
+
+    /**
      * Specify a callback that will be executed when Scribe is done generating your docs.
      * This callback will receive a map of all the output paths generated, that looks like this:
      * [

--- a/src/Tools/Globals.php
+++ b/src/Tools/Globals.php
@@ -12,6 +12,8 @@ class Globals
 
     public static $__beforeResponseCall;
 
+    public static $__beforeGenerating;
+
     public static $__afterGenerating;
 
     public static $__instantiateFormRequestUsing;

--- a/src/Tools/Globals.php
+++ b/src/Tools/Globals.php
@@ -12,7 +12,7 @@ class Globals
 
     public static $__beforeResponseCall;
 
-    public static $__beforeGenerateCommandStarts;
+    public static $__bootstrap;
 
     public static $__afterGenerating;
 

--- a/src/Tools/Globals.php
+++ b/src/Tools/Globals.php
@@ -12,7 +12,7 @@ class Globals
 
     public static $__beforeResponseCall;
 
-    public static $__beforeGenerating;
+    public static $__beforeGenerateCommandStarts;
 
     public static $__afterGenerating;
 

--- a/tests/GenerateDocumentation/BehavioursTest.php
+++ b/tests/GenerateDocumentation/BehavioursTest.php
@@ -126,6 +126,24 @@ class BehavioursTest extends BaseLaravelTest
     }
 
     /** @test */
+    public function calls_beforeGenerating_hook()
+    {
+        $called = false;
+
+        Scribe::beforeGenerating(function () use (&$called){
+            $called = true;
+        });
+
+        RouteFacade::get('/api/test', [TestController::class, 'withEndpointDescription']);
+
+        $this->generate();
+
+        $this->assertTrue($called);
+
+        Scribe::beforeGenerating(fn() => null);
+    }
+
+    /** @test */
     public function skips_methods_and_classes_with_hidefromapidocumentation_tag()
     {
         RouteFacade::get('/api/skip', [TestController::class, 'skip']);

--- a/tests/GenerateDocumentation/BehavioursTest.php
+++ b/tests/GenerateDocumentation/BehavioursTest.php
@@ -127,11 +127,11 @@ class BehavioursTest extends BaseLaravelTest
     }
 
     /** @test */
-    public function calls_beforeGenerating_hook()
+    public function calls_bootstrap_hook()
     {
         $commandInstance = null;
 
-        Scribe::beforeGenerateCommandStarts(function (GenerateDocumentation $command) use (&$commandInstance){
+        Scribe::bootstrap(function (GenerateDocumentation $command) use (&$commandInstance){
             $commandInstance = $command;
         });
 
@@ -141,7 +141,7 @@ class BehavioursTest extends BaseLaravelTest
 
         $this->assertTrue($commandInstance instanceof GenerateDocumentation);
 
-        Scribe::beforeGenerateCommandStarts(fn() => null);
+        Scribe::bootstrap(fn() => null);
     }
 
     /** @test */

--- a/tests/GenerateDocumentation/BehavioursTest.php
+++ b/tests/GenerateDocumentation/BehavioursTest.php
@@ -3,6 +3,7 @@
 namespace Knuckles\Scribe\Tests\GenerateDocumentation;
 
 use Illuminate\Support\Facades\Route as RouteFacade;
+use Knuckles\Scribe\Commands\GenerateDocumentation;
 use Knuckles\Scribe\Scribe;
 use Knuckles\Scribe\Tests\BaseLaravelTest;
 use Knuckles\Scribe\Tests\Fixtures\TestController;
@@ -128,19 +129,19 @@ class BehavioursTest extends BaseLaravelTest
     /** @test */
     public function calls_beforeGenerating_hook()
     {
-        $called = false;
+        $commandInstance = null;
 
-        Scribe::beforeGenerating(function () use (&$called){
-            $called = true;
+        Scribe::beforeGenerateCommandStarts(function (GenerateDocumentation $command) use (&$commandInstance){
+            $commandInstance = $command;
         });
 
         RouteFacade::get('/api/test', [TestController::class, 'withEndpointDescription']);
 
         $this->generate();
 
-        $this->assertTrue($called);
+        $this->assertTrue($commandInstance instanceof GenerateDocumentation);
 
-        Scribe::beforeGenerating(fn() => null);
+        Scribe::beforeGenerateCommandStarts(fn() => null);
     }
 
     /** @test */


### PR DESCRIPTION
I think it'll be useful to have a `beforeGenerating` callback/hook. 
It can be used to replace a service container binding or fake certain events for example. 

I think it's a better option instead of listening to the default Laravel `CommandStarting` event and checking on the command type. Especially since the package already provides an `afterGenerating` callback.

