### PR TITLE
 * When not using dot notation, overrides no longer remove all the ch…

### DIFF
--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe\Writing;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
 use Knuckles\Scribe\Tools\DocumentationConfig;
@@ -127,7 +128,7 @@ class Writer
         $writer = app()->makeWith(PostmanCollectionWriter::class, ['config' => $this->config]);
 
         $collection = $writer->generatePostmanCollection($groupedEndpoints);
-        $overrides = $this->config->get('postman.overrides', []);
+        $overrides = Arr::dot($this->config->get('postman.overrides', []));
         if (count($overrides)) {
             foreach ($overrides as $key => $value) {
                 data_set($collection, $key, $value);
@@ -147,7 +148,7 @@ class Writer
         $writer = app()->makeWith(OpenAPISpecWriter::class, ['config' => $this->config]);
 
         $spec = $writer->generateSpecContent($groupedEndpoints);
-        $overrides = $this->config->get('openapi.overrides', []);
+        $overrides = Arr::dot($this->config->get('openapi.overrides', []));
         if (count($overrides)) {
             foreach ($overrides as $key => $value) {
                 data_set($spec, $key, $value);

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -13,7 +13,8 @@
     "_postman_id": "",
     "description": "",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "version": "3.9.9"
+    "version": "3.9.9",
+    "termsOfService": "http://api.api.dev/terms-of-service"
   },
   "item": [
     {

--- a/tests/Fixtures/openapi.yaml
+++ b/tests/Fixtures/openapi.yaml
@@ -3,6 +3,7 @@ info:
     title: Laravel
     description: ''
     version: 3.9.9
+    termsOfService: "http://api.api.dev/terms-of-service"
 servers:
     -
         url: 'http://localhost'

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -187,6 +187,9 @@ class OutputTest extends BaseLaravelTest
         config(['scribe.auth.enabled' => true]);
         config(['scribe.postman.overrides' => [
             'info.version' => '3.9.9',
+            'info' => [
+                'termsOfService' => 'http://api.api.dev/terms-of-service',
+            ],
         ]]);
         config([
             'scribe.routes.0.apply.headers' => [
@@ -221,6 +224,9 @@ class OutputTest extends BaseLaravelTest
         config(['scribe.openapi.enabled' => true]);
         config(['scribe.openapi.overrides' => [
             'info.version' => '3.9.9',
+            'info' => [
+                'termsOfService' => 'http://api.api.dev/terms-of-service',
+            ],
         ]]);
         config([
             'scribe.routes.0.apply.headers' => [


### PR DESCRIPTION
…ild keys in any parent array key. Instead, they are merged together.

**Note:** Dot notiation is still supported and I've also added support for the postman overrides too

Below i've put a screenshot of the overrides config and a before and after of the openapi.yaml file

**OVERRIDES**
<img width="361" alt="image" src="https://github.com/knuckleswtf/scribe/assets/23586974/859f7dc3-3bd4-4a5b-9f7a-847e39943c0d">

**BEFORE**
<img width="276" alt="image" src="https://github.com/knuckleswtf/scribe/assets/23586974/e6480e7a-4d1b-4dd6-98d3-787251275bc3">


**AFTER**

<img width="398" alt="image" src="https://github.com/knuckleswtf/scribe/assets/23586974/1ceec643-fbba-4ff2-9571-7ab63dcb47ab">




