### PR TITLE
Allow Endpoint-attribute to act as class target

### DIFF
--- a/src/Attributes/Endpoint.php
+++ b/src/Attributes/Endpoint.php
@@ -4,7 +4,7 @@ namespace Knuckles\Scribe\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 class Endpoint
 {
     public function __construct(

--- a/tests/Strategies/Metadata/GetFromMetadataAttributesTest.php
+++ b/tests/Strategies/Metadata/GetFromMetadataAttributesTest.php
@@ -14,6 +14,7 @@ use Knuckles\Scribe\Tools\DocumentationConfig;
 use PHPUnit\Framework\TestCase;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use ReflectionClass;
+use ReflectionMethod;
 
 class UseMetadataAttributesTest extends TestCase
 {
@@ -99,6 +100,15 @@ class UseMetadataAttributesTest extends TestCase
         $this->assertArraySubset([
             "authenticated" => false,
         ], $results);
+
+        $endpoint = $this->endpoint(function (ExtractedEndpointData $e) {
+            $e->controller = new ReflectionClass(MetadataAttributesTestController3::class);
+            $e->method = $e->controller->getMethod('c1');
+        });
+        $results = $this->fetch($endpoint);
+        $this->assertArraySubset([
+            "title" => "Endpoint C"
+        ], $results);
     }
 
     protected function fetch($endpoint): array
@@ -160,6 +170,15 @@ class MetadataAttributesTestController2
 
     #[Unauthenticated]
     public function c2()
+    {
+    }
+}
+
+
+#[Endpoint("Endpoint C")]
+class MetadataAttributesTestController3
+{
+    public function c1()
     {
     }
 }


### PR DESCRIPTION
I have changed the definition of the attributes for Endpoint so that they can be used as class attributes. 

This is useful if you use a library like [Laravel Actions] (https://github.com/lorisleiva/laravel-actions) where you have one controller per route. 