### PR TITLE
Update/fix migration URL in README. Remove errant backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Scribe helps you generate API documentation for humans from your Laravel/Lumen/[
 ## Documentation
 Check out the documentation at [scribe.knuckles.wtf/laravel](http://scribe.knuckles.wtf/laravel).
 
-If you're coming from `mpociot/laravel-apidoc-generator`, first [migrate to v3](http://scribe.knuckles.wtf/blog/laravel/3.x/migrating-apidoc)`, then [to v4](http://scribe.knuckles.wtf/blog/laravel/migrating-v4).
+If you're coming from `mpociot/laravel-apidoc-generator`, first migrate [to v3](https://scribe.knuckles.wtf/laravel/3.x/migrating-apidoc), then [to v4](https://scribe.knuckles.wtf/laravel/migrating-v4).
 
 ## Contributing
 Contributing is easy! See our [contribution guide](https://scribe.knuckles.wtf/laravel/contributing).


### PR DESCRIPTION
Update README:

- Update URL for migration guide v3 and v4
- Remove errant backtick