### PR TITLE
Provide ability to extend Header attribute

### DIFF
--- a/src/Extracting/Strategies/PhpAttributeStrategy.php
+++ b/src/Extracting/Strategies/PhpAttributeStrategy.php
@@ -41,19 +41,19 @@ abstract class PhpAttributeStrategy extends Strategy
     protected function getAttributes(ReflectionFunctionAbstract $method, ?ReflectionClass $class = null): array
     {
         $attributesOnMethod = collect(static::$attributeNames)
-            ->flatMap(fn(string $name) => $method->getAttributes($name))
+            ->flatMap(fn(string $name) => $method->getAttributes($name, ReflectionAttribute::IS_INSTANCEOF))
             ->map(fn(ReflectionAttribute $a) => $a->newInstance())->all();
 
         // If there's a FormRequest, we check there.
         if ($formRequestClass = $this->getFormRequestReflectionClass($method)) {
             $attributesOnFormRequest = collect(static::$attributeNames)
-                ->flatMap(fn(string $name) => $formRequestClass->getAttributes($name))
+                ->flatMap(fn(string $name) => $formRequestClass->getAttributes($name, ReflectionAttribute::IS_INSTANCEOF))
                 ->map(fn(ReflectionAttribute $a) => $a->newInstance())->all();
         }
 
         if ($class) {
             $attributesOnController = collect(static::$attributeNames)
-                ->flatMap(fn(string $name) => $class->getAttributes($name))
+                ->flatMap(fn(string $name) => $class->getAttributes($name, ReflectionAttribute::IS_INSTANCEOF))
                 ->map(fn(ReflectionAttribute $a) => $a->newInstance())->all();
         }
 


### PR DESCRIPTION
Our application has an extra header that needs to be sent with most (but not all) requests. It is not ideal to have to write `#[Header('Special-Header', 'this-needs-to-be-created-dynamically-at-runtime')]`

This PR makes it possible to extend the Header attribute.