### PR TITLE
Allow config and temp directories to be configured independently.

### DIFF
--- a/camel/Camel.php
+++ b/camel/Camel.php
@@ -15,12 +15,12 @@ class Camel
 {
     public static function cacheDir(PathConfig $pathConfiguration): string
     {
-        return $pathConfiguration->getTemporaryDirectoryPath() . "/endpoints.cache";
+        return $pathConfiguration->getTemporaryDirectoryPath('endpoints.cache');
     }
 
     public static function camelDir(PathConfig $pathConfiguration): string
     {
-        return $pathConfiguration->getTemporaryDirectoryPath() . "/endpoints";
+        return $pathConfiguration->getTemporaryDirectoryPath('endpoints');
     }
 
     /**

--- a/camel/Camel.php
+++ b/camel/Camel.php
@@ -6,20 +6,21 @@ namespace Knuckles\Camel;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Knuckles\Camel\Output\OutputEndpointData;
+use Knuckles\Scribe\Configuration\PathConfig;
 use Knuckles\Scribe\Tools\Utils;
 use Symfony\Component\Yaml\Yaml;
 
 
 class Camel
 {
-    public static function cacheDir(string $docsName = 'scribe'): string
+    public static function cacheDir(PathConfig $pathConfiguration): string
     {
-        return ".$docsName/endpoints.cache";
+        return $pathConfiguration->getTemporaryDirectoryPath() . "/endpoints.cache";
     }
 
-    public static function camelDir(string $docsName = 'scribe'): string
+    public static function camelDir(PathConfig $pathConfiguration): string
     {
-        return ".$docsName/endpoints";
+        return $pathConfiguration->getTemporaryDirectoryPath() . "/endpoints";
     }
 
     /**

--- a/camel/Camel.php
+++ b/camel/Camel.php
@@ -13,14 +13,14 @@ use Symfony\Component\Yaml\Yaml;
 
 class Camel
 {
-    public static function cacheDir(PathConfig $pathConfiguration): string
+    public static function cacheDir(PathConfig $paths): string
     {
-        return $pathConfiguration->getTemporaryDirectoryPath('endpoints.cache');
+        return $paths->intermediateOutputPath('endpoints.cache');
     }
 
-    public static function camelDir(PathConfig $pathConfiguration): string
+    public static function camelDir(PathConfig $paths): string
     {
-        return $pathConfiguration->getTemporaryDirectoryPath('endpoints');
+        return $paths->intermediateOutputPath('endpoints');
     }
 
     /**

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -41,6 +41,7 @@
             <file>tests/Unit/ExtractorTest.php</file>
             <file>tests/Unit/ExtractorPluginSystemTest.php</file>
             <file>tests/Unit/ConfigDifferTest.php</file>
+            <file>tests/Unit/PathConfigurationTest.php</file>
         </testsuite>
         <testsuite name="Unit Tests 2">
             <file>tests/Unit/ExtractedEndpointDataTest.php</file>

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -24,8 +24,8 @@ class GenerateDocumentation extends Command
                             {--force : Discard any changes you've made to the YAML or Markdown files}
                             {--no-extraction : Skip extraction of route and API info and just transform the YAML and Markdown files into HTML}
                             {--no-upgrade-check : Skip checking for config file upgrades. Won't make things faster, but can be helpful if the command is buggy}
-                            {--config=scribe : choose which config file to use}
-                            {--cache-dir= : choose which cache directory to use}
+                            {--config=scribe : Choose which config file to use}
+                            {--scribe-dir= : Specify the directory where Scribe stores its intermediate output and cache. Defaults to `.<config_file>`}
     ";
 
     protected $description = 'Generate API documentation from your Laravel/Dingo routes.';
@@ -106,9 +106,9 @@ class GenerateDocumentation extends Command
         }
 
         $this->paths = new PathConfig(configName: $configName);
-        if ($this->hasOption('cache-dir') && !empty($this->option('cache-dir'))) {
+        if ($this->hasOption('scribe-dir') && !empty($this->option('scribe-dir'))) {
             $this->paths = new PathConfig(
-                configName: $configName, cacheDir: $this->option('cache-dir')
+                configName: $configName, scribeDir: $this->option('scribe-dir')
             );
         }
 

--- a/src/Commands/GenerateDocumentation.php
+++ b/src/Commands/GenerateDocumentation.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Knuckles\Camel\Camel;
+use Knuckles\Scribe\Configuration\PathConfig;
 use Knuckles\Scribe\GroupedEndpoints\GroupedEndpointsFactory;
 use Knuckles\Scribe\Matching\RouteMatcherInterface;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
@@ -24,6 +25,7 @@ class GenerateDocumentation extends Command
                             {--no-extraction : Skip extraction of route and API info and just transform the YAML and Markdown files into HTML}
                             {--no-upgrade-check : Skip checking for config file upgrades. Won't make things faster, but can be helpful if the command is buggy}
                             {--config=scribe : choose which config file to use}
+                            {--cache-directory= : choose which cache directory to use}
     ";
 
     protected $description = 'Generate API documentation from your Laravel/Dingo routes.';
@@ -34,7 +36,8 @@ class GenerateDocumentation extends Command
 
     protected bool $forcing;
 
-    protected string $configName;
+    /** @var PathConfig  */
+    protected PathConfig $pathConfiguration;
 
     public function handle(RouteMatcherInterface $routeMatcher, GroupedEndpointsFactory $groupedEndpointsFactory): void
     {
@@ -47,9 +50,9 @@ class GenerateDocumentation extends Command
         }
 
         // Extraction stage - extract endpoint info either from app or existing Camel files (previously extracted data)
-        $groupedEndpointsInstance = $groupedEndpointsFactory->make($this, $routeMatcher, $this->configName);
+        $groupedEndpointsInstance = $groupedEndpointsFactory->make($this, $routeMatcher, $this->pathConfiguration);
         $extractedEndpoints = $groupedEndpointsInstance->get();
-        $userDefinedEndpoints = Camel::loadUserDefinedEndpoints(Camel::camelDir($this->configName));
+        $userDefinedEndpoints = Camel::loadUserDefinedEndpoints(Camel::camelDir($this->pathConfiguration));
         $groupedEndpoints = $this->mergeUserDefinedEndpoints($extractedEndpoints, $userDefinedEndpoints);
 
         // Output stage
@@ -61,7 +64,7 @@ class GenerateDocumentation extends Command
             $this->writeExampleCustomEndpoint();
         }
 
