### PR TITLE
Allow dot char into endpoint

### DIFF
--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -37,6 +37,7 @@ function getCookie(name) {
 }
 
 function tryItOut(endpointId) {
+    endpointId = endpointId.replaceAll('.', '\\.');
     document.querySelector(`#btn-tryout-${endpointId}`).hidden = true;
     document.querySelector(`#btn-canceltryout-${endpointId}`).hidden = false;
     const executeBtn = document.querySelector(`#btn-executetryout-${endpointId}`).hidden = false;


### PR DESCRIPTION
Hi,
This fix allow to put a dot character into the endpoint.
For my case, I have this error when I click on "Try it out" : 
![image](https://github.com/knuckleswtf/scribe/assets/83085039/b4ac2771-139b-46d2-ac5a-7b85d6d2d76c)

https://stackoverflow.com/questions/17563296/does-queryselectorall-support-the-period-character-in-an-id


