### PR TITLE
Add a `docker-compose` setup to allow others to quickly run the test suite on their local machines.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# docker-compose up -d && docker logs -f scribe_app_1
+FROM ubuntu:jammy
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+# APT
+RUN apt-get -qq update && apt-get install -qq \
+    make \
+    curl \
+    php \
+    php-curl \
+    php-xml \
+    php-sqlite3 \
+    php-bcmath \
+    php-curl \
+    php-gd \
+    php-imagick \
+    php-intl \
+    php-mbstring \
+    php-pdo \
+    php-zip \
+    php-soap \
+    php-pcov \
+    git \
+    p7zip-full
+
+# Composer Install
+RUN curl -sS https://getcomposer.org/installer | php && \
+    mv composer.phar /usr/local/bin/composer

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+install:
+	composer install
+
+test: install
+	composer test-ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+# Allow devs to run the unit tests in a dockerized environment
+# clear && docker-compose up -d && docker logs -f scribe_app_1
+version: '3.7'
+services:
+    app:
+      build:
+        context: ./
+      volumes:
+        - ./:/testing
+      working_dir: /testing
+      command: make test


### PR DESCRIPTION
### Whats changed?
- **Added** a `docker-compose` setup to allow others to quickly run the test suite on their local machines without needing to install the test stack onto their environment.

### How do I run the tests in the new docker container?
- Simply run `clear && docker-compose up -d && docker logs -f scribe_app_1` and the tests are run and results printed into your terminal!