### PR TITLE
Support specifying `Example: null` in annotations

### DIFF
--- a/camel/Extraction/Parameter.php
+++ b/camel/Extraction/Parameter.php
@@ -13,7 +13,7 @@ class Parameter extends BaseDTO
     public mixed $example = null;
     public string $type = 'string';
     public array $enumValues = [];
-    public bool $hasExample = false;
+    public bool $exampleWasSpecified = false;
 
     public function __construct(array $parameters = [])
     {

--- a/camel/Extraction/Parameter.php
+++ b/camel/Extraction/Parameter.php
@@ -13,7 +13,7 @@ class Parameter extends BaseDTO
     public mixed $example = null;
     public string $type = 'string';
     public array $enumValues = [];
-    public bool $exampleExist = false;
+    public bool $hasExample = false;
 
     public function __construct(array $parameters = [])
     {

--- a/camel/Extraction/Parameter.php
+++ b/camel/Extraction/Parameter.php
@@ -13,6 +13,7 @@ class Parameter extends BaseDTO
     public mixed $example = null;
     public string $type = 'string';
     public array $enumValues = [];
+    public bool $exampleExist = false;
 
     public function __construct(array $parameters = [])
     {

--- a/src/Extracting/Extractor.php
+++ b/src/Extracting/Extractor.php
@@ -240,7 +240,7 @@ class Extractor
         foreach ($parameters as $paramName => $details) {
             
             // Remove params which have no intentional examples and are optional.
-            if (!$details->hasExample) {
+            if (!$details->exampleWasSpecified) {
                 if (is_null($details->example) && $details->required === false) {
                     continue;
                 }

--- a/src/Extracting/Extractor.php
+++ b/src/Extracting/Extractor.php
@@ -240,7 +240,7 @@ class Extractor
         foreach ($parameters as $paramName => $details) {
             
             // Remove params which have no intentional examples and are optional.
-            if (!$details->exampleExist) {
+            if (!$details->hasExample) {
                 if (is_null($details->example) && $details->required === false) {
                     continue;
                 }

--- a/src/Extracting/Extractor.php
+++ b/src/Extracting/Extractor.php
@@ -238,9 +238,12 @@ class Extractor
          * @var Parameter $details
          */
         foreach ($parameters as $paramName => $details) {
-            // Remove params which have no examples and are optional.
-            if (is_null($details->example) && $details->required === false) {
-                continue;
+            
+            // Remove params which have no intentional examples and are optional.
+            if (!$details->exampleExist) {
+                if (is_null($details->example) && $details->required === false) {
+                    continue;
+                }
             }
 
             if ($details->type === 'file') {

--- a/src/Extracting/ParamHelpers.php
+++ b/src/Extracting/ParamHelpers.php
@@ -236,12 +236,12 @@ trait ParamHelpers
      */
     protected function parseExampleFromParamDescription(string $description, string $type): array
     {
-        $exampleExist = false;
+        $hasExample = false;
         $example = null;
         $enumValues = [];
 
         if (preg_match('/(.*)\bExample:\s*([\s\S]+)\s*/s', $description, $content)) {
-            $exampleExist = true;
+            $hasExample = true;
             $description = trim($content[1]);
 
             if ($content[2] == 'null') {
@@ -262,6 +262,6 @@ trait ParamHelpers
             );
         }
 
-        return [$description, $example, $enumValues, $exampleExist];
+        return [$description, $example, $enumValues, $hasExample];
     }
 }

--- a/src/Extracting/ParamHelpers.php
+++ b/src/Extracting/ParamHelpers.php
@@ -236,14 +236,21 @@ trait ParamHelpers
      */
     protected function parseExampleFromParamDescription(string $description, string $type): array
     {
+        $exampleExist = false;
         $example = null;
         $enumValues = [];
 
         if (preg_match('/(.*)\bExample:\s*([\s\S]+)\s*/s', $description, $content)) {
+            $exampleExist = true;
             $description = trim($content[1]);
 
-            // Examples are parsed as strings by default, we need to cast them properly
-            $example = $this->castToType($content[2], $type);
+            if ($content[2] == 'null') {
+                // If we intentionally put null as example we return null as example
+                $example = null;
+            } else {
+                // Examples are parsed as strings by default, we need to cast them properly
+                $example = $this->castToType($content[2], $type);
+            }
         }
 
         if (preg_match('/(.*)\bEnum:\s*([\s\S]+)\s*/s', $description, $content)) {
@@ -255,6 +262,6 @@ trait ParamHelpers
             );
         }
 
-        return [$description, $example, $enumValues];
+        return [$description, $example, $enumValues, $exampleExist];
     }
 }

--- a/src/Extracting/ParamHelpers.php
+++ b/src/Extracting/ParamHelpers.php
@@ -236,12 +236,12 @@ trait ParamHelpers
      */
     protected function parseExampleFromParamDescription(string $description, string $type): array
     {
-        $hasExample = false;
+        $exampleWasSpecified = false;
         $example = null;
         $enumValues = [];
 
         if (preg_match('/(.*)\bExample:\s*([\s\S]+)\s*/s', $description, $content)) {
-            $hasExample = true;
+            $exampleWasSpecified = true;
             $description = trim($content[1]);
 
             if ($content[2] == 'null') {
@@ -262,6 +262,6 @@ trait ParamHelpers
             );
         }
 
-        return [$description, $example, $enumValues, $hasExample];
+        return [$description, $example, $enumValues, $exampleWasSpecified];
     }
 }

--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -655,14 +655,14 @@ trait ParsesValidationRules
         foreach ($parameters as $name => $details) {
             if (Str::endsWith($name, '.*')) {
                 // The user might have set the example via bodyParameters()
-                $hasExample = $this->examplePresent($details);
+                $exampleWasSpecified = $this->examplePresent($details);
 
                 // Change cars.*.dogs.things.*.* with type X to cars.*.dogs.things with type X[][]
                 while (Str::endsWith($name, '.*')) {
                     $details['type'] .= '[]';
                     $name = substr($name, 0, -2);
 
-                    if ($hasExample) {
+                    if ($exampleWasSpecified) {
                         $details['example'] = [$details['example']];
                     } else if (isset($details['setter'])) {
                         $previousSetter = $details['setter'];

--- a/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
@@ -33,9 +33,9 @@ class GetFromBodyParamTag extends GetFieldsFromTagStrategy
         }
 
         $type = static::normalizeTypeName($type);
-        [$description, $example, $enumValues, $hasExample] =
+        [$description, $example, $enumValues, $exampleWasSpecified] =
             $this->getDescriptionAndExample($description, $type, $tagContent, $name);
 
-        return compact('name', 'type', 'description', 'required', 'example', 'enumValues', 'hasExample');
+        return compact('name', 'type', 'description', 'required', 'example', 'enumValues', 'exampleWasSpecified');
     }
 }

--- a/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
@@ -33,9 +33,9 @@ class GetFromBodyParamTag extends GetFieldsFromTagStrategy
         }
 
         $type = static::normalizeTypeName($type);
-        [$description, $example, $enumValues, $exampleExist] =
+        [$description, $example, $enumValues, $hasExample] =
             $this->getDescriptionAndExample($description, $type, $tagContent, $name);
 
-        return compact('name', 'type', 'description', 'required', 'example', 'enumValues', 'exampleExist');
+        return compact('name', 'type', 'description', 'required', 'example', 'enumValues', 'hasExample');
     }
 }

--- a/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
@@ -33,9 +33,9 @@ class GetFromBodyParamTag extends GetFieldsFromTagStrategy
         }
 
         $type = static::normalizeTypeName($type);
-        [$description, $example, $enumValues] =
+        [$description, $example, $enumValues, $exampleExist] =
             $this->getDescriptionAndExample($description, $type, $tagContent, $name);
 
-        return compact('name', 'type', 'description', 'required', 'example', 'enumValues');
+        return compact('name', 'type', 'description', 'required', 'example', 'enumValues', 'exampleExist');
     }
 }

--- a/src/Extracting/Strategies/GetFieldsFromTagStrategy.php
+++ b/src/Extracting/Strategies/GetFieldsFromTagStrategy.php
@@ -37,15 +37,15 @@ abstract class GetFieldsFromTagStrategy extends TagStrategyWithFormRequestFallba
         string $description, string $type, string $tagContent, string $fieldName
     ): array
     {
-        [$description, $example, $enumValues, $hasExample] = $this->parseExampleFromParamDescription($description, $type);
+        [$description, $example, $enumValues, $exampleWasSpecified] = $this->parseExampleFromParamDescription($description, $type);
 
-        if($hasExample && $example === null) {
+        if($exampleWasSpecified && $example === null) {
             $example = null;
         } else {
             $example = $this->setExampleIfNeeded($example, $type, $tagContent, $fieldName, $enumValues);
         }
         
-        return [$description, $example, $enumValues, $hasExample];
+        return [$description, $example, $enumValues, $exampleWasSpecified];
     }
 
     protected function setExampleIfNeeded(

--- a/src/Extracting/Strategies/GetFieldsFromTagStrategy.php
+++ b/src/Extracting/Strategies/GetFieldsFromTagStrategy.php
@@ -37,8 +37,14 @@ abstract class GetFieldsFromTagStrategy extends TagStrategyWithFormRequestFallba
         string $description, string $type, string $tagContent, string $fieldName
     ): array
     {
-        [$description, $example, $enumValues] = $this->parseExampleFromParamDescription($description, $type);
-        $example = $this->setExampleIfNeeded($example, $type, $tagContent, $fieldName, $enumValues);
+        [$description, $example, $enumValues, $exampleExist] = $this->parseExampleFromParamDescription($description, $type);
+
+        if($exampleExist && $example === null) {
+            $example = null;
+        } else {
+            $example = $this->setExampleIfNeeded($example, $type, $tagContent, $fieldName, $enumValues);
+        }
+        
         return [$description, $example, $enumValues];
     }
 

--- a/src/Extracting/Strategies/GetFieldsFromTagStrategy.php
+++ b/src/Extracting/Strategies/GetFieldsFromTagStrategy.php
@@ -37,15 +37,15 @@ abstract class GetFieldsFromTagStrategy extends TagStrategyWithFormRequestFallba
         string $description, string $type, string $tagContent, string $fieldName
     ): array
     {
-        [$description, $example, $enumValues, $exampleExist] = $this->parseExampleFromParamDescription($description, $type);
+        [$description, $example, $enumValues, $hasExample] = $this->parseExampleFromParamDescription($description, $type);
 
-        if($exampleExist && $example === null) {
+        if($hasExample && $example === null) {
             $example = null;
         } else {
             $example = $this->setExampleIfNeeded($example, $type, $tagContent, $fieldName, $enumValues);
         }
         
-        return [$description, $example, $enumValues, $exampleExist];
+        return [$description, $example, $enumValues, $hasExample];
     }
 
     protected function setExampleIfNeeded(

--- a/src/Extracting/Strategies/GetFieldsFromTagStrategy.php
+++ b/src/Extracting/Strategies/GetFieldsFromTagStrategy.php
@@ -45,7 +45,7 @@ abstract class GetFieldsFromTagStrategy extends TagStrategyWithFormRequestFallba
             $example = $this->setExampleIfNeeded($example, $type, $tagContent, $fieldName, $enumValues);
         }
         
-        return [$description, $example, $enumValues];
+        return [$description, $example, $enumValues, $exampleExist];
     }
 
     protected function setExampleIfNeeded(

--- a/src/Extracting/Strategies/QueryParameters/GetFromQueryParamTag.php
+++ b/src/Extracting/Strategies/QueryParameters/GetFromQueryParamTag.php
@@ -63,9 +63,9 @@ class GetFromQueryParamTag extends GetFieldsFromTagStrategy
 
         }
 
-        [$description, $example, $enumValues] =
+        [$description, $example, $enumValues, $exampleExist] =
             $this->getDescriptionAndExample($description, $type, $tagContent, $name);
 
-        return compact('name', 'description', 'required', 'example', 'type', 'enumValues');
+        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'exampleExist');
     }
 }

