### PR TITLE
Openapi nested objects properties

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -379,22 +379,7 @@ class OpenAPISpecWriter
 
             case 'object':
                 $properties = collect($decoded)->mapWithKeys(function ($value, $key) use ($endpoint) {
-                    $spec = [
-                        // Note that we aren't recursing for nested objects. We stop at one level.
-                        'type' => $this->convertScribeOrPHPTypeToOpenAPIType(gettype($value)),
-                        'example' => $value,
-
-                    ];
-                    if (isset($endpoint->responseFields[$key]->description)) {
-                        $spec['description'] = $endpoint->responseFields[$key]->description;
-                    }
-                    if ($spec['type'] === 'array' && !empty($value)) {
-                        $spec['items']['type'] = $this->convertScribeOrPHPTypeToOpenAPIType(gettype($value[0]));
-                    }
-
-                    return [
-                        $key => $spec,
-                    ];
+                    return $this->generateObjectPropertiesResponseSpec($value, $endpoint, $key);
                 })->toArray();
 
                 if (!count($properties)) {
@@ -543,5 +528,45 @@ class OpenAPISpecWriter
 
         $parts = preg_split('/[^\w+]/', $endpoint->uri, -1, PREG_SPLIT_NO_EMPTY);
         return Str::lower($endpoint->httpMethods[0]) . join('', array_map(fn ($part) => ucfirst($part), $parts));
+    }
+
+
+    public function generateObjectPropertiesResponseSpec($value, OutputEndpointData $endpoint, $key): array
+    {
+        //Field is object
+        if ($value instanceof \stdClass) {
+            $value = (array)$value;
+            $fieldObjectSpec = [];
+            $fieldObjectSpec['type'] = 'object';
+            $fieldObjectSpec['properties']= [];
+            foreach($value as $subKey => $subValue){
+                $newKey = sprintf('%s.%s', $key, $subKey);
+                $generateResponseContentFieldSpec = $this->generateObjectPropertiesResponseSpec(
+                    $subValue,
+                    $endpoint,
+                    $newKey
+                );
+                $fieldObjectSpec['properties'][$subKey] = $generateResponseContentFieldSpec[$newKey];
+
+            }
+            return  [$key => $fieldObjectSpec];
+        }
+
+        $spec = [
+            'type' => $this->convertScribeOrPHPTypeToOpenAPIType(gettype($value)),
+            'example' => $value,
+
+        ];
+        if (isset($endpoint->responseFields[$key]->description)) {
+            $spec['description'] = $endpoint->responseFields[$key]->description;
+        }
+        if ($spec['type'] === 'array' && !empty($value)) {
+            $spec['items']['type'] = $this->convertScribeOrPHPTypeToOpenAPIType(gettype($value[0]));
+            $spec['example'] = json_decode(json_encode($spec['example']), true);//Convert stdClass to array
+        }
+
+        return [
+            $key => $spec,
+        ];
     }
 }

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -431,7 +431,7 @@ class OpenAPISpecWriterTest extends TestCase
                 [
                     'status' => 201,
                     'description' => '',
-                    'content' => '{"this": "shouldn\'t be ignored", "and this": "too"}',
+                    'content' => '{"this": "shouldn\'t be ignored", "and this": "too", "sub level 0": { "sub level 1 key 1": "sl0_sl1k1", "sub level 1 key 2": [ { "sub level 2 key 1": "sl0_sl1k2_sl2k1", "sub level 2 key 2": { "sub level 3 key 1": "sl0_sl1k2_sl2k2_sl3k1" } } ], "sub level 1 key 3": { "sub level 2 key 1": "sl0_sl1k3_sl2k2", "sub level 2 key 2": { "sub level 3 key 1": "sl0_sl1k3_sl2k2_sl3k1", "sub level 3 key null": null, "sub level 3 key integer": 99 } } } }',
                 ],
             ],
             'responseFields' => [
@@ -440,6 +440,9 @@ class OpenAPISpecWriterTest extends TestCase
                     'type' => 'string',
                     'description' => 'Parameter description, ha!',
                 ],
