### PR TITLE
Fixed parsing of nested fields in validation rules

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -145,9 +145,14 @@ trait ParsesValidationRules
         // Now this will return the complete ruleset.
         // Nested array parameters will be present, with '*' replaced by '0'
         $newRules = Validator::make($testData, $rules)->getRules();
-
-        // Transform the key names back from 'ids.0' to 'ids.*'
+       
         return collect($newRules)->mapWithKeys(function ($val, $paramName) use ($rules) {
+            // Transform the key names back from '__asterisk__' to '*'
+            if (Str::contains($paramName, '__asterisk__')) {
+                $paramName = str_replace('__asterisk__', '*', $paramName);
+            }
+
+            // Transform the key names back from 'ids.0' to 'ids.*'
             if (Str::contains($paramName, '.0')) {
                 $genericArrayKeyName = str_replace('.0', '.*', $paramName);
 

--- a/tests/Unit/ValidationRuleParsingTest.php
+++ b/tests/Unit/ValidationRuleParsingTest.php
@@ -110,6 +110,17 @@ class ValidationRuleParsingTest extends BaseLaravelTest
         $this->assertEquals('string[]', $results['array_of_objects_with_array[].another[].one.field1']['type']);
         $this->assertEquals('integer', $results['array_of_objects_with_array[].another[].one.field2']['type']);
         $this->assertEquals('number', $results['array_of_objects_with_array[].another[].two.field2']['type']);
+
+        $ruleset = [
+            '*.foo' => 'required|array',
+            '*.foo.*' => 'required|array',
+            '*.foo.*.bar' => 'required',
+        ];
+        $results = $this->strategy->parse($ruleset);
+        $this->assertCount(3, $results);
+        $this->assertEquals('object', $results['*']['type']);
+        $this->assertEquals('object[]', $results['*.foo']['type']);
+        $this->assertEquals('string', $results['*.foo[].bar']['type']);
     }
 
     public static function supportedRules()


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->
## Description
If there are nested fields in the request validation rules, the parsing is incorrect.
This PR fixes this, so that it also works when an array is expected, see examples below.


### Screenshots
Before the change
<img width="1290" alt="Bildschirmfoto 2023-10-16 um 03 12 22" src="https://github.com/knuckleswtf/scribe/assets/38925955/9cd628df-99dc-40e7-8d81-bb83b1f2356f">


After the change
<img width="1305" alt="Bildschirmfoto 2023-10-16 um 03 11 48" src="https://github.com/knuckleswtf/scribe/assets/38925955/ebb38509-e824-4e5b-b9c9-7619f42e0161">


## Example request class
```php
class ExampleRequest extends FormRequest
{
    public function rules()
    {
        return [
            '*.foo' => 'required|array',
            '*.foo.*' => 'required|array',
            '*.foo.*.bar' => 'required',
        ];
    }

    public function bodyParameters()
    {
        return [
            '*.foo' => [
                'description' => 'This is not shown (intended?).',
            ],
            '*.foo.*' => [
                'description' => 'A nested field.',
            ],
            '*.foo.*.bar' => [
                'description' => 'A double-nested field.',
            ],
        ];
    }
}
```
**Note:** The first description (of `*.foo` is ignored and will not be shown by scribe. I'm not sure if this is intended?


## Example request body
Single object example
```json
[
  {
    "foo": [
      {
        "bar": "hello world"
      }
    ]
  }
]
```

Multi object example
```json
[
  {
    "foo": [
      {
        "bar": "hello world"
      }
    ]
  },
  {
    "foo": [
      {
        "bar": "hallo welt"
      },
      {
        "bar": "hej världen"
      }
    ]
  }
]
```
