### PR TITLE
Endpoint URL params for OpenAPI

### DIFF
--- a/tests/Fixtures/openapi.yaml
+++ b/tests/Fixtures/openapi.yaml
@@ -183,6 +183,47 @@ paths:
             operationId: getApiEchoesUrlParametersParamParam2Param3Param4
             parameters:
                 -
+                    in: path
+                    name: param
+                    description: ''
+                    example: '4'
+                    required: true
+                    schema:
+                        type: string
+                -
+                    in: path
+                    name: param2
+                    description: ''
+                    required: true
+                    schema:
+                        type: string
+                    example: consequatur
+                -
+                    in: path
+                    name: param3
+                    description: 'Optional parameter.'
+                    required: true
+                    schema:
+                        type: string
+                    examples:
+                        omitted:
+                            summary: 'When the value is omitted'
+                            value: ''
+                        present:
+                            summary: 'When the value is present'
+                            value: consequatur
+                -
+                    in: path
+                    name: param4
+                    description: 'Optional parameter.'
+                    required: true
+                    schema:
+                        type: string
+                    examples:
+                        omitted:
+                            summary: 'When the value is omitted'
+                            value: ''
+                -
                     in: query
                     name: something
                     description: ''
@@ -219,48 +260,6 @@ paths:
             tags:
                 - Other😎
             security: []
-        parameters:
-            -
-                in: path
-                name: param
-                description: ''
-                example: '4'
-                required: true
-                schema:
-                    type: string
-            -
-                in: path
-                name: param2
-                description: ''
-                required: true
-                schema:
-                    type: string
-                example: consequatur
-            -
-                in: path
-                name: param3
-                description: 'Optional parameter.'
-                required: true
-                schema:
-                    type: string
-                examples:
-                    omitted:
-                        summary: 'When the value is omitted'
-                        value: ''
-                    present:
-                        summary: 'When the value is present'
-                        value: consequatur
-            -
-                in: path
-                name: param4
-                description: 'Optional parameter.'
-                required: true
-                schema:
-                    type: string
-                examples:
-                    omitted:
-                        summary: 'When the value is omitted'
-                        value: ''
     /api/withBodyParametersAsArray:
         post:
             summary: 'Endpoint with body parameters as array.'

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -127,7 +127,7 @@ class OpenAPISpecWriterTest extends BaseUnitTest
     }
 
     /** @test */
-    public function adds_url_parameters_correctly_as_parameters_on_path_item_object()
+    public function adds_url_parameters_correctly_as_parameters_on_operation_object()
     {
         $endpointData1 = $this->createMockEndpointData([
             'httpMethods' => ['POST'],
@@ -153,7 +153,8 @@ class OpenAPISpecWriterTest extends BaseUnitTest
         $results = $this->generate($groups);
 
         $this->assertArrayNotHasKey('parameters', $results['paths']['/path1']);
-        $this->assertCount(2, $results['paths']['/path1/{param}/{optionalParam}']['parameters']);
+        $this->assertArrayNotHasKey('parameters', $results['paths']['/path1/{param}/{optionalParam}']);
+        $this->assertCount(2, $results['paths']['/path1/{param}/{optionalParam}']['post']['parameters']);
         $this->assertEquals([
             'in' => 'path',
             'required' => true,
@@ -161,7 +162,7 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'description' => 'Something',
             'example' => 56,
             'schema' => ['type' => 'integer'],
-        ], $results['paths']['/path1/{param}/{optionalParam}']['parameters'][0]);
+        ], $results['paths']['/path1/{param}/{optionalParam}']['post']['parameters'][0]);
         $this->assertEquals([
             'in' => 'path',
             'required' => true,
@@ -173,7 +174,7 @@ class OpenAPISpecWriterTest extends BaseUnitTest
                     'summary' => 'When the value is present', 'value' => '69'],
             ],
             'schema' => ['type' => 'string'],
-        ], $results['paths']['/path1/{param}/{optionalParam}']['parameters'][1]);
+        ], $results['paths']['/path1/{param}/{optionalParam}']['post']['parameters'][1]);
     }
 
     /** @test */


### PR DESCRIPTION
Slight enhancement to the generated OpenAPI specification by simply moving URL parameters down to the endpoint level.  This can improve some http clients' ability to import and render the `openapi.yaml` specification accurately.  Generally, it's probably not a bad idea to define all parameters explicitly at the request level.  Tests have been updated and are passing.

### Example Routes

``` php
/**
 * Search Trucks
 * 
 */
Route::get('trucks', [TruckController::class, 'search'])->name('demo.search');

/**
 * View Truck
 * 
 * @urlParam id string Unique identifier for the truck
 */
Route::get('trucks/{id}', [TruckController::class, 'view'])->name('demo.view');
```

### BEFORE

#### openapi.yaml

``` yaml
paths:
  /trucks: ...
  '/trucks/{id}':
    get:
      summary: 'View a Truck'
      operationId: getTrucksId
      description: 'View a specific Truck'
      parameters: []
      responses: ...
      tags: ...
      security: []
    parameters:
      -
        in: path
        name: id
        description: 'The ID of the truck.'
        example: TRK123
        required: true
        schema:
          type: string
```

#### A Client

![image](https://github.com/knuckleswtf/scribe/assets/23061476/70246006-d471-4561-ba5c-800c5298ba95)

### AFTER

#### openapi.yaml

``` yaml
paths:
  /trucks: ...
  '/trucks/{id}':
    get:
      summary: 'View a Truck'
      operationId: getTrucksId
      description: 'View a specific Truck'
      parameters:
        -
          in: path
          name: id
          description: 'The ID of the truck.'
          example: TRK123
          required: true
          schema:
            type: string
      responses: ...
      tags: ...
      security: []
```

#### Same Client

![image](https://github.com/knuckleswtf/scribe/assets/23061476/ed49af7a-5689-4420-ae88-b4b84c1afb2e)