### PR TITLE
fix: include enum options for array values in OpenAPI spec

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -470,6 +470,10 @@ class OpenAPISpecWriter
                 'format' => 'binary',
             ] : ['type' => $baseType];
 
+            if (!empty($field->enumValues)) {
+                $baseItem['enum'] = $field->enumValues;
+            }
+
             $fieldData = [
                 'type' => 'array',
                 'description' => $field->description ?: '',


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

The enum values for an array query parameter are correctly identified in the Scribe documentation, but are not shown in the generated OpenAPI document. 

This PR adds to the enum values for the array query parameter in the OpenAPI document.

<details><summary>Before / After OpenAPI document</summary>

**Before**

 ```yaml
      parameters:
        -
          in: query
          name: type
          description: 'Filtre sur le type'
          example:
            - fichier
          required: false
          schema:
            type: array
            description: 'Filtre sur le type'
            example:
              - fichier
            items:
              type: string
``` 

**After**

```yaml
 parameters:
        -
          in: query
          name: type
          description: 'Filtre sur le type'
          example:
            - fichier
          required: false
          schema:
            type: array
            description: 'Filtre sur le type'
            example:
              - fichier
            items:
              type: string
              enum:
                - app
                - app_inst
                - bdd
                - fichier
                - rpa
                - monarch
```

</details>