### PR TITLE
`groups.order` now supports `*` wildcard, so you can put groups at the end

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -317,7 +317,8 @@ INTRO
          * By default, Scribe will sort groups alphabetically, and endpoints in the order their routes are defined.
          * You can override this by listing the groups, subgroups and endpoints here in the order you want them.
          *
-         * Any groups, subgroups or endpoints you don't list here will be added as usual after the ones here.
+         * Any groups, subgroups or endpoints you don't list here will be added as usual after the ones here unless you
+         * use the "*" character as this specifies the position of all unspecified groups
          * If an endpoint/subgroup is listed under a group it doesn't belong in, it will be ignored.
          * Note: you must include the initial '/' when writing an endpoint.
          */


### PR DESCRIPTION
…to determine where in the ordering all unspecified groups will be placed.

Opening this one as a Draft so we can talk about implementation/config @shalvah. Hopefully this is a feaure Scribe can support. 

This PR is adding a feature which allows you to bury endpoints at the bottom of the list for example older versions that you don't want consumers going to first. 

This is done with the following config:

```php
return [
// ...top of config
        'order' => [
            'First Group',
            'Second Group',
            '*',
            'Last Group',
        ],
// ...rest of config
];
```

This will generate the groups like the screenshot below:

<img width="223" alt="image" src="https://github.com/knuckleswtf/scribe/assets/23586974/af524f9e-a548-4020-bf0e-6c91414efec2">

