### PR TITLE
feat: write OpenAPI spec in json or yaml format

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -154,11 +154,9 @@ INTRO
     // For 'static' docs, the collection will be generated to public/docs/openapi.yaml.
     // For 'laravel' docs, it will be generated to storage/app/scribe/openapi.yaml.
     // Setting `laravel.add_routes` to true (above) will also add a route for the spec.
+    // If the json format is chosen, the file will be saved as openapi.json
     'openapi' => [
         'enabled' => true,
-
-        // The output format for the spec, either 'yaml' or 'json'.
-        'format' => 'yaml',
 
         'overrides' => [
             // 'info.version' => '2.0.0',

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -157,6 +157,9 @@ INTRO
     'openapi' => [
         'enabled' => true,
 
+        // The output format for the spec, either 'yaml' or 'json'.
+        'format' => 'yaml',
+
         'overrides' => [
             // 'info.version' => '2.0.0',
         ],

--- a/routes/laravel.php
+++ b/routes/laravel.php
@@ -16,6 +16,6 @@ Route::middleware($middleware)
         })->name('scribe.postman');
 
         Route::get("$prefix.openapi", function () {
-            return response()->file(Storage::disk('local')->path('scribe/openapi.' . config('scribe.openapi.format')));
+            return response()->file(Storage::disk('local')->path('scribe/openapi.' . (config('scribe.openapi.json', false) ? 'json' : 'yaml')));
         })->name('scribe.openapi');
     });

--- a/routes/laravel.php
+++ b/routes/laravel.php
@@ -16,6 +16,6 @@ Route::middleware($middleware)
         })->name('scribe.postman');
 
         Route::get("$prefix.openapi", function () {
-            return response()->file(Storage::disk('local')->path('scribe/openapi.yaml'));
+            return response()->file(Storage::disk('local')->path('scribe/openapi.' . config('scribe.openapi.format')));
         })->name('scribe.openapi');
     });

--- a/routes/lumen.php
+++ b/routes/lumen.php
@@ -18,6 +18,6 @@ $router->group([
         return new JsonResponse(Storage::disk('local')->get('scribe/collection.json'), json: true);
     })->name('scribe.postman');
     $router->get("$prefix.openapi", function () {
-        return response()->file(Storage::disk('local')->path('scribe/openapi.' . config('scribe.openapi.format')));
+        return response()->file(Storage::disk('local')->path('scribe/openapi.' . (config('scribe.openapi.json', false) ? 'json' : 'yaml')));
     })->name('scribe.openapi');
 });

--- a/routes/lumen.php
+++ b/routes/lumen.php
@@ -18,6 +18,6 @@ $router->group([
         return new JsonResponse(Storage::disk('local')->get('scribe/collection.json'), json: true);
     })->name('scribe.postman');
     $router->get("$prefix.openapi", function () {
-        return response()->file(Storage::disk('local')->path('scribe/openapi.yaml'));
+        return response()->file(Storage::disk('local')->path('scribe/openapi.' . config('scribe.openapi.format')));
     })->name('scribe.openapi');
 });

--- a/src/Writing/ExternalHtmlWriter.php
+++ b/src/Writing/ExternalHtmlWriter.php
@@ -33,7 +33,7 @@ class ExternalHtmlWriter extends HtmlWriter
             $postmanCollectionUrl = "{$this->assetPathPrefix}collection.json";
         }
         if ($this->config->get('openapi.enabled', false)) {
-            $openApiSpecUrl = "{$this->assetPathPrefix}openapi.yaml";
+            $openApiSpecUrl = "{$this->assetPathPrefix}openapi." . config('scribe.openapi.format');
         }
         return [
             'title' => $this->config->get('title') ?: config('app.name', '') . ' Documentation',

--- a/src/Writing/ExternalHtmlWriter.php
+++ b/src/Writing/ExternalHtmlWriter.php
@@ -33,7 +33,8 @@ class ExternalHtmlWriter extends HtmlWriter
             $postmanCollectionUrl = "{$this->assetPathPrefix}collection.json";
         }
         if ($this->config->get('openapi.enabled', false)) {
-            $openApiSpecUrl = "{$this->assetPathPrefix}openapi." . config('scribe.openapi.format');
+            $openApiSpecUrl = $this->assetPathPrefix . OpenAPISpecWriter::getSpecFileName();
+
         }
         return [
             'title' => $this->config->get('title') ?: config('app.name', '') . ' Documentation',

--- a/src/Writing/HtmlWriter.php
+++ b/src/Writing/HtmlWriter.php
@@ -117,8 +117,8 @@ class HtmlWriter
             $postmanCollectionUrl = "{$this->assetPathPrefix}collection.json";
         }
         if ($this->config->get('openapi.enabled', false)) {
-            $links[] = "<a href=\"{$this->assetPathPrefix}openapi.".config('scribe.openapi.format')."\">".u::trans("scribe::links.openapi")."</a>";
-            $openApiSpecUrl = "{$this->assetPathPrefix}openapi.".config('scribe.openapi.format');
+            $links[] = "<a href=\"{$this->assetPathPrefix}".OpenAPISpecWriter::getSpecFileName()."\">".u::trans("scribe::links.openapi")."</a>";
+            $openApiSpecUrl = $this->assetPathPrefix.OpenAPISpecWriter::getSpecFileName();
         }
 
         $auth = $this->config->get('auth');

