### PR TITLE
Fix sample body with array of object

### DIFF
--- a/src/Tools/WritingUtils.php
+++ b/src/Tools/WritingUtils.php
@@ -110,7 +110,7 @@ class WritingUtils
         $output = isset($braces[0]) ? "{$braces[0]}\n" : '';
         foreach ($cleanQueryParams as $parameter => $value) {
             $output .= self::printSingleQueryParamAsKeyValue($value, $spacesIndentation, $startLinesWith, $quote,
-                                                             $parameter, $delimiter, $endLinesWith);
+                $parameter, $delimiter, $endLinesWith);
         }
 
         $closing = isset($braces[1]) ? str_repeat(" ", $closingBraceIndentation) . "{$braces[1]}" : '';
@@ -150,11 +150,11 @@ class WritingUtils
                 $parameterString = sprintf('%s[%s]', $parameter, $item);
                 if (is_array($itemValue)) {
                     $output .= static::printSingleQueryParamAsKeyValue($itemValue, $spacesIndentation, $startLinesWith,
-                                                                       $quote, $parameterString, $delimiter, $endLinesWith);
+                        $quote, $parameterString, $delimiter, $endLinesWith);
                 } else {
                     $output .= str_repeat(" ", $spacesIndentation);
                     $output .= sprintf("%s%s%s%s%s %s%s%s%s\n", $startLinesWith, $quote, $parameterString, $quote,
-                                       $delimiter, $quote, $itemValue, $quote, $endLinesWith);
+                        $delimiter, $quote, $itemValue, $quote, $endLinesWith);
                 }
             }
         }

--- a/src/Tools/WritingUtils.php
+++ b/src/Tools/WritingUtils.php
@@ -110,7 +110,7 @@ class WritingUtils
         $output = isset($braces[0]) ? "{$braces[0]}\n" : '';
         foreach ($cleanQueryParams as $parameter => $value) {
             $output .= self::printSingleQueryParamAsKeyValue($value, $spacesIndentation, $startLinesWith, $quote,
-                $parameter, $delimiter, $endLinesWith);
+                                                             $parameter, $delimiter, $endLinesWith);
         }
 
         $closing = isset($braces[1]) ? str_repeat(" ", $closingBraceIndentation) . "{$braces[1]}" : '';
@@ -150,11 +150,11 @@ class WritingUtils
                 $parameterString = sprintf('%s[%s]', $parameter, $item);
                 if (is_array($itemValue)) {
                     $output .= static::printSingleQueryParamAsKeyValue($itemValue, $spacesIndentation, $startLinesWith,
-                        $quote, $parameterString, $delimiter, $endLinesWith);
+                                                                       $quote, $parameterString, $delimiter, $endLinesWith);
                 } else {
                     $output .= str_repeat(" ", $spacesIndentation);
                     $output .= sprintf("%s%s%s%s%s %s%s%s%s\n", $startLinesWith, $quote, $parameterString, $quote,
-                        $delimiter, $quote, $itemValue, $quote, $endLinesWith);
+                                       $delimiter, $quote, $itemValue, $quote, $endLinesWith);
                 }
             }
         }
