### PR TITLE
OpenAPI: Set properties of objects nested in arrays

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -560,8 +560,16 @@ class OpenAPISpecWriter
             $spec['description'] = $endpoint->responseFields[$key]->description;
         }
         if ($spec['type'] === 'array' && !empty($value)) {
-            $spec['items']['type'] = $this->convertScribeOrPHPTypeToOpenAPIType(gettype($value[0]));
+            $handle = $value[0];
+            $type = $this->convertScribeOrPHPTypeToOpenAPIType(gettype($handle));
+            $spec['items']['type'] = $type;
             $spec['example'] = json_decode(json_encode($spec['example']), true);//Convert stdClass to array
+
+            if ($type === 'object') {
+                $spec['items']['properties'] = collect($handle)->mapWithKeys(function ($v, $k) use ($endpoint) {
+                    return $this->generateObjectPropertiesResponseSpec($v, $endpoint, $k);
+                })->toArray();
+            }
         }
 
         return [


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

When generating the documentation, the OpenAPI does not include `properties` of objects that are nested in arrays. This PR aims at fixing this bug.

<details>
<summary><b>Before:</b></summary>

```yaml
openapi: 3.0.3
info:
  title: 'Test'
  version: 1.0.0
paths:
  /api/test:
    get:
      responses:
        '200':
          description: Successful response
          content:
            application/json:
              schema:
                type: object
                example:
                  someArray:
                    - anotherObjectKey: objectValue
                properties:
                  someArray:
                    type: array
                    example:
                      anotherObjectKey: objectValue
                    items:
                      type: object
```

</details>
<details>
<summary><b>After:</b></summary>

```yaml
openapi: 3.0.3
info:
  title: 'Test'
  version: 1.0.0
paths:
  /api/test:
    get:
      responses:
        '200':
          description: Successful response
          content:
            application/json:
              schema:
                type: object
                example:
                  someArray:
                    - anotherObjectKey: objectValue
                properties:
                  someArray:
                    type: array
                    example:
                      anotherObjectKey: objectValue
                    items:
                      type: object
                      properties:
                        anotherObjectKey:
                          type: string
                          example: objectValue
```

</details>

<details>
<summary><b>Diff:</b></summary>

```diff
--- a/before
+++ b/after
@@ -22,3 +22,7 @@ paths:
                       anotherObjectKey: objectValue
                     items:
                       type: object
+                      properties:
+                        anotherObjectKey:
+                          type: string
+                          example: objectValue
```

</details>