### PR TITLE
Fix Sidebar Style Error for 'External_Static' Type and 'Elements' Theme

### DIFF
--- a/resources/views/external/elements.blade.php
+++ b/resources/views/external/elements.blade.php
@@ -8,6 +8,11 @@
     <!-- Embed elements Elements via Web Component -->
     <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+    <style>
+        body {
+            height: 100vh;
+        }
+    </style>
 </head>
 <body>
 


### PR DESCRIPTION
[examples example](https://github.com/stoplightio/elements/blob/main/examples/static-html/zoom-api/index.html)
Based on the code examples from the official repository of 'stoplightio/elements', it appears that our generation template is missing the setting of the 'body' 'height' to '100vh', which causes a styling error in the sidebar. The sidebar height cannot be fixed and changes with the height of the content page on the right. The page is as follows:
<img width="1920" alt="image" src="https://github.com/knuckleswtf/scribe/assets/32818030/cf601d41-3717-47b5-8d11-9c77d1d194d2">
After the fix:
<img width="1920" alt="image" src="https://github.com/knuckleswtf/scribe/assets/32818030/61c0e6b2-91dc-4bfb-a3ab-125653810866">