--- a/src/Writing/HtmlWriter.php
+++ b/src/Writing/HtmlWriter.php
@@ -117,8 +117,8 @@ class HtmlWriter
             $postmanCollectionUrl = "{$this->assetPathPrefix}collection.json";
         }
         if ($this->config->get('openapi.enabled', false)) {
-            $links[] = "<a href=\"{$this->assetPathPrefix}openapi.yaml\">".u::trans("scribe::links.openapi")."</a>";
-            $openApiSpecUrl = "{$this->assetPathPrefix}openapi.yaml";
+            $links[] = "<a href=\"{$this->assetPathPrefix}openapi.".config('scribe.openapi.format')."\">".u::trans("scribe::links.openapi")."</a>";
+            $openApiSpecUrl = "{$this->assetPathPrefix}openapi.".config('scribe.openapi.format');
         }
 
         $auth = $this->config->get('auth');

--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -249,7 +249,6 @@ class OpenAPISpecWriter
             }
 
             $body['content'][$contentType]['schema'] = $schema;
-
         }
 
         // return object rather than empty array, so can get properly serialised as object
@@ -528,7 +527,7 @@ class OpenAPISpecWriter
         if ($endpoint->metadata->title) return preg_replace('/[^\w+]/', '', Str::camel($endpoint->metadata->title));
 
         $parts = preg_split('/[^\w+]/', $endpoint->uri, -1, PREG_SPLIT_NO_EMPTY);
-        return Str::lower($endpoint->httpMethods[0]) . join('', array_map(fn($part) => ucfirst($part), $parts));
+        return Str::lower($endpoint->httpMethods[0]) . join('', array_map(fn ($part) => ucfirst($part), $parts));
     }
 
     /**
@@ -585,5 +584,15 @@ class OpenAPISpecWriter
         }
 
         return $schema;
+    }
+
+    /**
+     * Get the filename for the OpenAPI spec file, with a .yaml or .json extension following the configuration
+     *
+     * @return string
+     */
+    public static function getSpecFileName(): string
+    {
+        return 'openapi.' . (config('scribe.openapi.json', false)  ? 'json' : 'yaml');
     }
 }

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -96,19 +96,17 @@ class Writer
 
             $spec = $this->generateOpenAPISpec($parsedRoutes);
 
