### PR TITLE
Endpoint level URL params for OpenAPI spec

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -98,50 +98,6 @@ class OpenAPISpecWriter
 
             $pathItem = $operations;
 
-            // Placing all URL parameters at the path level, since it's the same path anyway
-            if (count($endpoints[0]->urlParameters)) {
-                $parameters = [];
-                /**
-                 * @var string $name
-                 * @var Parameter $details
-                 */
-                foreach ($endpoints[0]->urlParameters as $name => $details) {
-                    $parameterData = [
-                        'in' => 'path',
-                        'name' => $name,
-                        'description' => $details->description,
-                        'example' => $details->example,
-                        // Currently, OAS requires path parameters to be required
-                        'required' => true,
-                        'schema' => [
-                            'type' => $details->type,
-                        ],
-                    ];
-                    // Workaround for optional parameters
-                    if (empty($details->required)) {
-                        $parameterData['description'] = rtrim('Optional parameter. ' . $parameterData['description']);
-                        $parameterData['examples'] = [
-                            'omitted' => [
-                                'summary' => 'When the value is omitted',
-                                'value' => '',
-                            ],
-                        ];
-
-                        if ($parameterData['example'] !== null) {
-                            $parameterData['examples']['present'] = [
-                                'summary' => 'When the value is present',
-                                'value' => $parameterData['example'],
-                            ];
-                        }
-
-                        // Can't have `example` and `examples`
-                        unset($parameterData['example']);
-                    }
-                    $parameters[] = $parameterData;
-                }
-                $pathItem['parameters'] = $parameters; // @phpstan-ignore-line
-            }
-
             return [$path => $pathItem];
         })->toArray();
     }
@@ -156,6 +112,48 @@ class OpenAPISpecWriter
     protected function generateEndpointParametersSpec(OutputEndpointData $endpoint): array
     {
         $parameters = [];
+
+        if (count($endpoints[0]->urlParameters)) {
+            $parameters = [];
+            /**
+             * @var string $name
+             * @var Parameter $details
+             */
+            foreach ($endpoints[0]->urlParameters as $name => $details) {
+                $parameterData = [
+                    'in' => 'path',
+                    'name' => $name,
+                    'description' => $details->description,
+                    'example' => $details->example,
+                    // Currently, OAS requires path parameters to be required
+                    'required' => true,
+                    'schema' => [
+                        'type' => $details->type,
+                    ],
+                ];
+                // Workaround for optional parameters
+                if (empty($details->required)) {
+                    $parameterData['description'] = rtrim('Optional parameter. ' . $parameterData['description']);
+                    $parameterData['examples'] = [
+                        'omitted' => [
+                            'summary' => 'When the value is omitted',
+                            'value' => '',
+                        ],
+                    ];
+
+                    if ($parameterData['example'] !== null) {
+                        $parameterData['examples']['present'] = [
+                            'summary' => 'When the value is present',
+                            'value' => $parameterData['example'],
+                        ];
+                    }
+
+                    // Can't have `example` and `examples`
+                    unset($parameterData['example']);
+                }
+                $parameters[] = $parameterData;
+            }
+        }
 
         if (count($endpoint->queryParameters)) {
             /**


### PR DESCRIPTION
Move URL parameters down to the endpoint level for the OpenAPI specification.  This can help improve some http clients ability to import and render the spec correctly.

### Example Routes

``` php
use Illuminate\Support\Facades\Route;
use App\Http\Controllers\Api\v1\TruckController;

/**
 * Search Trucks
 * 
 */
Route::get('trucks', [TruckController::class, 'search'])->name('demo.search');

/**
 * View Truck
 * 
 * @urlParam id string Unique identifier for the truck
 */
Route::get('trucks/{id}', [TruckController::class, 'view'])->name('demo.view');
```

### BEFORE

#### openapi.yaml

``` yaml
paths:
  /trucks: ...
  '/trucks/{id}':
    get:
      summary: 'View a Truck'
      operationId: getTrucksId
      description: 'View a specific Truck'
      parameters: []
      responses: ...
      tags: ...
      security: []
    parameters:
      -
        in: path
        name: id
        description: 'The ID of the truck.'
        example: provident
        required: true
        schema:
          type: string
```

#### HTTP Client

![image](https://github.com/knuckleswtf/scribe/assets/23061476/70246006-d471-4561-ba5c-800c5298ba95)

### AFTER

#### openapi.yaml

``` yaml
paths:
  /trucks: ...
  '/trucks/{id}':
    get:
      summary: 'View a Truck'
      operationId: getTrucksId
      description: 'View a specific Truck'
      parameters:
        -
          in: path
          name: id
          description: 'The ID of the truck.'
          example: trk123
          required: true
          schema:
            type: string
      responses: ...
      tags: ...
      security: []
```

#### HTTP Client

![image](https://github.com/knuckleswtf/scribe/assets/23061476/ed49af7a-5689-4420-ae88-b4b84c1afb2e)