### PR TITLE
Refactor CustomTranslationsLoader for Compatibility with Statamic

### DIFF
--- a/src/Writing/CustomTranslationsLoader.php
+++ b/src/Writing/CustomTranslationsLoader.php
@@ -4,16 +4,17 @@ namespace Knuckles\Scribe\Writing;
 
 use Illuminate\Translation\FileLoader;
 use Knuckles\Scribe\Tools\Globals;
+use Illuminate\Contracts\Translation\Loader as LoaderContract;
 
 class CustomTranslationsLoader extends FileLoader
 {
-    protected FileLoader $defaultLoader;
+    protected LoaderContract $defaultLoader;
     protected mixed $langPath;
 
     protected ?array $scribeTranslationsCache = null;
     protected ?array $userTranslationsCache = null;
 
-    public function __construct(FileLoader $loader)
+    public function __construct(LoaderContract $loader)
     {
         $this->defaultLoader = $loader;
         $this->files = app('files');


### PR DESCRIPTION
This PR addresses a compatibility issue with Statamic. The `CustomTranslationsLoader` class was previously using `FileLoader`, which led to conflicts as Statamic also mutates the loader. 

To resolve this, we've refactored `CustomTranslationsLoader` to use `LoaderContract` instead of `FileLoader`. This change enhances flexibility and ensures compatibility with Statamic and potentially other packages that mutate the loader.

Key Changes:

- `defaultLoader` property type is now `LoaderContract`.
- Constructor now accepts `LoaderContract` instead of `FileLoader`.

This change is crucial for ensuring our package's seamless integration with Statamic. Please review and provide feedback.
