### PR TITLE
Allow config and temp directories to be configured independently.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# docker-compose up -d && docker logs -f scribe_app_1
+FROM ubuntu:jammy
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+# APT
+RUN apt-get -qq update && apt-get install -qq \
+    make \
+    curl \
+    php \
+    php-curl \
+    php-xml \
+    php-sqlite3 \
+    php-bcmath \
+    php-curl \
+    php-gd \
+    php-imagick \
+    php-intl \
+    php-mbstring \
+    php-pdo \
+    php-zip \
+    php-soap \
+    php-pcov \
+    git \
+    p7zip-full
+
+# Composer Install
+RUN curl -sS https://getcomposer.org/installer | php && \
+    mv composer.phar /usr/local/bin/composer

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+install:
+	composer install
+
+test: install
+	composer test-ci

--- a/camel/Camel.php
+++ b/camel/Camel.php
@@ -6,20 +6,21 @@ namespace Knuckles\Camel;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Knuckles\Camel\Output\OutputEndpointData;
+use Knuckles\Scribe\Configuration\CacheConfiguration;
 use Knuckles\Scribe\Tools\Utils;
 use Symfony\Component\Yaml\Yaml;
 
 
 class Camel
 {
-    public static function cacheDir(string $docsName = 'scribe'): string
+    public static function cacheDir(CacheConfiguration $docsObject): string
     {
-        return ".$docsName/endpoints.cache";
+        return $docsObject . "/endpoints.cache";
     }
 
-    public static function camelDir(string $docsName = 'scribe'): string
+    public static function camelDir(CacheConfiguration $docsObject): string
     {
-        return ".$docsName/endpoints";
+        return $docsObject . "/endpoints";
     }
 
     /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+# Allow devs to run the unit tests in a dockerized environment
+# clear && docker-compose up -d && docker logs -f scribe_app_1
+version: '3.7'
+services:
+    app:
+      build:
+        context: ./
+      volumes:
+        - ./:/testing
+      working_dir: /testing
+      command: make test

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -41,6 +41,7 @@
             <file>tests/Unit/ExtractorTest.php</file>
             <file>tests/Unit/ExtractorPluginSystemTest.php</file>
             <file>tests/Unit/ConfigDifferTest.php</file>
+            <file>tests/Unit/CacheConfigurationTest.php</file>
         </testsuite>
         <testsuite name="Unit Tests 2">
             <file>tests/Unit/ExtractedEndpointDataTest.php</file>

--- a/src/Configuration/CacheConfiguration.php
+++ b/src/Configuration/CacheConfiguration.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Knuckles\Scribe\Configuration;
+
+/**
+ * Decouple scribe config file name from the cache directory.
+ */
+class CacheConfiguration
+{
+    /** @var string */
+    private string $scribeConfig;
+
+    /** @var string */
+    private string $cacheDir;
+
+    /** @var bool */
+    private bool $isHidden;
+
+    /**
+     * @param string $cacheDir
+     * @param string $scribeConfig
+     * @param bool $isHidden
+     */
+    public function __construct(string $cacheDir, string$scribeConfig, bool $isHidden = true)
+    {
+        $this->cacheDir = $cacheDir;
+        $this->scribeConfig = $scribeConfig;
+        $this->isHidden = $isHidden;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScribeConfigFile(): string
+    {
+        return $this->scribeConfig;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return ($this->isHidden ? '.' : '') . $this->cacheDir;
+    }
+}

--- a/src/Extracting/ApiDetails.php
+++ b/src/Extracting/ApiDetails.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe\Extracting;
 
+use Knuckles\Scribe\Configuration\CacheConfiguration;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
 use Knuckles\Scribe\Tools\Utils as u;
 use Knuckles\Scribe\Tools\DocumentationConfig;
@@ -23,9 +24,9 @@ class ApiDetails
 
     private array $lastKnownFileContentHashes = [];
 
-    public function __construct(DocumentationConfig $config = null, bool $preserveUserChanges = true, string $docsName = 'scribe')
+    public function __construct(DocumentationConfig $config = null, bool $preserveUserChanges = true, CacheConfiguration $docsName)
     {
-        $this->markdownOutputPath = ".{$docsName}"; //.scribe by default
+        $this->markdownOutputPath = $docsName; //.scribe by default
         // If no config is injected, pull from global. Makes testing easier.
         $this->config = $config ?: new DocumentationConfig(config($docsName));
         $this->baseUrl = $this->config->get('base_url') ?? config('app.url');

--- a/src/GroupedEndpoints/GroupedEndpointsFactory.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFactory.php
@@ -3,12 +3,16 @@
 namespace Knuckles\Scribe\GroupedEndpoints;
 
 use Knuckles\Scribe\Commands\GenerateDocumentation;
+use Knuckles\Scribe\Configuration\CacheConfiguration;
 use Knuckles\Scribe\Matching\RouteMatcherInterface;
 
 class GroupedEndpointsFactory
 {
-    public function make(GenerateDocumentation $command, RouteMatcherInterface $routeMatcher, string $docsName = 'scribe'): GroupedEndpointsContract
-    {
+    public function make(
+        GenerateDocumentation $command,
+        RouteMatcherInterface $routeMatcher,
+        CacheConfiguration $docsName
+    ): GroupedEndpointsContract {
         if ($command->isForcing()) {
             return static::fromApp($command, $routeMatcher, false, $docsName);
         }
@@ -24,12 +28,12 @@ class GroupedEndpointsFactory
         GenerateDocumentation $command,
         RouteMatcherInterface $routeMatcher,
         bool $preserveUserChanges,
-        string $docsName = 'scribe'
+        CacheConfiguration $docsName
     ): GroupedEndpointsFromApp {
         return new GroupedEndpointsFromApp($command, $routeMatcher, $preserveUserChanges, $docsName);
     }
 
-    public static function fromCamelDir(string $docsName = 'scribe'): GroupedEndpointsFromCamelDir
+    public static function fromCamelDir(CacheConfiguration $docsName): GroupedEndpointsFromCamelDir
     {
         return new GroupedEndpointsFromCamelDir($docsName);
     }

--- a/src/GroupedEndpoints/GroupedEndpointsFromApp.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFromApp.php
@@ -10,6 +10,7 @@ use Knuckles\Camel\Camel;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Camel\Output\OutputEndpointData;
 use Knuckles\Scribe\Commands\GenerateDocumentation;
+use Knuckles\Scribe\Configuration\CacheConfiguration;
 use Knuckles\Scribe\Exceptions\CouldntGetRouteDetails;
 use Knuckles\Scribe\Extracting\ApiDetails;
 use Knuckles\Scribe\Extracting\Extractor;
@@ -34,10 +35,11 @@ class GroupedEndpointsFromApp implements GroupedEndpointsContract
     public static string $cacheDir;
 
     public function __construct(
-        private GenerateDocumentation $command, private RouteMatcherInterface $routeMatcher,
-        private bool $preserveUserChanges = true, protected string $docsName = 'scribe'
-    )
-    {
+        private GenerateDocumentation $command,
+        private RouteMatcherInterface $routeMatcher,
+        private bool $preserveUserChanges = true,
+        protected CacheConfiguration $docsName
+    ) {
         $this->docConfig = $command->getDocConfig();
 
         static::$camelDir = Camel::camelDir($this->docsName);

--- a/src/GroupedEndpoints/GroupedEndpointsFromCamelDir.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFromCamelDir.php
@@ -3,12 +3,13 @@
 namespace Knuckles\Scribe\GroupedEndpoints;
 
 use Knuckles\Camel\Camel;
+use Knuckles\Scribe\Configuration\CacheConfiguration;
 
 class GroupedEndpointsFromCamelDir implements GroupedEndpointsContract
 {
-    protected string $docsName;
+    protected CacheConfiguration $docsName;
 
-    public function __construct(string $docsName = 'scribe')
+    public function __construct(CacheConfiguration $docsName)
     {
         $this->docsName = $docsName;
     }

--- a/tests/Unit/CacheConfigurationTest.php
+++ b/tests/Unit/CacheConfigurationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Unit;
+
+use Knuckles\Scribe\Configuration\CacheConfiguration;
+use PHPUnit\Framework\TestCase;
+
+class CacheConfigurationTest extends TestCase
+{
+    /** @test */
+    public function object_coerses_into_hidden_string()
+    {
+        $cacheConfiguration = new CacheConfiguration('scribe', 'scribe', true);
+        $this->assertEquals('.scribe', $cacheConfiguration);
+    }
+
+    /** @test */
+    public function object_coerses_into_non_hidden_string()
+    {
+        $cacheConfiguration = new CacheConfiguration('scribe', 'scribe', false);
+        $this->assertEquals('scribe', $cacheConfiguration);
+    }
+
+    /** @test */
+    public function object_coerses_into_hidden_string_for_subdirs()
+    {
+        $cacheConfiguration = new CacheConfiguration('scribe/bob', 'scribe', true);
+        $this->assertEquals('.scribe/bob', $cacheConfiguration);
+    }
+
+    /** @test */
+    public function object_coerses_into_non_hidden_string_for_subdirs()
+    {
+        $cacheConfiguration = new CacheConfiguration('scribe/bob/dave', 'scribe', false);
+        $this->assertEquals('scribe/bob/dave', $cacheConfiguration);
+    }
+}


### PR DESCRIPTION
### Whats changed?

- **Added** the ability to configure the `scribe.php` (or custom php config file) independently of the temp directory.
- **Added** a `docker-compose` setup to allow others to quickly run the test suite on their local machines without needing to install the test stack onto their environment.

### How do I run the tests in the new docker container?
- Simply run `clear && docker-compose up -d && docker logs -f scribe_app_1` and the tests are run and results printed into your terminal!