--- a/src/Extracting/Strategies/QueryParameters/GetFromQueryParamTag.php
+++ b/src/Extracting/Strategies/QueryParameters/GetFromQueryParamTag.php
@@ -63,9 +63,9 @@ class GetFromQueryParamTag extends GetFieldsFromTagStrategy
 
         }
 
-        [$description, $example, $enumValues, $hasExample] =
+        [$description, $example, $enumValues, $exampleWasSpecified] =
             $this->getDescriptionAndExample($description, $type, $tagContent, $name);
 
-        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'hasExample');
+        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'exampleWasSpecified');
     }
 }

--- a/src/Extracting/Strategies/QueryParameters/GetFromQueryParamTag.php
+++ b/src/Extracting/Strategies/QueryParameters/GetFromQueryParamTag.php
@@ -63,9 +63,9 @@ class GetFromQueryParamTag extends GetFieldsFromTagStrategy
 
         }
 
-        [$description, $example, $enumValues, $exampleExist] =
+        [$description, $example, $enumValues, $hasExample] =
             $this->getDescriptionAndExample($description, $type, $tagContent, $name);
 
-        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'exampleExist');
+        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'hasExample');
     }
 }

--- a/src/Extracting/Strategies/UrlParameters/GetFromUrlParamTag.php
+++ b/src/Extracting/Strategies/UrlParameters/GetFromUrlParamTag.php
@@ -46,9 +46,9 @@ class GetFromUrlParamTag extends GetFieldsFromTagStrategy
                 : static::normalizeTypeName($type);
         }
 
