### PR TITLE
Fix sorting of multiple responses by status code

### DIFF
--- a/src/Extracting/Extractor.php
+++ b/src/Extracting/Extractor.php
@@ -165,7 +165,7 @@ class Extractor
             $endpointData->responses->concat($results);
         });
         // Ensure 200 responses come first
-        $endpointData->responses->sortBy('status');
+        $endpointData->responses = $endpointData->responses->sortBy('status');
     }
 
     protected function fetchResponseFields(ExtractedEndpointData $endpointData, array $rulesToApply): void

--- a/src/Extracting/Extractor.php
+++ b/src/Extracting/Extractor.php
@@ -165,7 +165,7 @@ class Extractor
             $endpointData->responses->concat($results);
         });
         // Ensure 200 responses come first
-        $endpointData->responses = $endpointData->responses->sortBy('status');
+        $endpointData->responses = $endpointData->responses->sortBy('status')->values();
     }
 
     protected function fetchResponseFields(ExtractedEndpointData $endpointData, array $rulesToApply): void

--- a/src/Extracting/Extractor.php
+++ b/src/Extracting/Extractor.php
@@ -165,7 +165,7 @@ class Extractor
             $endpointData->responses->concat($results);
         });
         // Ensure 200 responses come first
-        $endpointData->responses = $endpointData->responses->sortBy('status')->values();
+        $endpointData->responses = new ResponseCollection($endpointData->responses->sortBy('status')->values());
     }
 
     protected function fetchResponseFields(ExtractedEndpointData $endpointData, array $rulesToApply): void


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->
The `sortBy` function from Laravel does not modify the collection's sort order. It returns a new sorted collection.
