### PR TITLE
Support `@apiResource` with missing `@apiResourceModel`

### DIFF
--- a/src/Extracting/InstantiatesExampleModels.php
+++ b/src/Extracting/InstantiatesExampleModels.php
@@ -24,7 +24,7 @@ trait InstantiatesExampleModels
         array   $relations = [], ?ReflectionFunctionAbstract $transformationMethod = null
     )
     {
-        // Early return if JsonResource working with empty resource, there won't have an example model
+        // If the API Resource uses an empty resource, there won't be an example model
         if($type == null && $transformationMethod == null)
             return null;
 

--- a/src/Extracting/InstantiatesExampleModels.php
+++ b/src/Extracting/InstantiatesExampleModels.php
@@ -17,13 +17,17 @@ trait InstantiatesExampleModels
      * @param string[] $relations
      * @param \ReflectionFunctionAbstract|null $transformationMethod A method which has the model as its first parameter. Useful if the `$type` is empty.
      *
-     * @return \Illuminate\Database\Eloquent\Model|object
+     * @return \Illuminate\Database\Eloquent\Model|object|null
      */
     protected function instantiateExampleModel(
         ?string $type = null, array $factoryStates = [],
         array   $relations = [], ?ReflectionFunctionAbstract $transformationMethod = null
     )
     {
+        // Early return if JsonResource working with empty resource, there won't have an example model
+        if($type == null && $transformationMethod == null)
+            return null;
+
         if ($type == null) {
             $parameter = Arr::first($transformationMethod->getParameters());
             if ($parameter->hasType() && !$parameter->getType()->isBuiltin() && class_exists($parameter->getType()->getName())) {

--- a/src/Extracting/Shared/ApiResourceResponseTools.php
+++ b/src/Extracting/Shared/ApiResourceResponseTools.php
@@ -54,8 +54,8 @@ class ApiResourceResponseTools
         array  $paginationStrategy = [], array $additionalData = []
     ): JsonResource
     {
-        // If the JsonResource is working with empty $resource (such like an empty array), the $modelInstantiator will be null
-        // If $modelInstantiator is null set to an empty array as default
+        // If the API Resource uses an empty $resource (e.g. an empty array), the $modelInstantiator will be null
+        // See https://github.com/knuckleswtf/scribe/issues/652
         $modelInstance = $modelInstantiator() ?? [];
         try {
             $resource = new $apiResourceClass($modelInstance);

--- a/src/Extracting/Shared/ApiResourceResponseTools.php
+++ b/src/Extracting/Shared/ApiResourceResponseTools.php
@@ -54,7 +54,9 @@ class ApiResourceResponseTools
         array  $paginationStrategy = [], array $additionalData = []
     ): JsonResource
     {
-        $modelInstance = $modelInstantiator();
+        // If the JsonResource is working with empty $resource (such like an empty array), the $modelInstantiator will be null
+        // If $modelInstantiator is null set to an empty array as default
+        $modelInstance = $modelInstantiator() ?? [];
         try {
             $resource = new $apiResourceClass($modelInstance);
         } catch (Exception) {

--- a/src/Extracting/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Extracting/Strategies/Responses/UseApiResourceTags.php
@@ -11,6 +11,7 @@ use Knuckles\Scribe\Extracting\RouteDocBlocker;
 use Knuckles\Scribe\Extracting\Shared\ApiResourceResponseTools;
 use Knuckles\Scribe\Extracting\Strategies\Strategy;
 use Knuckles\Scribe\Tools\AnnotationParser as a;
+use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
 use Knuckles\Scribe\Tools\Utils;
 use Mpociot\Reflection\DocBlock\Tag;
 
@@ -101,7 +102,7 @@ class UseApiResourceTags extends Strategy
         }
 
         if (empty($modelClass)) {
-            throw new Exception("Couldn't detect an Eloquent API resource model from your docblock. Did you remember to specify a model using @apiResourceModel?");
+            c::warn("Couldn't detect an Eloquent API resource model from your docblock. Did you remember to specify a model using @apiResourceModel?");
         }
 
         return [$modelClass, $states, $relations, $pagination];

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -197,6 +197,14 @@ class TestController extends Controller
     }
 
     /**
+     * @apiResource \Knuckles\Scribe\Tests\Fixtures\TestEmptyApiResource
+     */
+    public function withEmptyApiResource()
+    {
+        return new TestEmptyApiResource();
+    }
+
+    /**
      * @group Other😎
      *
      * @apiResourceCollection Knuckles\Scribe\Tests\Fixtures\TestUserApiResource

--- a/tests/Fixtures/TestEmptyApiResource.php
+++ b/tests/Fixtures/TestEmptyApiResource.php
@@ -24,7 +24,7 @@ class TestEmptyApiResource extends JsonResource
      * @param  \Illuminate\Http\Request  $request
      * @return array
      */
-    public function with(Request $request)
+    public function with($request)
     {
         return [
             'request-id' => 'ea02ebc1-4e3c-497f-9ea8-7a1ac5008af2',

--- a/tests/Fixtures/TestEmptyApiResource.php
+++ b/tests/Fixtures/TestEmptyApiResource.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TestEmptyApiResource extends JsonResource
+{
+    /**
+     * Create a new resource instance.
+     *
+     * @param  mixed  $resource
+     * @return void
+     */
+    public function __construct($resource = [])
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Get any additional data that should be returned with the resource array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function with(Request $request)
+    {
+        return [
+            'request-id' => 'ea02ebc1-4e3c-497f-9ea8-7a1ac5008af2',
+            'error_code' => 0,
+            'messages'   => []
+        ];
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     *
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [];
+    }
+}

--- a/tests/GenerateDocumentation/BehavioursTest.php
+++ b/tests/GenerateDocumentation/BehavioursTest.php
@@ -228,4 +228,14 @@ class BehavioursTest extends BaseLaravelTest
         unlink("config/scribe_test.php");
         Utils::deleteDirectoryAndContents(".scribe_test");
     }
+
+    /** @test */
+    public function can_generate_with_apiresource_tag_but_without_apiresourcemodel_tag()
+    {
+        RouteFacade::get('/api/test', [TestController::class, 'withEmptyApiResource']);
+        $this->generateAndExpectConsoleOutput(
+            "Couldn't detect an Eloquent API resource model from your docblock. Did you remember to specify a model using @apiResourceModel?",
+            'Processed route: [GET] api/test'
+        );
+    }
 }

--- a/tests/Strategies/Responses/UseApiResourceTagsTest.php
+++ b/tests/Strategies/Responses/UseApiResourceTagsTest.php
@@ -85,6 +85,31 @@ class UseApiResourceTagsTest extends BaseLaravelTest
     }
 
     /** @test */
+    public function can_parse_apiresource_tags_without_apiresourcemodel()
+    {
+        $config = new DocumentationConfig([]);
+
+        $route = new Route(['POST'], "/somethingRandom", ['uses' => [TestController::class, 'dummy']]);
+
+        $strategy = new UseApiResourceTags($config);
+        $tags = [
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestEmptyApiResource')
+        ];
+        $results = $strategy->getApiResourceResponseFromTags($strategy->getApiResourceTag($tags), $tags, ExtractedEndpointData::fromRoute($route));
+        $this->assertArraySubset([
+            [
+                'status' => 200,
+                'content' => json_encode([
+                    'data' => [],
+                    'request-id' => 'ea02ebc1-4e3c-497f-9ea8-7a1ac5008af2',
+                    'error_code' => 0,
+                    'messages' => []
+                ]),
+            ],
+        ], $results);
+    }
+
+    /** @test */
     public function respects_models_source_settings()
     {
         $config = new DocumentationConfig(['examples' => ['models_source' => ['databaseFirst', 'factoryMake']]]);


### PR DESCRIPTION
Update：

* Allow generate document without @apiResourceModel tag (but will remind you didn't use the @apiResourceModel tag)

This is a little feature to allow the document generate when the JsonResource is working with empty resource which means won't have any model to specify on the @apiResourceModel tag.

This might help some project using JsonResource to manage the api response which like webhook api or none data response api.

From [#652](https://github.com/knuckleswtf/scribe/issues/652).