### PR TITLE
Allow examples to be shown in response fields

### DIFF
--- a/camel/Extraction/ResponseField.php
+++ b/camel/Extraction/ResponseField.php
@@ -19,7 +19,7 @@ class ResponseField extends BaseDTO
     /** @var string */
     public $type;
 
-    /** @var string */
+    /** @var mixed */
     public $example;
 
     public array $enumValues = [];

--- a/camel/Extraction/ResponseField.php
+++ b/camel/Extraction/ResponseField.php
@@ -19,5 +19,8 @@ class ResponseField extends BaseDTO
     /** @var string */
     public $type;
 
+    /** @var string */
+    public $example;
+
     public array $enumValues = [];
 }


### PR DESCRIPTION
Allowing examples to be shown in the templates in the response description set