-        [$description, $example, $enumValues, $hasExample] =
+        [$description, $example, $enumValues, $exampleWasSpecified] =
             $this->getDescriptionAndExample($description, $type, $tagContent, $name);
 
-        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'hasExample');
+        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'exampleWasSpecified');
     }
 }

--- a/src/Extracting/Strategies/UrlParameters/GetFromUrlParamTag.php
+++ b/src/Extracting/Strategies/UrlParameters/GetFromUrlParamTag.php
@@ -46,9 +46,9 @@ class GetFromUrlParamTag extends GetFieldsFromTagStrategy
                 : static::normalizeTypeName($type);
         }
 
-        [$description, $example, $enumValues, $exampleExist] =
+        [$description, $example, $enumValues, $hasExample] =
             $this->getDescriptionAndExample($description, $type, $tagContent, $name);
 
-        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'exampleExist');
+        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'hasExample');
     }
 }

--- a/src/Extracting/Strategies/UrlParameters/GetFromUrlParamTag.php
+++ b/src/Extracting/Strategies/UrlParameters/GetFromUrlParamTag.php
@@ -46,9 +46,9 @@ class GetFromUrlParamTag extends GetFieldsFromTagStrategy
                 : static::normalizeTypeName($type);
         }
 
-        [$description, $example, $enumValues] =
+        [$description, $example, $enumValues, $exampleExist] =
             $this->getDescriptionAndExample($description, $type, $tagContent, $name);
 