-        $writer = new Writer($this->docConfig, $this->configName);
+        $writer = new Writer($this->docConfig, $this->pathConfiguration);
         $writer->writeDocs($groupedEndpoints);
 
         $this->upgradeConfigFileIfNeeded();
@@ -98,12 +101,17 @@ class GenerateDocumentation extends Command
 
         c::bootstrapOutput($this->output);
 
-        $this->configName = $this->option('config');
-        if (!config($this->configName)) {
-            throw new \InvalidArgumentException("The specified config (config/{$this->configName}.php) doesn't exist.");
+        $configName = $this->option('config');
+        if (!config($configName)) {
+            throw new \InvalidArgumentException("The specified config (config/{$configName}.php) doesn't exist.");
         }
 
-        $this->docConfig = new DocumentationConfig(config($this->configName));
+        $this->pathConfiguration = new PathConfig($configName, $configName, true);
+        if ($this->hasOption('cache-directory') && !empty($this->option('cache-directory'))) {
+            $this->pathConfiguration = new PathConfig($this->option('cache-directory'), $configName, false);
+        }
+
+        $this->docConfig = new DocumentationConfig(config($this->pathConfiguration->getScribeConfigurationPath()));
 
         // Force root URL so it works in Postman collection
         $baseUrl = $this->docConfig->get('base_url') ?? config('app.url');
@@ -146,7 +154,7 @@ class GenerateDocumentation extends Command
     protected function writeExampleCustomEndpoint(): void
     {
         // We add an example to guide users in case they need to add a custom endpoint.
-        copy(__DIR__ . '/../../resources/example_custom_endpoint.yaml', Camel::camelDir($this->configName) . '/custom.0.yaml');
+        copy(__DIR__ . '/../../resources/example_custom_endpoint.yaml', Camel::camelDir($this->pathConfiguration) . '/custom.0.yaml');
     }
 
     protected function upgradeConfigFileIfNeeded(): void
@@ -155,12 +163,12 @@ class GenerateDocumentation extends Command
 
         $this->info("Checking for any pending upgrades to your config file...");
         try {
-            if (! $this->laravel['files']->exists($this->laravel->configPath("{$this->configName}.php"))) {
+            if (! $this->laravel['files']->exists($this->laravel->configPath($this->pathConfiguration->getScribeConfigurationPath('php', '.')))) {
                 $this->info("No config file to upgrade.");
                 return;
             }
 
-            $upgrader = Upgrader::ofConfigFile("config/{$this->configName}.php", __DIR__ . '/../../config/scribe.php')
+            $upgrader = Upgrader::ofConfigFile("config/" . $this->pathConfiguration->getScribeConfigurationPath('php', '.'), __DIR__ . '/../../config/scribe.php')
                 ->dontTouch(
                     'routes', 'example_languages', 'database_connections_to_transact', 'strategies', 'laravel.middleware',
                     'postman.overrides', 'openapi.overrides', 'groups', 'examples.models_source'

--- a/src/Commands/Upgrade.php
+++ b/src/Commands/Upgrade.php
@@ -103,7 +103,7 @@ class Upgrade extends Command
         $this->info("We'll automatically import your current sorting into the config item `groups.order`.");
 
         $defaultGroup = config($this->configName.".default_group");
-        $pathConfig = new PathConfig($this->configName, $this->configName, true);
+        $pathConfig = new PathConfig($this->configName);
         $extractedEndpoints = GroupedEndpointsFactory::fromCamelDir($pathConfig)->get();
 
         $order = array_map(function (array $group) {

--- a/src/Commands/Upgrade.php
+++ b/src/Commands/Upgrade.php
@@ -4,6 +4,7 @@ namespace Knuckles\Scribe\Commands;
 
 use Illuminate\Console\Command;
 use Knuckles\Camel\Camel;
+use Knuckles\Scribe\Configuration\PathConfig;
 use Knuckles\Scribe\GroupedEndpoints\GroupedEndpointsFactory;
 use Knuckles\Scribe\Scribe;
 use Shalvah\Upgrader\Upgrader;
@@ -102,7 +103,8 @@ class Upgrade extends Command
         $this->info("We'll automatically import your current sorting into the config item `groups.order`.");
 
         $defaultGroup = config($this->configName.".default_group");
-        $extractedEndpoints = GroupedEndpointsFactory::fromCamelDir($this->configName)->get();
+        $pathConfig = new PathConfig($this->configName, $this->configName, true);
+        $extractedEndpoints = GroupedEndpointsFactory::fromCamelDir($pathConfig)->get();
 
         $order = array_map(function (array $group) {
             return array_map(function (array $endpoint) {
@@ -112,7 +114,7 @@ class Upgrade extends Command
         $groupsOrder = array_keys($order);
         $keyIndices = array_flip($groupsOrder);
 
-        $userDefinedEndpoints = Camel::loadUserDefinedEndpoints(Camel::camelDir($this->configName));
+        $userDefinedEndpoints = Camel::loadUserDefinedEndpoints(Camel::camelDir($pathConfig));
 
         if ($userDefinedEndpoints) {
             foreach ($userDefinedEndpoints as $endpoint) {

--- a/src/Configuration/PathConfig.php
+++ b/src/Configuration/PathConfig.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Knuckles\Scribe\Configuration;
+
+/**
+ * A home for path configurations.
+ */
+class PathConfig
+{
+    /** @var string */
+    private string $scribeConfig;
+
+    /** @var string */
+    private string $cacheDir;
+
+    /** @var bool */
+    private bool $isHidden;
+
+    /**
+     * @param string $cacheDir
+     * @param string $scribeConfig
+     * @param bool $isHidden
+     */
+    public function __construct(string $cacheDir, string$scribeConfig, bool $isHidden = true)
+    {
+        $this->cacheDir = $cacheDir;
+        $this->scribeConfig = $scribeConfig;
+        $this->isHidden = $isHidden;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScribeConfigurationPath(string $resolvePath = null, string $separator = '/'): string
+    {
+        if (is_null($resolvePath)) {
+            return $this->scribeConfig;
+        }
+        // Separate the path with a /
+        return sprintf("%s%s%s", $this->scribeConfig, $separator, $resolvePath);
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemporaryDirectoryPath(string $resolvePath = null): string
+    {
+        $path = ($this->isHidden ? '.' : '') . $this->cacheDir;
+        if (is_null($resolvePath)) {
+            return $path;
+        }
+        // Separate the path with a /
+        return sprintf("%s/%s", $path, $resolvePath);
+
+    }
+}

--- a/src/Configuration/PathConfig.php
+++ b/src/Configuration/PathConfig.php
@@ -21,7 +21,7 @@ class PathConfig
      * @param string $scribeConfig
      * @param bool $isHidden
      */
-    public function __construct(string $cacheDir, string$scribeConfig, bool $isHidden = true)
+    public function __construct(string $cacheDir, string $scribeConfig, bool $isHidden = true)
     {
         $this->cacheDir = $cacheDir;
         $this->scribeConfig = $scribeConfig;
@@ -29,6 +29,10 @@ class PathConfig
     }
 
     /**
+     * Path to the scribe.php (default) or otherwise named configuration file.
+     *
+     * @param string|null $resolvePath
+     * @param string $separator
      * @return string
      */
     public function getScribeConfigurationPath(string $resolvePath = null, string $separator = '/'): string
@@ -36,21 +40,25 @@ class PathConfig
         if (is_null($resolvePath)) {
             return $this->scribeConfig;
         }
-        // Separate the path with a /
+        // Separate the path with a / (default) or an override via $separator
         return sprintf("%s%s%s", $this->scribeConfig, $separator, $resolvePath);
     }
 
     /**
+     * Get the path to the .scribe (default) or otherwise named temporary file path.
+     *
+     * @param string|null $resolvePath
+     * @param string $separator
      * @return string
      */
-    public function getTemporaryDirectoryPath(string $resolvePath = null): string
+    public function getTemporaryDirectoryPath(string $resolvePath = null, string $separator = '/'): string
     {
         $path = ($this->isHidden ? '.' : '') . $this->cacheDir;
         if (is_null($resolvePath)) {
             return $path;
         }
-        // Separate the path with a /
-        return sprintf("%s/%s", $path, $resolvePath);
+        // Separate the path with a / (default) or an override via $separator
+        return sprintf("%s%s%s", $path, $separator, $resolvePath);
 
     }
 }

--- a/src/Configuration/PathConfig.php
+++ b/src/Configuration/PathConfig.php
@@ -9,11 +9,13 @@ class PathConfig
 {
     public function __construct(
         public string     $configName = 'scribe',
-        protected ?string $cacheDir = null
+        // FOr lack of a better name, we'll call this `scribeDir`.
+        // It's sort of the cache dir, where Scribe stores its intermediate outputs.
+        protected ?string $scribeDir = null
     )
     {
-        if (is_null($this->cacheDir)) {
-            $this->cacheDir = ".{$this->configName}";
+        if (is_null($this->scribeDir)) {
+            $this->scribeDir = ".{$this->configName}";
         }
     }
 
@@ -37,9 +39,9 @@ class PathConfig
     public function intermediateOutputPath(string $resolvePath = null, string $separator = '/'): string
     {
         if (is_null($resolvePath)) {
-            return $this->cacheDir;
+            return $this->scribeDir;
         }
 
-        return "{$this->cacheDir}{$separator}{$resolvePath}";
+        return "{$this->scribeDir}{$separator}{$resolvePath}";
     }
 }

--- a/src/Configuration/PathConfig.php
+++ b/src/Configuration/PathConfig.php
@@ -3,62 +3,43 @@
 namespace Knuckles\Scribe\Configuration;
 
 /**
- * A home for path configurations.
+ * A home for path configurations. The important paths Scribe depends on.
  */
 class PathConfig
 {
-    /** @var string */
-    private string $scribeConfig;
-
-    /** @var string */
-    private string $cacheDir;
-
-    /** @var bool */
-    private bool $isHidden;
-
-    /**
-     * @param string $cacheDir
-     * @param string $scribeConfig
-     * @param bool $isHidden
-     */
-    public function __construct(string $cacheDir, string $scribeConfig, bool $isHidden = true)
+    public function __construct(
+        public string     $configName = 'scribe',
+        protected ?string $cacheDir = null
+    )
     {
-        $this->cacheDir = $cacheDir;
-        $this->scribeConfig = $scribeConfig;
-        $this->isHidden = $isHidden;
+        if (is_null($this->cacheDir)) {
+            $this->cacheDir = ".{$this->configName}";
+        }
+    }
+
+    public function outputPath(string $resolvePath = null, string $separator = '/'): string
+    {
+        if (is_null($resolvePath)) {
+            return $this->configName;
+        }
+
+        return "{$this->configName}{$separator}{$resolvePath}";
+    }
+
+    public function configFileName(): string
+    {
+        return "{$this->configName}.php";
     }
 
     /**
-     * Path to the scribe.php (default) or otherwise named configuration file.
-     *
-     * @param string|null $resolvePath
-     * @param string $separator
-     * @return string
+     * The directory where Scribe writes its intermediate output (default is .<config> ie .scribe)
      */
-    public function getScribeConfigurationPath(string $resolvePath = null, string $separator = '/'): string
+    public function intermediateOutputPath(string $resolvePath = null, string $separator = '/'): string
     {
         if (is_null($resolvePath)) {
-            return $this->scribeConfig;
+            return $this->cacheDir;
         }
-        // Separate the path with a / (default) or an override via $separator
-        return sprintf("%s%s%s", $this->scribeConfig, $separator, $resolvePath);
-    }
 
-    /**
-     * Get the path to the .scribe (default) or otherwise named temporary file path.
-     *
-     * @param string|null $resolvePath
-     * @param string $separator
-     * @return string
-     */
-    public function getTemporaryDirectoryPath(string $resolvePath = null, string $separator = '/'): string
-    {
-        $path = ($this->isHidden ? '.' : '') . $this->cacheDir;
-        if (is_null($resolvePath)) {
-            return $path;
-        }
-        // Separate the path with a / (default) or an override via $separator
-        return sprintf("%s%s%s", $path, $separator, $resolvePath);
-
+        return "{$this->cacheDir}{$separator}{$resolvePath}";
     }
 }

--- a/src/Extracting/ApiDetails.php
+++ b/src/Extracting/ApiDetails.php
@@ -36,7 +36,7 @@ class ApiDetails
     ) {
         $this->markdownOutputPath = $pathConfig->getTemporaryDirectoryPath(); //.scribe by default
         // If no config is injected, pull from global. Makes testing easier.
-        $this->config = $config ?: new DocumentationConfig(config($pathConfig));
+        $this->config = $config ?: new DocumentationConfig(config($pathConfig->getScribeConfigurationPath()));
         $this->baseUrl = $this->config->get('base_url') ?? config('app.url');
         $this->preserveUserChanges = $preserveUserChanges;
 

--- a/src/Extracting/ApiDetails.php
+++ b/src/Extracting/ApiDetails.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe\Extracting;
 
+use Knuckles\Scribe\Configuration\PathConfig;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
 use Knuckles\Scribe\Tools\Utils as u;
 use Knuckles\Scribe\Tools\DocumentationConfig;
@@ -23,11 +24,19 @@ class ApiDetails
 
     private array $lastKnownFileContentHashes = [];
 
-    public function __construct(DocumentationConfig $config = null, bool $preserveUserChanges = true, string $docsName = 'scribe')
-    {
-        $this->markdownOutputPath = ".{$docsName}"; //.scribe by default
+    /**
+     * @param PathConfig $pathConfig
+     * @param DocumentationConfig|null $config
+     * @param bool $preserveUserChanges
+     */
+    public function __construct(
+        PathConfig          $pathConfig,
+        DocumentationConfig $config = null,
+        bool                $preserveUserChanges = true
+    ) {
+        $this->markdownOutputPath = $pathConfig->getTemporaryDirectoryPath(); //.scribe by default
         // If no config is injected, pull from global. Makes testing easier.
-        $this->config = $config ?: new DocumentationConfig(config($docsName));
+        $this->config = $config ?: new DocumentationConfig(config($pathConfig));
         $this->baseUrl = $this->config->get('base_url') ?? config('app.url');
         $this->preserveUserChanges = $preserveUserChanges;
 

--- a/src/Extracting/ApiDetails.php
+++ b/src/Extracting/ApiDetails.php
@@ -24,19 +24,14 @@ class ApiDetails
 
     private array $lastKnownFileContentHashes = [];
 
-    /**
-     * @param PathConfig $pathConfig
-     * @param DocumentationConfig|null $config
-     * @param bool $preserveUserChanges
-     */
     public function __construct(
-        PathConfig          $pathConfig,
+        PathConfig          $paths,
         DocumentationConfig $config = null,
         bool                $preserveUserChanges = true
     ) {
-        $this->markdownOutputPath = $pathConfig->getTemporaryDirectoryPath(); //.scribe by default
+        $this->markdownOutputPath = $paths->intermediateOutputPath(); //.scribe by default
         // If no config is injected, pull from global. Makes testing easier.
-        $this->config = $config ?: new DocumentationConfig(config($pathConfig->getScribeConfigurationPath()));
+        $this->config = $config ?: new DocumentationConfig(config($paths->configName));
         $this->baseUrl = $this->config->get('base_url') ?? config('app.url');
         $this->preserveUserChanges = $preserveUserChanges;
 

--- a/src/GroupedEndpoints/GroupedEndpointsFactory.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFactory.php
@@ -8,50 +8,43 @@ use Knuckles\Scribe\Matching\RouteMatcherInterface;
 
 class GroupedEndpointsFactory
 {
-    /**
-     * @param GenerateDocumentation $command
-     * @param RouteMatcherInterface $routeMatcher
-     * @param PathConfig $pathConfig
-     * @return GroupedEndpointsContract
-     */
     public function make(
         GenerateDocumentation $command,
         RouteMatcherInterface $routeMatcher,
-        PathConfig $pathConfig
+        PathConfig $paths
     ): GroupedEndpointsContract {
         if ($command->isForcing()) {
-            return static::fromApp($command, $routeMatcher, false, $pathConfig);
+            return static::fromApp(
+                command: $command,
+                routeMatcher: $routeMatcher,
+                preserveUserChanges: false,
+                paths: $paths
+            );
         }
 
         if ($command->shouldExtract()) {
-            return static::fromApp($command, $routeMatcher, true, $pathConfig);
+            return static::fromApp(
+                command: $command,
+                routeMatcher: $routeMatcher,
+                preserveUserChanges: true,
+                paths: $paths
+            );
         }
 
-        return static::fromCamelDir($pathConfig);
+        return static::fromCamelDir($paths);
     }
 
-    /**
-     * @param GenerateDocumentation $command
-     * @param RouteMatcherInterface $routeMatcher
-     * @param bool $preserveUserChanges
-     * @param PathConfig $pathConfig
-     * @return GroupedEndpointsFromApp
-     */
     public static function fromApp(
         GenerateDocumentation $command,
         RouteMatcherInterface $routeMatcher,
         bool $preserveUserChanges,
-        PathConfig $pathConfig
+        PathConfig $paths
     ): GroupedEndpointsFromApp {
-        return new GroupedEndpointsFromApp($command, $routeMatcher, $pathConfig, $preserveUserChanges);
+        return new GroupedEndpointsFromApp($command, $routeMatcher, $paths, $preserveUserChanges);
     }
 
-    /**
-     * @param PathConfig $pathConfig
-     * @return GroupedEndpointsFromCamelDir
-     */
-    public static function fromCamelDir(PathConfig $pathConfig): GroupedEndpointsFromCamelDir
+    public static function fromCamelDir(PathConfig $paths): GroupedEndpointsFromCamelDir
     {
-        return new GroupedEndpointsFromCamelDir($pathConfig);
+        return new GroupedEndpointsFromCamelDir($paths);
     }
 }

--- a/src/GroupedEndpoints/GroupedEndpointsFactory.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFactory.php
@@ -3,34 +3,55 @@
 namespace Knuckles\Scribe\GroupedEndpoints;
 
 use Knuckles\Scribe\Commands\GenerateDocumentation;
+use Knuckles\Scribe\Configuration\PathConfig;
 use Knuckles\Scribe\Matching\RouteMatcherInterface;
 
 class GroupedEndpointsFactory
 {
-    public function make(GenerateDocumentation $command, RouteMatcherInterface $routeMatcher, string $docsName = 'scribe'): GroupedEndpointsContract
-    {
+    /**
+     * @param GenerateDocumentation $command
+     * @param RouteMatcherInterface $routeMatcher
+     * @param PathConfig $pathConfig
+     * @return GroupedEndpointsContract
+     */
+    public function make(
+        GenerateDocumentation $command,
+        RouteMatcherInterface $routeMatcher,
+        PathConfig $pathConfig
+    ): GroupedEndpointsContract {
         if ($command->isForcing()) {
-            return static::fromApp($command, $routeMatcher, false, $docsName);
+            return static::fromApp($command, $routeMatcher, false, $pathConfig);
         }
 
         if ($command->shouldExtract()) {
-            return static::fromApp($command, $routeMatcher, true, $docsName);
+            return static::fromApp($command, $routeMatcher, true, $pathConfig);
         }
 
-        return static::fromCamelDir($docsName);
+        return static::fromCamelDir($pathConfig);
     }
 
+    /**
+     * @param GenerateDocumentation $command
+     * @param RouteMatcherInterface $routeMatcher
+     * @param bool $preserveUserChanges
+     * @param PathConfig $pathConfig
+     * @return GroupedEndpointsFromApp
+     */
     public static function fromApp(
         GenerateDocumentation $command,
         RouteMatcherInterface $routeMatcher,
         bool $preserveUserChanges,
-        string $docsName = 'scribe'
+        PathConfig $pathConfig
     ): GroupedEndpointsFromApp {
-        return new GroupedEndpointsFromApp($command, $routeMatcher, $preserveUserChanges, $docsName);
+        return new GroupedEndpointsFromApp($command, $routeMatcher, $pathConfig, $preserveUserChanges);
     }
 
-    public static function fromCamelDir(string $docsName = 'scribe'): GroupedEndpointsFromCamelDir
+    /**
+     * @param PathConfig $pathConfig
+     * @return GroupedEndpointsFromCamelDir
+     */
+    public static function fromCamelDir(PathConfig $pathConfig): GroupedEndpointsFromCamelDir
     {
-        return new GroupedEndpointsFromCamelDir($docsName);
+        return new GroupedEndpointsFromCamelDir($pathConfig);
     }
 }

--- a/src/GroupedEndpoints/GroupedEndpointsFromApp.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFromApp.php
@@ -34,22 +34,16 @@ class GroupedEndpointsFromApp implements GroupedEndpointsContract
     public static string $camelDir;
     public static string $cacheDir;
 
-    /**
-     * @param GenerateDocumentation $command
-     * @param RouteMatcherInterface $routeMatcher
-     * @param PathConfig $pathConfiguration
-     * @param bool $preserveUserChanges
-     */
     public function __construct(
         private GenerateDocumentation $command,
         private RouteMatcherInterface $routeMatcher,
-        protected PathConfig $pathConfiguration,
+        protected PathConfig $paths,
         private bool $preserveUserChanges = true
     ) {
         $this->docConfig = $command->getDocConfig();
 
-        static::$camelDir = Camel::camelDir($this->pathConfiguration);
-        static::$cacheDir = Camel::cacheDir($this->pathConfiguration);
+        static::$camelDir = Camel::camelDir($this->paths);
+        static::$cacheDir = Camel::cacheDir($this->paths);
     }
 
     public function get(): array
@@ -290,7 +284,7 @@ class GroupedEndpointsFromApp implements GroupedEndpointsContract
 
     protected function makeApiDetails(): ApiDetails
     {
-        return new ApiDetails($this->pathConfiguration, $this->docConfig, !$this->command->option('force'));
+        return new ApiDetails($this->paths, $this->docConfig, !$this->command->option('force'));
     }
 
     /**

--- a/src/GroupedEndpoints/GroupedEndpointsFromApp.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFromApp.php
@@ -10,6 +10,7 @@ use Knuckles\Camel\Camel;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Camel\Output\OutputEndpointData;
 use Knuckles\Scribe\Commands\GenerateDocumentation;
+use Knuckles\Scribe\Configuration\PathConfig;
 use Knuckles\Scribe\Exceptions\CouldntGetRouteDetails;
 use Knuckles\Scribe\Extracting\ApiDetails;
 use Knuckles\Scribe\Extracting\Extractor;
@@ -33,15 +34,22 @@ class GroupedEndpointsFromApp implements GroupedEndpointsContract
     public static string $camelDir;
     public static string $cacheDir;
 
+    /**
+     * @param GenerateDocumentation $command
+     * @param RouteMatcherInterface $routeMatcher
+     * @param PathConfig $pathConfiguration
+     * @param bool $preserveUserChanges
+     */
     public function __construct(
-        private GenerateDocumentation $command, private RouteMatcherInterface $routeMatcher,
-        private bool $preserveUserChanges = true, protected string $docsName = 'scribe'
-    )
-    {
+        private GenerateDocumentation $command,
+        private RouteMatcherInterface $routeMatcher,
+        protected PathConfig $pathConfiguration,
+        private bool $preserveUserChanges = true
+    ) {
         $this->docConfig = $command->getDocConfig();
 
-        static::$camelDir = Camel::camelDir($this->docsName);
-        static::$cacheDir = Camel::cacheDir($this->docsName);
+        static::$camelDir = Camel::camelDir($this->pathConfiguration);
+        static::$cacheDir = Camel::cacheDir($this->pathConfiguration);
     }
 
     public function get(): array
@@ -282,7 +290,7 @@ class GroupedEndpointsFromApp implements GroupedEndpointsContract
 
     protected function makeApiDetails(): ApiDetails
     {
-        return new ApiDetails($this->docConfig, !$this->command->option('force'), $this->docsName);
+        return new ApiDetails($this->pathConfiguration, $this->docConfig, !$this->command->option('force'));
     }
 
     /**

--- a/src/GroupedEndpoints/GroupedEndpointsFromCamelDir.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFromCamelDir.php
@@ -7,22 +7,20 @@ use Knuckles\Scribe\Configuration\PathConfig;
 
 class GroupedEndpointsFromCamelDir implements GroupedEndpointsContract
 {
-    protected PathConfig $pathConfig;
 
-    public function __construct(PathConfig $pathConfig)
+    public function __construct(protected PathConfig $paths)
     {
-        $this->pathConfig = $pathConfig;
     }
 
     public function get(): array
     {
-        if (!is_dir(Camel::camelDir($this->pathConfig))) {
+        if (!is_dir(Camel::camelDir($this->paths))) {
             throw new \InvalidArgumentException(
-                "Can't use --no-extraction because there are no endpoints in the " . Camel::camelDir($this->pathConfig) . " directory."
+                "Can't use --no-extraction because there are no endpoints in the " . Camel::camelDir($this->paths) . " directory."
             );
         }
 
-        return Camel::loadEndpointsIntoGroups(Camel::camelDir($this->pathConfig));
+        return Camel::loadEndpointsIntoGroups(Camel::camelDir($this->paths));
     }
 
     public function hasEncounteredErrors(): bool

--- a/src/GroupedEndpoints/GroupedEndpointsFromCamelDir.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFromCamelDir.php
@@ -3,25 +3,26 @@
 namespace Knuckles\Scribe\GroupedEndpoints;
 
 use Knuckles\Camel\Camel;
+use Knuckles\Scribe\Configuration\PathConfig;
 
 class GroupedEndpointsFromCamelDir implements GroupedEndpointsContract
 {
-    protected string $docsName;
+    protected PathConfig $pathConfig;
 
-    public function __construct(string $docsName = 'scribe')
+    public function __construct(PathConfig $pathConfig)
     {
-        $this->docsName = $docsName;
+        $this->pathConfig = $pathConfig;
     }
 
     public function get(): array
     {
-        if (!is_dir(Camel::camelDir($this->docsName))) {
+        if (!is_dir(Camel::camelDir($this->pathConfig))) {
             throw new \InvalidArgumentException(
-                "Can't use --no-extraction because there are no endpoints in the " . Camel::camelDir($this->docsName) . " directory."
+                "Can't use --no-extraction because there are no endpoints in the " . Camel::camelDir($this->pathConfig) . " directory."
             );
         }
 
-        return Camel::loadEndpointsIntoGroups(Camel::camelDir($this->docsName));
+        return Camel::loadEndpointsIntoGroups(Camel::camelDir($this->pathConfig));
     }
 
     public function hasEncounteredErrors(): bool

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -12,14 +12,6 @@ use Symfony\Component\Yaml\Yaml;
 
 class Writer
 {
-    /**
-     * The "name" of this docs instance. By default, it is "scribe".
-     * Used for multi-docs.
-     */
-    public PathConfig $paths;
-
-    private DocumentationConfig $config;
-
     private bool $isStatic;
 
     private ?string $staticTypeOutputPath;
@@ -39,20 +31,15 @@ class Writer
 
     private string $laravelAssetsPath;
 
-    public function __construct(DocumentationConfig $config = null, PathConfig $pathConfig)
+    public function __construct(protected DocumentationConfig $config, public PathConfig $paths)
     {
-        $this->paths = $pathConfig;
-
-        // If no config is injected, pull from global, for easier testing.
-        $this->config = $config ?: new DocumentationConfig(config($this->paths->getScribeConfigurationPath()));
-
         $this->isStatic = $this->config->get('type') === 'static';
         $this->laravelTypeOutputPath = $this->getLaravelTypeOutputPath();
         $this->staticTypeOutputPath = rtrim($this->config->get('static.output_path', 'public/docs'), '/');
 
         $this->laravelAssetsPath = $this->config->get('laravel.assets_directory')
             ? '/' . $this->config->get('laravel.assets_directory')
-            : "/vendor/" . $this->paths->getScribeConfigurationPath();
+            : "/vendor/" . $this->paths->outputPath();
     }
 
     /**
@@ -84,8 +71,9 @@ class Writer
                 $collectionPath = "{$this->staticTypeOutputPath}/collection.json";
                 file_put_contents($collectionPath, $collection);
             } else {
-                Storage::disk('local')->put($this->paths->getScribeConfigurationPath('collection.json'), $collection);
-                $collectionPath = Storage::disk('local')->path($this->paths->getScribeConfigurationPath('collection.json'));
+                $outputPath = $this->paths->outputPath('collection.json');
+                Storage::disk('local')->put($outputPath, $collection);
+                $collectionPath = Storage::disk('local')->path($outputPath);
             }
 
             c::success("Wrote Postman collection to: {$this->makePathFriendly($collectionPath)}");
@@ -103,8 +91,9 @@ class Writer
                 $specPath = "{$this->staticTypeOutputPath}/openapi.yaml";
                 file_put_contents($specPath, $spec);
             } else {
-                Storage::disk('local')->put($this->paths->getScribeConfigurationPath('openapi.yaml'), $spec);
-                $specPath = Storage::disk('local')->path($this->paths->getScribeConfigurationPath('openapi.yaml'));
+                $outputPath = $this->paths->outputPath('openapi.yaml');
+                Storage::disk('local')->put($outputPath, $spec);
+                $specPath = Storage::disk('local')->path($outputPath);
             }
 
             c::success("Wrote OpenAPI specification to: {$this->makePathFriendly($specPath)}");
@@ -178,8 +167,8 @@ class Writer
         // Rewrite asset links to go through Laravel
         $contents = preg_replace('#href="\.\./docs/css/(.+?)"#', 'href="{{ asset("' . $this->laravelAssetsPath . '/css/$1") }}"', $contents);
         $contents = preg_replace('#src="\.\./docs/(js|images)/(.+?)"#', 'src="{{ asset("' . $this->laravelAssetsPath . '/$1/$2") }}"', $contents);
-        $contents = str_replace('href="../docs/collection.json"', 'href="{{ route("' . $this->paths->getScribeConfigurationPath('postman', '.') . '") }}"', $contents);
-        $contents = str_replace('href="../docs/openapi.yaml"', 'href="{{ route("' . $this->paths->getScribeConfigurationPath('openapi', '.') . '") }}"', $contents);
+        $contents = str_replace('href="../docs/collection.json"', 'href="{{ route("' . $this->paths->outputPath('postman', '.') . '") }}"', $contents);
+        $contents = str_replace('href="../docs/openapi.yaml"', 'href="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
 
         file_put_contents("$this->laravelTypeOutputPath/index.blade.php", $contents);
     }
@@ -191,7 +180,7 @@ class Writer
         // Then we convert them to HTML, and throw in the endpoints as well.
         /** @var HtmlWriter $writer */
         $writer = app()->makeWith(HtmlWriter::class, ['config' => $this->config]);
-        $writer->generate($groupedEndpoints, $this->paths->getTemporaryDirectoryPath(), $this->staticTypeOutputPath);
+        $writer->generate($groupedEndpoints, $this->paths->intermediateOutputPath(), $this->staticTypeOutputPath);
 
         if (!$this->isStatic) {
             $this->performFinalTasksForLaravelType();
@@ -229,7 +218,7 @@ class Writer
         return config(
             'view.paths.0',
             function_exists('base_path') ? base_path("resources/views") : "resources/views"
-        ). "/" . $this->paths->getScribeConfigurationPath();
+        ). "/" . $this->paths->outputPath();
     }
 
     /**

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -148,7 +148,7 @@ class OutputTest extends BaseLaravelTest
     {
         $this->supports_base_test([
             "--config" => "scribe_admin",
-            "--cache-directory" => ".scribe_admin_dir"
+            "--cache-dir" => ".scribe_admin_dir"
         ], '.scribe_admin_dir');
     }
 
@@ -157,7 +157,7 @@ class OutputTest extends BaseLaravelTest
     {
         $this->supports_base_test([
             "--config" => "scribe_admin",
-            "--cache-directory" => "scribe_admin_dir"
+            "--cache-dir" => "scribe_admin_dir"
         ], 'scribe_admin_dir');
     }
 
@@ -166,7 +166,7 @@ class OutputTest extends BaseLaravelTest
     {
         $this->supports_base_test([
             "--config" => "bananas_are_good",
-            "--cache-directory" => "5.5/Apple/26"
+            "--cache-dir" => "5.5/Apple/26"
         ], '5.5/Apple/26');
     }
 

--- a/tests/Unit/PathConfigurationTest.php
+++ b/tests/Unit/PathConfigurationTest.php
@@ -8,30 +8,32 @@ use PHPUnit\Framework\TestCase;
 class PathConfigurationTest extends TestCase
 {
     /** @test */
-    public function object_resolves_into_hidden_string()
+    public function resolves_default_cache_path()
     {
-        $pathConfig = new PathConfig('scribe', 'scribe', true);
-        $this->assertEquals('.scribe', $pathConfig->getTemporaryDirectoryPath());
+        $pathConfig = new PathConfig('scribe');
+        $this->assertEquals('.scribe', $pathConfig->intermediateOutputPath());
+        $this->assertEquals('.scribe/endpoints', $pathConfig->intermediateOutputPath('endpoints'));
+        $this->assertEquals('scribe', $pathConfig->outputPath());
+        $this->assertEquals('scribe/tim', $pathConfig->outputPath('tim'));
     }
 
     /** @test */
-    public function object_resolves_into_non_hidden_string()
+    public function resolves_cache_path_with_subdirectories()
     {
-        $pathConfig = new PathConfig('scribe', 'scribe', false);
-        $this->assertEquals('scribe', $pathConfig->getTemporaryDirectoryPath());
+        $pathConfig = new PathConfig('scribe/bob');
+        $this->assertEquals('.scribe/bob', $pathConfig->intermediateOutputPath());
+        $this->assertEquals('.scribe/bob/tim', $pathConfig->intermediateOutputPath('tim'));
+        $this->assertEquals('scribe/bob', $pathConfig->outputPath());
+        $this->assertEquals('scribe/bob/tim', $pathConfig->outputPath('tim'));
     }
 
     /** @test */
-    public function object_resolves_into_hidden_string_for_subdirs()
+    public function supports_custom_cache_path()
     {
-        $pathConfig = new PathConfig('scribe/bob', 'scribe', true);
-        $this->assertEquals('.scribe/bob', $pathConfig->getTemporaryDirectoryPath());
-    }
-
-    /** @test */
-    public function object_resolves_into_non_hidden_string_for_subdirs()
-    {
-        $pathConfig = new PathConfig('scribe/bob/dave', 'scribe', false);
-        $this->assertEquals('scribe/bob/dave', $pathConfig->getTemporaryDirectoryPath());
+        $pathConfig = new PathConfig('scribe/bob', cacheDir: 'scribe_cache');
+        $this->assertEquals('scribe_cache', $pathConfig->intermediateOutputPath());
+        $this->assertEquals('scribe_cache/tim', $pathConfig->intermediateOutputPath('tim'));
+        $this->assertEquals('scribe/bob', $pathConfig->outputPath());
+        $this->assertEquals('scribe/bob/tim', $pathConfig->outputPath('tim'));
     }
 }

--- a/tests/Unit/PathConfigurationTest.php
+++ b/tests/Unit/PathConfigurationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Unit;
+
+use Knuckles\Scribe\Configuration\PathConfig;
+use PHPUnit\Framework\TestCase;
+
+class PathConfigurationTest extends TestCase
+{
+    /** @test */
+    public function object_resolves_into_hidden_string()
+    {
+        $pathConfig = new PathConfig('scribe', 'scribe', true);
+        $this->assertEquals('.scribe', $pathConfig->getTemporaryDirectoryPath());
+    }
+
+    /** @test */
+    public function object_resolves_into_non_hidden_string()
+    {
+        $pathConfig = new PathConfig('scribe', 'scribe', false);
+        $this->assertEquals('scribe', $pathConfig->getTemporaryDirectoryPath());
+    }
+
+    /** @test */
+    public function object_resolves_into_hidden_string_for_subdirs()
+    {
+        $pathConfig = new PathConfig('scribe/bob', 'scribe', true);
+        $this->assertEquals('.scribe/bob', $pathConfig->getTemporaryDirectoryPath());
+    }
+
+    /** @test */
+    public function object_resolves_into_non_hidden_string_for_subdirs()
+    {
+        $pathConfig = new PathConfig('scribe/bob/dave', 'scribe', false);
+        $this->assertEquals('scribe/bob/dave', $pathConfig->getTemporaryDirectoryPath());
+    }
+}

--- a/tests/Unit/PathConfigurationTest.php
+++ b/tests/Unit/PathConfigurationTest.php
@@ -30,7 +30,7 @@ class PathConfigurationTest extends TestCase
     /** @test */
     public function supports_custom_cache_path()
     {
-        $pathConfig = new PathConfig('scribe/bob', cacheDir: 'scribe_cache');
+        $pathConfig = new PathConfig('scribe/bob', scribeDir: 'scribe_cache');
         $this->assertEquals('scribe_cache', $pathConfig->intermediateOutputPath());
         $this->assertEquals('scribe_cache/tim', $pathConfig->intermediateOutputPath('tim'));
         $this->assertEquals('scribe/bob', $pathConfig->outputPath());


### PR DESCRIPTION
### Whats changed?

- **Added** the ability to configure the `scribe.php` (or custom php config file) independently of the temp directory.


#### This PR continues https://github.com/knuckleswtf/scribe/pull/760 which has been split into two smaller PRs.