### PR TITLE
External Elements : fix title & missing logo

### DIFF
--- a/resources/views/external/elements.blade.php
+++ b/resources/views/external/elements.blade.php
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Elements in HTML</title>
+    <title>{!! $metadata['title'] !!}L</title>
     <!-- Embed elements Elements via Web Component -->
     <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
@@ -25,7 +25,9 @@
     router="hash"
     layout="sidebar"
     hideTryIt="{!! ($tryItOut['enabled'] ?? true) ? '' : 'true'!!}"
+@if(!empty($metadata['logo']))
     logo="{!! $metadata['logo'] !!}"
+@endif
 />
 
 </body>


### PR DESCRIPTION
Two fixes when choose theme="elements" :
- use the title in config
- don't set logo param if not set