@@ -218,6 +218,10 @@ class WritingUtils
 
         return array_map(function ($param) {
             if (!empty($param['__fields'])) {
+                if ($param['type'] === 'object[]') {
+                    return [self::getSampleBody($param['__fields'])];
+                }
+
                 return self::getSampleBody($param['__fields']);
             }
 

--- a/tests/Unit/WritingUtilsTest.php
+++ b/tests/Unit/WritingUtilsTest.php
@@ -78,6 +78,25 @@ class WritingUtilsTest extends BaseLaravelTest
         $this->assertEquals($expected, $queryParams);
     }
 
+    /** @test */
+    public function get_sample_body()
+    {
+        $sampleBody = WritingUtils::getSampleBody($this->bodyParams());
+
+        $expected = [
+            'name' => 'Experience Form',
+            'fields' => [
+                [
+                    'name' => 'experience',
+                    'label' => 'Experience',
+                    'type' => 'textarea',
+                    'order' => 1,
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $sampleBody);
+    }
+
     private function queryParams(): array
     {
         return [
@@ -95,6 +114,63 @@ class WritingUtilsTest extends BaseLaravelTest
                     'nested query level 2 query' => 'name nested 2',
                 ],
                 'nested query level 1 query' => 'name nested 1'
+            ],
+        ];
+    }
+
+    private function bodyParams(): array
+    {
+        return [
+            'name' => [
+                'name' => 'name',
+                'description' => 'Form\'s name',
+                'required' => true,
+                'example' => 'Experience Form',
+                'type' => 'string',
+                'custom' => [],
+                '__fields' => [],
+            ],
+            'fields' => [
+                'name' => 'fields',
+                'description' => 'Form\'s fields',
+                'required' => false,
+                'example' => [[]],
+                'type' => 'object[]',
+                'custom' => [],
+                '__fields' => [
+                    'name' => [
+                        'name' => 'fields[].name',
+                        'description' => 'Field\'s name',
+                        'required' => true,
+                        'example' => 'experience',
+                        'type' => 'string',
+                        'custom' => [],
+                    ],
+                    'label' => [
+                        'name' => 'fields[].label',
+                        'description' => 'Field\'s label',
+                        'required' => true,
+                        'example' => 'Experience',
+                        'type' => 'string',
+                        'custom' => [],
+                    ],
+                    'type' => [
+                        'name' => 'fields[].type',
+                        'description' => 'Field\'s type',
+                        'required' => true,
+                        'example' => 'textarea',
+                        'type' => 'string',
+                        'custom' => [],
+                    ],
+                    'order' => [
+                        'name' => 'fields[].order',
+                        'description' => 'Field\'s order',
+                        'required' => true,
+                        'example' => 1,
+                        'type' => 'number',
+                        'custom' => [],
+                    ],
+                ],
             ],
         ];
     }

--- a/tests/Unit/WritingUtilsTest.php
+++ b/tests/Unit/WritingUtilsTest.php
@@ -79,9 +79,9 @@ class WritingUtilsTest extends BaseLaravelTest
     }
 
     /** @test */
-    public function get_sample_body()
+    public function get_sample_body_with_array_fields()
     {
-        $sampleBody = WritingUtils::getSampleBody($this->bodyParams());
+        $sampleBody = WritingUtils::getSampleBody($this->bodyParamsWithArrayFields());
 
         $expected = [
             'name' => 'Experience Form',
@@ -118,7 +118,7 @@ class WritingUtilsTest extends BaseLaravelTest
         ];
     }
 
-    private function bodyParams(): array
+    private function bodyParamsWithArrayFields(): array
     {
         return [
             'name' => [


### PR DESCRIPTION
Hi,

Fix sample body with an object of array. For example :

```php
    #[BodyParam('fields', 'object[]', 'Form\'s fields', required: false)]
    #[BodyParam('fields[].name', 'string', 'Field\'s name', required: true, example: 'experience')]
    #[BodyParam('fields[].label', 'string', 'Field\'s label', required: true, example: 'Expérience')]
    #[BodyParam('fields[].type', 'string', 'Field\'s type', required: true, example: 'textarea')]
    #[BodyParam('fields[].order', 'number', 'Field\'s order', required: true, example: 1)]
```

Before
```json
{
    "name": "Experience Form",
    "fields": {
        "name": "experience",
        "label": "Exp\u00e9rience",
        "type": "textarea",
        "order": 1
    }
}
```

After
```json
{
    "name": "Experience Form",
    "fields": [
        {
            "name": "experience",
            "label": "Exp\u00e9rience",
            "type": "textarea",
            "order": 1
        }
    ]
}
```