### PR TITLE
Fix float values 

### DIFF
--- a/resources/views/components/field-details.blade.php
+++ b/resources/views/components/field-details.blade.php
@@ -41,6 +41,7 @@
         </label>
     @elseif($isList)
         <input type="{{ $inputType }}" style="display: none"
+               @if($inputType === 'number')step="any"@endif
                name="{{ $fullName."[0]" }}" @if($class)class="{{ $class }}"@endif
                data-endpoint="{{ $endpointId }}"
                data-component="{{ $component }}">
@@ -50,6 +51,7 @@
                data-component="{{ $component }}">
     @else
         <input type="{{ $inputType }}" style="display: none"
+               @if($inputType === 'number')step="any"@endif
                name="{{ $fullName }}" @if($class)class="{{ $class }}"@endif
                data-endpoint="{{ $endpointId }}"
                value="{!! (isset($example) && (is_string($example) || is_numeric($example))) ? $example : '' !!}"


### PR DESCRIPTION
Adds step="any" to input type when type is number to prevent a bug that occurs when number is used for non integer values.

Example:
Let's have an API that support Latitude and Longitude as input values
    /*
     * @queryParam lat number Latitudine. Example: 45.3267105
     * @queryParam lng number Longitudine. Example: 7.995482
    */
The generated documentation example will have a field that look like this:
```html
<input type="number" style="display: block;" name="lat" data-endpoint="GETapi-v2-carrier-eolo-secondary-check" value="45.3267105" data-component="query">
```

As per validation rules the browser won't let you indroduce any value that isn't an integer number, so if you need to enter a precise value for testing it will be impossible.
Adding 'step="any"' makes possible to input any numeric value, integer or float.