-        return compact('name', 'description', 'required', 'example', 'type', 'enumValues');
+        return compact('name', 'description', 'required', 'example', 'type', 'enumValues', 'exampleExist');
     }
 }

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -478,7 +478,7 @@ class OutputTest extends BaseLaravelTest
             'type' => 'integer',
             'enumValues' => [],
             'custom' => [],
-            'hasExample' => false,
+            'exampleWasSpecified' => false,
         ];
         $group['endpoints'][0]['urlParameters']['a_param'] = $extraParam;
         file_put_contents($firstGroupFilePath, Yaml::dump(

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -478,7 +478,7 @@ class OutputTest extends BaseLaravelTest
             'type' => 'integer',
             'enumValues' => [],
             'custom' => [],
-            'exampleExist' => false,
+            'hasExample' => false,
         ];
         $group['endpoints'][0]['urlParameters']['a_param'] = $extraParam;
         file_put_contents($firstGroupFilePath, Yaml::dump(

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -478,6 +478,7 @@ class OutputTest extends BaseLaravelTest
             'type' => 'integer',
             'enumValues' => [],
             'custom' => [],
+            'exampleExist' => false,
         ];
         $group['endpoints'][0]['urlParameters']['a_param'] = $extraParam;
         file_put_contents($firstGroupFilePath, Yaml::dump(

--- a/tests/Strategies/BodyParameters/GetFromBodyParamTagTest.php
+++ b/tests/Strategies/BodyParameters/GetFromBodyParamTagTest.php
@@ -127,6 +127,31 @@ class GetFromBodyParamTagTest extends TestCase
     }
 
     /** @test */
+    public function retains_null_as_example_if_specified()
+    {
+        $tags = [
+            new Tag('bodyParam', 'id int required The id to use. Leave null to autogenerate. Example: null'),
+            new Tag('bodyParam', 'key string A key. Example: null'),
+        ];
+        $results = $this->strategy->getFromTags($tags);
+
+        $this->assertArraySubset([
+            'id' => [
+                'type' => 'integer',
+                'required' => true,
+                'description' => 'The id to use. Leave null to autogenerate.',
+                'example' => null,
+            ],
+            'key' => [
+                'type' => 'string',
+                'required' => false,
+                'description' => 'A key.',
+                'example' => null,
+            ],
+        ], $results);
+    }
+
+    /** @test */
     public function can_fetch_from_bodyparam_tag_for_array_body()
     {
         $tags = [


### PR DESCRIPTION
Allow null parameter in the generation of API example specification

```
@bodyParam col_id integer required ID Example: null 
@bodyParam col_name string name Example: null
```

Example of use 
We want to put null value in the database.
We want to pass null as ID to create a new ID. //presence of parameter required
We want to pass null instead of '' string.