### PR TITLE
Include database-generated values on factory create

### DIFF
--- a/src/Extracting/InstantiatesExampleModels.php
+++ b/src/Extracting/InstantiatesExampleModels.php
@@ -69,7 +69,7 @@ trait InstantiatesExampleModels
     protected function getExampleModelFromFactoryCreate(string $type, array $factoryStates = [], array $relations = [])
     {
         $factory = Utils::getModelFactory($type, $factoryStates, $relations);
-        return $factory->create()->load($relations);
+        return $factory->create()->load($relations)->refresh();
     }
 
     /**


### PR DESCRIPTION
When creating a model from a factory, the initial result does not contain any values generated by the database. The `refresh` pulls the actual values from the database, thus including the values generated by the database.

