### PR TITLE
Ensure example code supports multipart/form-data without files

### DIFF
--- a/resources/views/partials/example-requests/bash.md.blade.php
+++ b/resources/views/partials/example-requests/bash.md.blade.php
@@ -10,10 +10,11 @@ curl --request {{$endpoint->httpMethods[0]}} \
 @endif
 @endforeach
 @endif
-@if($endpoint->hasFiles())
+@if($endpoint->hasFiles() || (isset($endpoint->headers['Content-Type']) && $endpoint->headers['Content-Type'] == 'multipart/form-data' && count($endpoint->cleanBodyParameters)))
 @foreach($endpoint->cleanBodyParameters as $parameter => $value)
 @foreach(u::getParameterNamesAndValuesForFormData($parameter, $value) as $key => $actualValue)
-    --form "{!! "$key=".$actualValue !!}" \
+    --form "{!! "$key=".$actualValue !!}"@if(!($loop->parent->last) || count($endpoint->fileParameters))\
+@endif
 @endforeach
 @endforeach
 @foreach($endpoint->fileParameters as $parameter => $value)

--- a/resources/views/partials/example-requests/javascript.md.blade.php
+++ b/resources/views/partials/example-requests/javascript.md.blade.php
@@ -24,7 +24,7 @@ const headers = {
 };
 @endif
 
-@if($endpoint->hasFiles())
+@if($endpoint->hasFiles() || (isset($endpoint->headers['Content-Type']) && $endpoint->headers['Content-Type'] == 'multipart/form-data' && count($endpoint->cleanBodyParameters)))
 const body = new FormData();
 @foreach($endpoint->cleanBodyParameters as $parameter => $value)
 @foreach( u::getParameterNamesAndValuesForFormData($parameter, $value) as $key => $actualValue)
@@ -49,7 +49,7 @@ fetch(url, {
 @if(count($endpoint->headers))
     headers,
 @endif
-@if($endpoint->hasFiles())
+@if($endpoint->hasFiles() || (isset($endpoint->headers['Content-Type']) && $endpoint->headers['Content-Type'] == 'multipart/form-data' && count($endpoint->cleanBodyParameters)))
     body,
 @elseif(count($endpoint->cleanBodyParameters))
 @if ($endpoint->headers['Content-Type'] == 'application/x-www-form-urlencoded')

--- a/resources/views/partials/example-requests/php.md.blade.php
+++ b/resources/views/partials/example-requests/php.md.blade.php
@@ -14,7 +14,7 @@ $response = $client->{{ strtolower($endpoint->httpMethods[0]) }}(
 @if(!empty($endpoint->cleanQueryParameters))
         'query' => {!! u::printQueryParamsAsKeyValue($endpoint->cleanQueryParameters, "'", " =>", 12, "[]", 8) !!},
 @endif
-@if($endpoint->hasFiles())
+@if($endpoint->hasFiles() || (isset($endpoint->headers['Content-Type']) && $endpoint->headers['Content-Type'] == 'multipart/form-data' && !empty($endpoint->cleanBodyParameters)))
         'multipart' => [
 @foreach($endpoint->cleanBodyParameters as $parameter => $value)
 @foreach(u::getParameterNamesAndValuesForFormData($parameter, $value) as $key => $actualValue)
@@ -33,7 +33,7 @@ $response = $client->{{ strtolower($endpoint->httpMethods[0]) }}(
 @endforeach
 @endforeach
         ],
-@elseif(!empty($endpoint->cleanBodyParameters))
+@elseif(count($endpoint->cleanBodyParameters))
 @if ($endpoint->headers['Content-Type'] == 'application/x-www-form-urlencoded')
         'form_params' => {!! u::printPhpValue($endpoint->cleanBodyParameters, 8) !!},
 @else

--- a/resources/views/partials/example-requests/python.md.blade.php
+++ b/resources/views/partials/example-requests/python.md.blade.php
@@ -7,15 +7,20 @@ import requests
 import json
 
 url = '{{ rtrim($baseUrl, '/') }}/{{ $endpoint->boundUri }}'
-@if($endpoint->hasFiles())
+@if($endpoint->hasFiles() || (isset($endpoint->headers['Content-Type']) && $endpoint->headers['Content-Type'] == 'multipart/form-data' && count($endpoint->cleanBodyParameters)))
 files = {
+@foreach($endpoint->cleanBodyParameters as $parameter => $value)
+@foreach(u::getParameterNamesAndValuesForFormData($parameter, $value) as $key => $actualValue)
+  '{!! $key !!}': (None, '{!! $actualValue !!}')@if(!($loop->parent->last) || count($endpoint->fileParameters)),
+@endif
+@endforeach
+@endforeach
 @foreach($endpoint->fileParameters as $parameter => $value)
 @foreach(u::getParameterNamesAndValuesForFormData($parameter, $value) as $key => $file)
   '{!! $key !!}': open('{!! $file->path() !!}', 'rb')@if(!($loop->parent->last)),
 @endif
 @endforeach
 @endforeach
-
 }
 @endif
 @if(count($endpoint->cleanBodyParameters))
@@ -38,7 +43,7 @@ headers = {
 $optionalArguments = [];
 if (count($endpoint->headers)) $optionalArguments[] = "headers=headers";
 if (count($endpoint->fileParameters)) $optionalArguments[] = "files=files";
-if (count($endpoint->cleanBodyParameters)) $optionalArguments[] = (count($endpoint->fileParameters) || $endpoint->headers['Content-Type'] == 'application/x-www-form-urlencoded' ? "data=payload" : "json=payload");
+if (count($endpoint->cleanBodyParameters) && $endpoint->headers['Content-Type'] != 'multipart/form-data') $optionalArguments[] = (count($endpoint->fileParameters) || $endpoint->headers['Content-Type'] == 'application/x-www-form-urlencoded' ? "data=payload" : "json=payload");
 if (count($endpoint->cleanQueryParameters)) $optionalArguments[] = "params=params";
 $optionalArguments = implode(', ',$optionalArguments);
 @endphp


### PR DESCRIPTION
Currently the Postman and OpenAPI writers both make allowances for when the `Content-Type` header has been set to `multipart/form-data` to render different output. This extends the same logic to the generated example code, which currently only uses the `multipart/form-data` format if there is a file required to send for the endpoint.
