### PR TITLE
Allow collision v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "league/flysystem": "^1.1.4|^2.1.1|^3.0",
         "mpociot/reflection-docblock": "^1.0.1",
         "nikic/php-parser": "^4.10",
-        "nunomaduro/collision": "^5.10|^6.0|^7.0",
+        "nunomaduro/collision": "^5.10|^6.0|^7.0|^8.0",
         "ramsey/uuid": "^4.2.2",
         "shalvah/clara": "^3.1.0",
         "shalvah/upgrader": "^0.3.0",


### PR DESCRIPTION
✅  This just allows to install `nunomaduro/collision: v8` 

⚠️ If someone want's to use **v8** - then **PHP 8.2** is minimum required.