### PR TITLE
* auth.extra_info now propagates through to the security schema as de…

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -403,18 +403,18 @@ class OpenAPISpecWriter
 
         $location = $this->config->get('auth.in');
         $parameterName = $this->config->get('auth.name');
-
+        $description = $this->config->get('auth.extra_info');
         $scheme = match ($location) {
             'query', 'header' => [
                 'type' => 'apiKey',
                 'name' => $parameterName,
                 'in' => $location,
-                'description' => '',
+                'description' => $description,
             ],
             'bearer', 'basic' => [
                 'type' => 'http',
                 'scheme' => $location,
-                'description' => '',
+                'description' => $description,
             ],
             default => [],
         };

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -80,8 +80,14 @@ class OpenAPISpecWriterTest extends TestCase
         $endpointData1 = $this->createMockEndpointData(['uri' => 'path1', 'httpMethods' => ['GET'], 'metadata.authenticated' => true]);
         $endpointData2 = $this->createMockEndpointData(['uri' => 'path1', 'httpMethods' => ['POST'], 'metadata.authenticated' => false]);
         $groups = [$this->createGroup([$endpointData1, $endpointData2])];
-
-        $config = array_merge($this->config, ['auth' => ['enabled' => true, 'in' => 'bearer']]);
+        $extraInfo = "When stuck trying to authenticate, have a coffee!";
+        $config = array_merge($this->config, [
+            'auth' => [
+                'enabled' => true,
+                'in' => 'bearer',
+                'extra_info' => $extraInfo,
+            ],
+        ]);
         $writer = new OpenAPISpecWriter(new DocumentationConfig($config));
         $results = $writer->generateSpecContent($groups);
 
@@ -89,6 +95,7 @@ class OpenAPISpecWriterTest extends TestCase
         $this->assertArrayHasKey('default', $results['components']['securitySchemes']);
         $this->assertEquals('http', $results['components']['securitySchemes']['default']['type']);
         $this->assertEquals('bearer', $results['components']['securitySchemes']['default']['scheme']);
+        $this->assertEquals($extraInfo, $results['components']['securitySchemes']['default']['description']);
         $this->assertCount(1, $results['security']);
         $this->assertCount(1, $results['security'][0]);
         $this->assertArrayHasKey('default', $results['security'][0]);
@@ -97,13 +104,21 @@ class OpenAPISpecWriterTest extends TestCase
         $this->assertCount(0, $results['paths']['/path1']['post']['security']);
 
         // Next try: auth with a query parameter
-        $config = array_merge($this->config, ['auth' => ['enabled' => true, 'in' => 'query', 'name' => 'token']]);
+        $config = array_merge($this->config, [
+            'auth' => [
+                'enabled' => true,
+                'in' => 'query',
+                'name' => 'token',
+                'extra_info' => $extraInfo,
+            ],
+        ]);
         $writer = new OpenAPISpecWriter(new DocumentationConfig($config));
         $results = $writer->generateSpecContent($groups);
 
         $this->assertCount(1, $results['components']['securitySchemes']);
         $this->assertArrayHasKey('default', $results['components']['securitySchemes']);
         $this->assertEquals('apiKey', $results['components']['securitySchemes']['default']['type']);
+        $this->assertEquals($extraInfo, $results['components']['securitySchemes']['default']['description']);
         $this->assertEquals($config['auth']['name'], $results['components']['securitySchemes']['default']['name']);
         $this->assertEquals('query', $results['components']['securitySchemes']['default']['in']);
         $this->assertCount(1, $results['security']);


### PR DESCRIPTION
…scription

Please see the screenshots below of the openapi.yaml file

**Before**
<img width="275" alt="image" src="https://github.com/knuckleswtf/scribe/assets/23586974/89e3ce40-2953-4d2d-9517-774362007b0a">


**After**

<img width="462" alt="image" src="https://github.com/knuckleswtf/scribe/assets/23586974/624be483-9185-43fc-a45d-4cf22ae0361d">


