### PR TITLE
Fixed enum values not displaying in nested objects

### DIFF
--- a/resources/views/components/nested-fields.blade.php
+++ b/resources/views/components/nested-fields.blade.php
@@ -67,7 +67,7 @@
                           'required' => $subfield['required'] ?? false,
                           'description' => $subfield['description'] ?? '',
                           'example' => $subfield['example'] ?? '',
-                          'enumValues' => $field['enumValues'] ?? null,
+                          'enumValues' => $subfield['enumValues'] ?? null,
                           'endpointId' => $endpointId,
                           'hasChildren' => false,
                           'component' => 'body',


### PR DESCRIPTION
If the request rule for an enum was inside a nested object field, it wouldn't display the values, as the template was using the wrong variable ($field instead of $subfield like it does for the rest of the component params)