### PR TITLE
Fixes #810

### DIFF
--- a/resources/views/themes/elements/endpoint.blade.php
+++ b/resources/views/themes/elements/endpoint.blade.php
@@ -175,7 +175,7 @@
                                 <div class="sl-bg-canvas-100 example-request example-request-{{ $language }}"
                                      style="{{ $index == 0 ? '' : 'display: none;' }}">
                                     <div class="sl-px-0 sl-py-1">
-                                        <div style="max-height: 400px;" class="sl-rounded">
+                                        <div style="max-height: 400px;" class="sl-overflow-y-auto sl-rounded">
                                             @include("scribe::partials.example-requests.$language")
                                         </div>
                                     </div>


### PR DESCRIPTION
Adds  `sl-overflow-y-auto` in example request so that content is not truncated but can scroll.

Fixes #810 

Before
![scribe_elements_request_before](https://github.com/knuckleswtf/scribe/assets/6875243/456f5f33-5271-4627-9836-cd11e2a67b97)
After
![scribe_elements_request_after](https://github.com/knuckleswtf/scribe/assets/6875243/155d2c0d-844e-4d1f-94f9-a5fab7ceb391)


