### PR TITLE
Array with Form request doesn't generate both example and fields at the same time

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -636,8 +636,11 @@ trait ParsesValidationRules
                 // 2. If `users.<name>` exists, `users` is an `object`
                 // 3. Otherwise, default to `object`
                 // Important: We're iterating in reverse, to ensure we set child items before parent items
-                // (assuming the user specified parents first, which is the more common thing)
-                if ($childKey = Arr::first($allKeys, fn($key) => Str::startsWith($key, "$name.*"))) {
+                // (assuming the user specified parents first, which is the more common thing)y
+                if(Arr::first($allKeys, fn($key) => Str::startsWith($key, "$name.*."))) {
+                    $details['type'] = 'object[]';
+                    unset($details['setter']);
+                } else if ($childKey = Arr::first($allKeys, fn($key) => Str::startsWith($key, "$name.*"))) {
                     $childType = ($converted[$childKey] ?? $parameters[$childKey])['type'];
                     $details['type'] = "{$childType}[]";
                 } else { // `array` types default to `object` if no subtype is specified


### PR DESCRIPTION
When using it in the form request:

![Captura de tela de 2024-04-30 14-04-08](https://github.com/knuckleswtf/scribe/assets/54078100/39d14bd7-0cbe-4a2d-b4a2-37fa69cf31e9)

It generates the examples, but it doesn't generate the fields in the body parameters.

![Captura de tela de 2024-04-30 14-04-46](https://github.com/knuckleswtf/scribe/assets/54078100/72daaad4-4e68-41b4-8170-446eb3bbd02c)

If I remove the parent index:

![Captura de tela de 2024-04-30 14-06-55](https://github.com/knuckleswtf/scribe/assets/54078100/30165cc9-e1a3-410b-9a2e-eaf953c4d409)

It generates the fields in the body parameters, but it doesn't generate the examples.

![Captura de tela de 2024-04-30 14-07-53](https://github.com/knuckleswtf/scribe/assets/54078100/46e09798-c4c7-43d9-8fc9-2628683c25a4)


After the correction, passing the parent index, it generates the examples and also generates the fields in the body parameters.

![Captura de tela de 2024-04-30 14-04-08](https://github.com/knuckleswtf/scribe/assets/54078100/d9dd5525-7db4-4245-b23f-a2ffdcb0bc74)
![Captura de tela de 2024-04-30 14-09-40](https://github.com/knuckleswtf/scribe/assets/54078100/25364327-9fc0-46d0-abe4-65bf1b7deb89)