-            if (config('scribe.openapi.format') === 'json') {
-                $fileName = "openapi.json";
+            if (config('scribe.openapi.json', false)) {
                 $fileContent = json_encode($spec, JSON_PRETTY_PRINT);
             } else {
-                $fileName = "openapi.yaml";
                 $fileContent = Yaml::dump($spec, 20, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_OBJECT_AS_MAP);
             }
 
             if ($this->isStatic) {
-                $specPath = "{$this->staticTypeOutputPath}/{$fileName}";
+                $specPath = "{$this->staticTypeOutputPath}/" . OpenAPISpecWriter::getSpecFileName();
                 file_put_contents($specPath, $fileContent);
             } else {
-                $outputPath = $this->paths->outputPath($fileName);
+                $outputPath = $this->paths->outputPath(OpenAPISpecWriter::getSpecFileName());
                 Storage::disk('local')->put($outputPath, $fileContent);
                 $specPath = Storage::disk('local')->path($outputPath);
             }
@@ -186,8 +184,8 @@ class Writer
         $contents = preg_replace('#href="\.\./docs/css/(.+?)"#', 'href="{{ asset("' . $this->laravelAssetsPath . '/css/$1") }}"', $contents);
         $contents = preg_replace('#src="\.\./docs/(js|images)/(.+?)"#', 'src="{{ asset("' . $this->laravelAssetsPath . '/$1/$2") }}"', $contents);
         $contents = str_replace('href="../docs/collection.json"', 'href="{{ route("' . $this->paths->outputPath('postman', '.') . '") }}"', $contents);
-        $contents = str_replace('href="../docs/openapi.' . config('scribe.openapi.format') . '"', 'href="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
-        $contents = str_replace('url="../docs/openapi.' . config('scribe.openapi.format') . '"', 'url="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
+        $contents = str_replace('href="../docs'.OpenAPISpecWriter::getSpecFileName().'"', 'href="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
+        $contents = str_replace('url="../docs'.OpenAPISpecWriter::getSpecFileName().'"', 'url="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
 
         file_put_contents("$this->laravelTypeOutputPath/index.blade.php", $contents);
     }

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -186,8 +186,8 @@ class Writer
         $contents = preg_replace('#href="\.\./docs/css/(.+?)"#', 'href="{{ asset("' . $this->laravelAssetsPath . '/css/$1") }}"', $contents);
         $contents = preg_replace('#src="\.\./docs/(js|images)/(.+?)"#', 'src="{{ asset("' . $this->laravelAssetsPath . '/$1/$2") }}"', $contents);
         $contents = str_replace('href="../docs/collection.json"', 'href="{{ route("' . $this->paths->outputPath('postman', '.') . '") }}"', $contents);
-        $contents = str_replace('href="../docs/openapi.yaml"', 'href="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
-        $contents = str_replace('url="../docs/openapi.yaml"', 'url="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
+        $contents = str_replace('href="../docs/openapi.' . config('scribe.openapi.format') . '"', 'href="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
+        $contents = str_replace('url="../docs/openapi.' . config('scribe.openapi.format') . '"', 'url="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
 
         file_put_contents("$this->laravelTypeOutputPath/index.blade.php", $contents);
     }

--- a/tests/GenerateDocumentation/BehavioursTest.php
+++ b/tests/GenerateDocumentation/BehavioursTest.php
@@ -118,7 +118,7 @@ class BehavioursTest extends BaseLaravelTest
             'html' => realpath('public/docs/index.html'),
             'blade' => null,
             'postman' => realpath('public/docs/collection.json') ?: null,
-            'openapi' => realpath('public/docs/openapi.'.config('scribe.openapi.format')) ?: null,
+            'openapi' => realpath('public/docs/openapi.'.(config('scribe.openapi.json') ? 'json' : 'yaml')) ?: null,
             'assets' => [
                 'js' => realpath('public/docs/js'),
                 'css' => realpath('public/docs/css'),

--- a/tests/GenerateDocumentation/BehavioursTest.php
+++ b/tests/GenerateDocumentation/BehavioursTest.php
@@ -118,7 +118,7 @@ class BehavioursTest extends BaseLaravelTest
             'html' => realpath('public/docs/index.html'),
             'blade' => null,
             'postman' => realpath('public/docs/collection.json') ?: null,
-            'openapi' => realpath('public/docs/openapi.yaml') ?: null,
+            'openapi' => realpath('public/docs/openapi.'.config('scribe.openapi.format')) ?: null,
             'assets' => [
                 'js' => realpath('public/docs/js'),
                 'css' => realpath('public/docs/css'),

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -244,7 +244,7 @@ class OutputTest extends BaseLaravelTest
 
         $this->setConfig([
             'openapi.enabled' => true,
-            'openapi.format' => 'json',
+            'openapi.json' => true,
             'openapi.overrides' => [
                 'info.version' => '3.9.9',
             ],


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

From https://swagger.io/specification/, 
> An OpenAPI document that conforms to the OpenAPI Specification is itself a JSON object, which may be represented either **in JSON or YAML format**.

This PR adds a configuration toggle to output the OpenAPI document in the JSON format, which is useful to use it with the package [nextapps-be/laravel-swagger-ui](https://github.com/nextapps-be/laravel-swagger-ui) without the `yaml` PECL extension.