### PR TITLE
Remove unnecessary randomisation from auth description

### DIFF
--- a/src/Extracting/ApiDetails.php
+++ b/src/Extracting/ApiDetails.php
@@ -2,7 +2,6 @@
 
 namespace Knuckles\Scribe\Extracting;
 
-use Illuminate\Support\Arr;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils;
 use Knuckles\Scribe\Tools\DocumentationConfig;
 
@@ -91,11 +90,7 @@ class ApiDetails
         if ($isAuthed) {
             $strategy = $this->config->get('auth.in');
             $parameterName = $this->config->get('auth.name');
-            $authDescription = Arr::random([
-                "This API is authenticated by sending ",
-                "To authenticate requests, include ",
-                "Authenticate requests to this API's endpoints by sending ",
-            ]);
+            $authDescription = "To authenticate requests, include ";
             $authDescription .= match ($strategy) {
                 'query' => "a query parameter **`$parameterName`** in the request.",
                 'body' => "a parameter **`$parameterName`** in the body of the request.",


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

Whenever new documentation is generated, it should ideally not change if none of the backing endpoints or configuration has changed. I think this randomisation should not occur while generating the contents of API documentation.