### PR TITLE
Ignore upgrade check if user hasn't published config yet

### DIFF
--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -156,6 +156,7 @@ class GenerateDocumentation extends Command
         $this->info("Checking for any pending upgrades to your config file...");
         try {
             if (! $this->laravel['files']->exists($this->laravel->configPath("{$this->configName}.php"))) {
+                $this->info("No config file to upgrade.");
                 return;
             }
 

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -155,6 +155,10 @@ class GenerateDocumentation extends Command
 
         $this->info("Checking for any pending upgrades to your config file...");
         try {
+            if (! $this->laravel['files']->exists($this->laravel->configPath("{$this->configName}.php"))) {
+                return;
+            }
+
             $upgrader = Upgrader::ofConfigFile("config/{$this->configName}.php", __DIR__ . '/../../config/scribe.php')
                 ->dontTouch(
                     'routes', 'example_languages', 'database_connections_to_transact', 'strategies', 'laravel.middleware',

--- a/tests/GenerateDocumentation/BehavioursTest.php
+++ b/tests/GenerateDocumentation/BehavioursTest.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe\Tests\GenerateDocumentation;
 
+use Illuminate\Support\Facades\File as FileFacade;
 use Illuminate\Support\Facades\Route as RouteFacade;
 use Knuckles\Scribe\Commands\GenerateDocumentation;
 use Knuckles\Scribe\Scribe;
@@ -213,8 +214,13 @@ class BehavioursTest extends BaseLaravelTest
         config(["scribe_test" => require "config/scribe_test.php"]);
 
         $output = $this->artisan('scribe:generate', ['--config' => 'scribe_test']);
-        $this->assertStringContainsString("Checking for any pending upgrades to your config file...", $output);
-        $this->assertStringContainsString("`logo` will be added", $output);
+
+        if (! FileFacade::exists(config_path("scribe.php"))) {
+            $this->assertStringContainsString("No config file to upgrade.", $output);
+        } else {
+            $this->assertStringContainsString("Checking for any pending upgrades to your config file...", $output);
+            $this->assertStringContainsString("`logo` will be added", $output);
+        }
 
         $output = $this->artisan('scribe:generate', ['--config' => 'scribe_test', '--no-upgrade-check' => true]);
         $this->assertStringNotContainsString("Checking for any pending upgrades to your config file...", $output);


### PR DESCRIPTION
It will throw error if there is no config file in `config/scribe.php`.

We should check if this file exists or not, if it's not exists, just ignore upgrade config.

Before:
<img width="993" alt="Screenshot 2023-03-07 at 15 42 57" src="https://user-images.githubusercontent.com/6972407/223370024-0ed58a6e-7801-4ab9-b50e-b7dcbdae5a5d.png">

After:
<img width="495" alt="Screenshot 2023-03-07 at 15 45 05" src="https://user-images.githubusercontent.com/6972407/223370086-ccd64549-997d-48ed-8fa9-0cf5e336aa21.png">
