### PR TITLE
fix: enum rule no longer overrides description

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -203,7 +203,7 @@ trait ParsesValidationRules
             if (enum_exists($type) && method_exists($type, 'tryFrom')) {
                 $cases = array_map(fn ($case) => $case->value, $type::cases());
                 $parameterData['type'] = gettype($cases[0]);
-                $parameterData['description'] = ' Must be one of ' . w::getListOfValuesAsFriendlyHtmlString($cases) . ' ';
+                $parameterData['description'] .= ' Must be one of ' . w::getListOfValuesAsFriendlyHtmlString($cases) . ' ';
                 $parameterData['setter'] = fn () => Arr::random($cases);
             }
 

--- a/tests/Unit/ValidationRuleParsingTest.php
+++ b/tests/Unit/ValidationRuleParsingTest.php
@@ -554,6 +554,21 @@ class ValidationRuleParsingTest extends BaseLaravelTest
             $results['enum']['example'],
             array_map(fn ($case) => $case->value, Fixtures\TestIntegerBackedEnum::cases())
         ));
+
+        $results = $this->strategy->parse([
+            'enum' => ['required', Rule::enum(Fixtures\TestStringBackedEnum::class)],
+        ], [
+            'enum' => ['description' => 'A description'],
+        ]);
+        $this->assertEquals('string', $results['enum']['type']);
+        $this->assertEquals(
+            'A description. Must be one of <code>red</code>, <code>green</code>, or <code>blue</code>.',
+            $results['enum']['description']
+        );
+        $this->assertTrue(in_array(
+            $results['enum']['example'],
+            array_map(fn ($case) => $case->value, Fixtures\TestStringBackedEnum::cases())
+        ));
     }
 }
 


### PR DESCRIPTION
Add a missing string concatenation when dealing with enum rules and a test for it.

closes #665