### PR TITLE
Exclude Authorization header from openapi specs.

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -177,7 +177,7 @@ class OpenAPISpecWriter
 
         if (count($endpoint->headers)) {
             foreach ($endpoint->headers as $name => $value) {
-                if (in_array($name, ['Content-Type', 'content-type', 'Accept', 'accept']))
+                if (in_array(strtolower($name), ['content-type', 'accept', 'authorization']))
                     // These headers are not allowed in the spec.
                     // https://swagger.io/docs/specification/describing-parameters/#header-parameters
                     continue;


### PR DESCRIPTION
In addition to the existing 2 headers, the Authorization header is also not allowed. Instead it is taken care of by the security schemes

<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

