### PR TITLE
Don't autoload with class_exists

### DIFF
--- a/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
+++ b/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
@@ -214,7 +214,7 @@ class GetFromLaravelAPI extends Strategy
         $className = str_replace(['-', '_', ' '], '', Str::title($urlThing));
         $rootNamespace = app()->getNamespace();
 
-        if (class_exists($class = "{$rootNamespace}Models\\" . $className, false)
+        if (class_exists($class = "{$rootNamespace}Models\\" . $className, autoload: false)
             // For the heathens that don't use a Models\ directory
             || class_exists($class = $rootNamespace . $className, false)) {
             try {

--- a/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
+++ b/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
@@ -216,7 +216,7 @@ class GetFromLaravelAPI extends Strategy
 
         if (class_exists($class = "{$rootNamespace}Models\\" . $className, autoload: false)
             // For the heathens that don't use a Models\ directory
-            || class_exists($class = $rootNamespace . $className, false)) {
+            || class_exists($class = $rootNamespace . $className, autoload: false)) {
             try {
                 $instance = new $class;
             } catch (\Error) { // It might be an enum or some other non-instantiable class

--- a/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
+++ b/src/Extracting/Strategies/UrlParameters/GetFromLaravelAPI.php
@@ -214,9 +214,9 @@ class GetFromLaravelAPI extends Strategy
         $className = str_replace(['-', '_', ' '], '', Str::title($urlThing));
         $rootNamespace = app()->getNamespace();
 
-        if (class_exists($class = "{$rootNamespace}Models\\" . $className)
+        if (class_exists($class = "{$rootNamespace}Models\\" . $className, false)
             // For the heathens that don't use a Models\ directory
-            || class_exists($class = $rootNamespace . $className)) {
+            || class_exists($class = $rootNamespace . $className, false)) {
             try {
                 $instance = new $class;
             } catch (\Error) { // It might be an enum or some other non-instantiable class


### PR DESCRIPTION
Due to legacy reasons, in my codebase I have all the models being in the root namespace, not in the `\App\Models` namespace.

When trying to run `php artisan scribe:generate`, it would immediately fail when trying to actually load my models (`Cannot declare class Account, because the name is already in use`, because of the autoloading of `class_exists`. Setting the autoload to false made everything work again.

For what it's worth, the parameter it's checking does use Model Binding, so it sounds like it shouldn't be doing this anyway? (`UrlParamsNormalizer::getTypeHintedEloquentModels` finds it)

But either way, thought I'd submit this fix!