### PR TITLE
`rules()` are optional for GetFromFormRequestBase

### DIFF
--- a/src/Extracting/Strategies/GetFromFormRequestBase.php
+++ b/src/Extracting/Strategies/GetFromFormRequestBase.php
@@ -70,9 +70,11 @@ class GetFromFormRequestBase extends Strategy
 
             return call_user_func_array([$formRequest, 'validator'], [$validationFactory])
                 ->getRules();
-        } else {
+        } elseif (method_exists($formRequest, 'rules')) {
             return call_user_func_array([$formRequest, 'rules'], []);
         }
+
+        return [];
     }
 
     /**


### PR DESCRIPTION
rules() are now [optional as of Laravel 10.9](https://github.com/laravel/framework/releases/tag/v10.9.0)