### PR TITLE
Required array overwritten

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -658,6 +658,10 @@ trait ParsesValidationRules
                         $parentPath = substr($parentPath, 0, -2);
                         $normalisedParentPath = str_replace('.*.', '[].', $parentPath);
 
+                        if (!empty($results[$normalisedParentPath])) {
+                            break;
+                        }
+
                         $type = 'object[]';
                         $example = [[]];
                     } else {

--- a/tests/Unit/ValidationRuleParsingTest.php
+++ b/tests/Unit/ValidationRuleParsingTest.php
@@ -438,6 +438,19 @@ class ValidationRuleParsingTest extends BaseLaravelTest
             ];
         }
     }
+
+    /** @test */
+    public function child_does_not_overwrite_parent_status()
+    {
+        $ruleset = [
+            'array_param' => 'array|required',
+            'array_param.*' => 'array|required',
+            'array_param.*.an_item' => 'string|required',
+        ];
+        $results = $this->strategy->parse($ruleset);
+        $this->assertCount(2, $results);
+        $this->assertEquals(true, $results['array_param']['required']);
+    }
 }
 
 class DummyValidationRule implements \Illuminate\Contracts\Validation\Rule


### PR DESCRIPTION
addMissingParentFields was checking for the existence of 'name.*' but then renaming to 'name' before saving.
Add a check to see if 'name' already exists to avoid overwriting a parent that is not missing.

fix #608