### PR TITLE
added support for nested arrays as query parameters for bash examples

### DIFF
--- a/src/Tools/WritingUtils.php
+++ b/src/Tools/WritingUtils.php
@@ -57,7 +57,14 @@ class WritingUtils
                 } else {
                     // Hash query param (eg filter[name]=john should become "filter[name]": "john")
                     foreach ($value as $item => $itemValue) {
-                        $qs .= "$paramName" . '[' . urlencode($item) . ']=' . urlencode($itemValue) . '&';
+                        if (is_array($itemValue)) {
+                            // Handle arrays (eg filter[category][]=1&filter[category][]=5 should become filter[category]: [1,5])
+                            foreach ($itemValue as $itemValueEntry) {
+                                $qs .= "$paramName" . '[' . urlencode($item) . '][]=' . urlencode($itemValueEntry) . '&';
+                            }
+                        } else {
+                            $qs .= "$paramName" . '[' . urlencode($item) . ']=' . urlencode($itemValue) . '&';
+                        }
                     }
                 }
             }

--- a/tests/Unit/WritingUtilsTest.php
+++ b/tests/Unit/WritingUtilsTest.php
@@ -61,6 +61,17 @@ class WritingUtilsTest extends BaseLaravelTest
 
     }
 
+    /** @test */
+    public function print_query_params_as_string_bash()
+    {
+        $queryParams = WritingUtils::printQueryParamsAsString($this->queryParams());
+
+        $this->assertEquals(
+            'name+query=name+value&list+query[]=list+element+1&list+query[]=list+element+2&nested+query[nested+query+level+1+array][nested+query+level+2+list][]=nested+level+2+list+element+1&nested+query[nested+query+level+1+array][nested+query+level+2+list][]=nested+level+2+list+element+2&nested+query[nested+query+level+1+array][nested+query+level+2+query]=name+nested+2&nested+query[nested+query+level+1+query]=name+nested+1',
+            $queryParams
+        );
+    }
+    
     private function queryParams(): array
     {
         return [


### PR DESCRIPTION
Fixed: When using nested arrays as query parameters, the bash examples throw an exception. 

Example: `filter[category][]=2&filter[category][ ]=6` broke the existing code. 

Solution: Check if the parameter is an array and handle it accordingly. 