### PR TITLE
 * Scribe now natively supports all info fields described here https:…

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -17,6 +17,38 @@ return [
     'description' => '',
 
     /*
+     * A URL to the Terms of Service for the API. This MUST be in the form of a URL.
+     * See https://swagger.io/specification/v3/#info-object for more info
+     */
+    'terms_of_service' => null,
+
+    /*
+     * Contact details for users of the Api to use to get more information or help.
+     * See https://swagger.io/specification/v3/#info-object for more info
+     */
+    'contact' => [
+        'name' => null,
+        'email' => null,
+        'url' => null,
+    ],
+
+    /*
+     * License information about who can use the api and to what extent
+     * See https://swagger.io/specification/v3/#info-object for more info
+     */
+    'license' => [
+        'name' => null,
+        'url' => null,
+    ],
+
+    /*
+     * The current version string of the api
+     * See https://swagger.io/specification/v3/#info-object for more info
+     */
+    'version' => null,
+
+
+    /*
      * The base URL displayed in the docs. If this is empty, Scribe will use the value of config('app.url') at generation time.
      * If you're using `laravel`` type, you can set this to a dynamic string, like '{{ config("app.tenant_url") }}' to get a dynamic base URL.
      */

--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -41,7 +41,10 @@ class OpenAPISpecWriter
             'info' => [
                 'title' => $this->config->get('title') ?: config('app.name', ''),
                 'description' => $this->config->get('description', ''),
-                'version' => '1.0.0',
+                'version' => $this->config->get('version', ''),
+                'termsOfService' => $this->config->get('terms_of_service', ''),
+                'contact' => $this->config->get('contact', []),
+                'license' => $this->config->get('license', []),
             ],
             'servers' => [
                 [

--- a/tests/Fixtures/openapi.yaml
+++ b/tests/Fixtures/openapi.yaml
@@ -3,6 +3,14 @@ info:
     title: Laravel
     description: ''
     version: 3.9.9
+    termsOfService: http://api.api.dev/terms-of-service
+    contact:
+        name: Scribe Support
+        email: support@scribe.test
+        url: https://scribe.knuckles.wtf/laravel
+    license:
+        name: MIT License
+        url: https://github.com/knuckleswtf/scribe/blob/master/LICENSE.md
 servers:
     -
         url: 'http://localhost'

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -219,6 +219,17 @@ class OutputTest extends BaseLaravelTest
         RouteFacade::get('/api/echoesUrlParameters/{param}/{param2}/{param3?}/{param4?}', [TestController::class, 'echoesUrlParameters']);
 
         config(['scribe.openapi.enabled' => true]);
+        config(['scribe.version' => '2.4.1']);
+        config(['scribe.terms_of_service' => 'http://api.api.dev/terms-of-service']);
+        config(['scribe.contact' => [
+            'name' => 'Scribe Support',
+            'email' => 'support@scribe.test',
+            'url' => 'https://scribe.knuckles.wtf/laravel',
+        ]]);
+        config(['scribe.license' => [
+            'name' => 'MIT License',
+            'url' => 'https://github.com/knuckleswtf/scribe/blob/master/LICENSE.md',
+        ]]);
         config(['scribe.openapi.overrides' => [
             'info.version' => '3.9.9',
         ]]);

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -22,6 +22,17 @@ class OpenAPISpecWriterTest extends TestCase
         'title' => 'My Testy Testes API',
         'description' => 'All about testy testes.',
         'base_url' => 'http://api.api.dev',
+        'version' => '2.4.1',
+        'terms_of_service' => 'http://api.api.dev/terms-of-service',
+        'contact' => [
+            'name' => 'Scribe Support',
+            'email' => 'support@scribe.test',
+            'url' => 'https://scribe.knuckles.wtf/laravel',
+        ],
+        'license' => [
+            'name' => 'MIT License',
+            'url' => 'https://github.com/knuckleswtf/scribe/blob/master/LICENSE.md',
+        ],
     ];
 
     /** @test */
@@ -36,7 +47,10 @@ class OpenAPISpecWriterTest extends TestCase
         $this->assertEquals(OpenAPISpecWriter::SPEC_VERSION, $results['openapi']);
         $this->assertEquals($this->config['title'], $results['info']['title']);
         $this->assertEquals($this->config['description'], $results['info']['description']);
-        $this->assertNotEmpty($results['info']['version']);
+        $this->assertEquals($this->config['contact'], $results['info']['contact']);
+        $this->assertEquals($this->config['version'], $results['info']['version']);
+        $this->assertEquals($this->config['license'], $results['info']['license']);
+        $this->assertEquals($this->config['terms_of_service'], $results['info']['termsOfService']);
         $this->assertEquals($this->config['base_url'], $results['servers'][0]['url']);
         $this->assertIsArray($results['paths']);
         $this->assertGreaterThan(0, count($results['paths']));


### PR DESCRIPTION
…//swagger.io/specification/#info-object

<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->


**New Config Variables**
<img width="885" alt="image" src="https://github.com/knuckleswtf/scribe/assets/23586974/08874771-ac2a-4b22-b401-dee9d65600bf">

**Before**
<img width="257" alt="image" src="https://github.com/knuckleswtf/scribe/assets/23586974/4d17b3bd-0b7e-4faf-955c-f57104e3b8cb">


**After**
<img width="627" alt="image" src="https://github.com/knuckleswtf/scribe/assets/23586974/a007049a-66c4-485a-a004-47d15c0e0c25">