+                'sub level 0.sub level 1 key 3.sub level 2 key 1'=> [
+                    'description' => 'This is description of nested object',
+                ]
             ],
         ]);
         $endpointData2 = $this->createMockEndpointData([
@@ -477,6 +480,56 @@ class OpenAPISpecWriterTest extends TestCase
                                     'example' => "too",
                                     'type' => 'string',
                                 ],
+                                'sub level 0' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'sub level 1 key 1' => [
+                                            'type' => 'string',
+                                            'example' => 'sl0_sl1k1'
+                                        ],
+                                        'sub level 1 key 2' => [
+                                            'type' => 'array',
+                                            'example' => [
+                                                [
+                                                    'sub level 2 key 1' => 'sl0_sl1k2_sl2k1',
+                                                    'sub level 2 key 2' => [
+                                                        'sub level 3 key 1' => 'sl0_sl1k2_sl2k2_sl3k1'
+                                                    ]
+                                                ]
+                                            ],
+                                            'items' => [
+                                                'type' => 'object'
+                                            ]
+                                        ],
+                                        'sub level 1 key 3' => [
+                                            'type' => 'object',
+                                            'properties' => [
+                                                'sub level 2 key 1' => [
+                                                    'type' => 'string',
+                                                    'example' => 'sl0_sl1k3_sl2k2',
+                                                    'description' => 'This is description of nested object'
+                                                ],
+                                                'sub level 2 key 2' => [
+                                                    'type' => 'object',
+                                                    'properties' => [
+                                                        'sub level 3 key 1' => [
+                                                            'type' => 'string',
+                                                            'example' => 'sl0_sl1k3_sl2k2_sl3k1'
+                                                        ],
+                                                        'sub level 3 key null' => [
+                                                            'type' => 'string',
+                                                            'example' => null
+                                                        ],
+                                                        'sub level 3 key integer' => [
+                                                            'type' => 'integer',
+                                                            'example' => 99
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
                             ],
                         ],
                     ],


### PR DESCRIPTION
This PR adds a generation of property types for nested objects inside responses during openapi generation.  
Previously if the response contained nested objects, it was marked simply as `object`, and no additional params were generated. Now `OpenAPISpecWriter.php` will iterate through its properties and generate specs for them.


<details>

<summary><h3>Previously</h3></summary>

```YAML
'201':
  description: ''
  content:
    application/json:
      schema:
        type: object
        #example: ...
        properties:
          this:
            type: string
            example: shouldn't be ignored
          and this:
            type: string
            example: too
            description: Parameter description, ha!
          sub level 0:
            type: object
            example:
              sub level 1 key 1: sl0_sl1k1
              sub level 1 key 2:
              - sub level 2 key 1: sl0_sl1k2_sl2k1
                sub level 2 key 2:
                  sub level 3 key 1: sl0_sl1k2_sl2k2_sl3k1
              sub level 1 key 3:
                sub level 2 key 1: sl0_sl1k3_sl2k2
                sub level 2 key 2:
                  sub level 3 key 1: sl0_sl1k3_sl2k2_sl3k1
                  sub level 3 key null:
                  sub level 3 key integer: 99
'204':
  description: Successfully updated.

```
</details>

<details>

<summary><h3>Now</h3></summary>

```YAML
'201':
  description: ''
  content:
    application/json:
      schema:
        type: object
        #example: ...
        properties:
          this:
            type: string
            example: shouldn't be ignored
          and this:
            type: string
            example: too
            description: Parameter description, ha!
          sub level 0:
            type: object
            properties:
              sub level 1 key 1:
                type: string
                example: sl0_sl1k1
              sub level 1 key 2:
                type: array
                example:
                - sub level 2 key 1: sl0_sl1k2_sl2k1
                  sub level 2 key 2:
                    sub level 3 key 1: sl0_sl1k2_sl2k2_sl3k1
                items:
                  type: object
              sub level 1 key 3:
                type: object
                properties:
                  sub level 2 key 1:
                    type: string
                    example: sl0_sl1k3_sl2k2
                    description: This is description of nested object
                  sub level 2 key 2:
                    type: object
                    properties:
                      sub level 3 key 1:
                        type: string
                        example: sl0_sl1k3_sl2k2_sl3k1
                      sub level 3 key null:
                        type: string
                        example:
                      sub level 3 key integer:
                        type: integer
                        example: 99
'204':
  description: Successfully updated.

```
</details>
