### PR TITLE
Remove redundant imports

### DIFF
--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -7,8 +7,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Knuckles\Camel\Camel;
-use Knuckles\Camel\Output\OutputEndpointData;
-use Knuckles\Scribe\Exceptions\GroupNotFound;
 use Knuckles\Scribe\GroupedEndpoints\GroupedEndpointsFactory;
 use Knuckles\Scribe\Matching\RouteMatcherInterface;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;

--- a/src/Extracting/Strategies/ResponseFields/GetFromResponseFieldAttribute.php
+++ b/src/Extracting/Strategies/ResponseFields/GetFromResponseFieldAttribute.php
@@ -38,6 +38,7 @@ class GetFromResponseFieldAttribute extends PhpAttributeStrategy
 
         return collect([...$attributesOnController, ...$attributesOnMethod, ...$attributesOnApiResourceMethods])
             ->mapWithKeys(function ($attributeInstance) use ($endpointData) {
+                /** @var ResponseField $attributeInstance */
                 $data = $attributeInstance->toArray();
 
                 $data['type'] = ResponseFieldTools::inferTypeOfResponseField($data, $endpointData);

--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Str;
 use Knuckles\Camel\Camel;
 use Knuckles\Camel\Extraction\Response;
 use Knuckles\Camel\Output\OutputEndpointData;
-use Knuckles\Camel\Output\Group;
 use Knuckles\Camel\Output\Parameter;
 use Knuckles\Scribe\Extracting\ParamHelpers;
 use Knuckles\Scribe\Tools\DocumentationConfig;


### PR DESCRIPTION
This PR removes two redundant imports from `src/Commands/GenerateDocumentation.php` that were not used and one import of a non-existing class in `src/Writing/OpenAPISpecWriter.php`