### PR TITLE
Fix for issue "Incorrect generation of URL parameters in OpenAPI YAML file #653"

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -106,50 +106,6 @@ class OpenAPISpecWriter
 
             $pathItem = $operations;
 
-            // Placing all URL parameters at the path level, since it's the same path anyway
-            if (count($endpoints[0]->urlParameters)) {
-                $parameters = [];
-                /**
-                 * @var string $name
-                 * @var Parameter $details
-                 */
-                foreach ($endpoints[0]->urlParameters as $name => $details) {
-                    $parameterData = [
-                        'in' => 'path',
-                        'name' => $name,
-                        'description' => $details->description,
-                        'example' => $details->example,
-                        // Currently, OAS requires path parameters to be required
-                        'required' => true,
-                        'schema' => [
-                            'type' => $details->type,
-                        ],
-                    ];
-                    // Workaround for optional parameters
-                    if (empty($details->required)) {
-                        $parameterData['description'] = rtrim('Optional parameter. ' . $parameterData['description']);
-                        $parameterData['examples'] = [
-                            'omitted' => [
-                                'summary' => 'When the value is omitted',
-                                'value' => '',
-                            ],
-                        ];
-
-                        if ($parameterData['example'] !== null) {
-                            $parameterData['examples']['present'] = [
-                                'summary' => 'When the value is present',
-                                'value' => $parameterData['example'],
-                            ];
-                        }
-
-                        // Can't have `example` and `examples`
-                        unset($parameterData['example']);
-                    }
-                    $parameters[] = $parameterData;
-                }
-                $pathItem['parameters'] = $parameters; // @phpstan-ignore-line
-            }
-
             return [$path => $pathItem];
         })->toArray();
     }
@@ -164,6 +120,27 @@ class OpenAPISpecWriter
     protected function generateEndpointParametersSpec(OutputEndpointData $endpoint): array
     {
         $parameters = [];
+
+        // Add this block of code to handle URL parameters
+        if (count($endpoint->urlParameters)) {
+            /**
+             * @var string $name
+             * @var Parameter $details
+             */
+            foreach ($endpoint->urlParameters as $name => $details) {
+                $parameterData = [
+                    'in' => 'path',
+                    'name' => $name,
+                    'description' => $details->description,
+                    'example' => $details->example,
+                    'required' => $details->required,
+                    'schema' => [
+                        'type' => $details->type,
+                    ],
+                ];
+                $parameters[] = $parameterData;
+            }
+        }
 
         if (count($endpoint->queryParameters)) {
             /**


### PR DESCRIPTION
https://github.com/knuckleswtf/scribe/issues/653

1. In the generatePathsSpec method, remove the following block of code that adds URL parameters at the path level

2. Modify the generateEndpointParametersSpec method to add URL parameters at the operation level. Insert the code removed in the previous step before the code handling query parameters
3. Remove the $parameters variable from the removed code since it's already defined at the beginning of the generateEndpointParametersSpec method.

By making these changes, URL parameters will be added at the operation level instead of the path level. This should fix the issue with displaying parameters in the documentation.

<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

