### PR TITLE
feat: add afterResponseCall hook

### DIFF
--- a/src/Extracting/Strategies/Responses/ResponseCalls.php
+++ b/src/Extracting/Strategies/Responses/ResponseCalls.php
@@ -6,7 +6,6 @@ use Dingo\Api\Dispatcher;
 use Dingo\Api\Routing\Route as DingoRoute;
 use Exception;
 use Illuminate\Contracts\Http\Kernel;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;

--- a/src/Extracting/Strategies/Responses/ResponseCalls.php
+++ b/src/Extracting/Strategies/Responses/ResponseCalls.php
@@ -174,10 +174,10 @@ class ResponseCalls extends Strategy
         }
     }
 
-    protected function runPostRequestHook(Request $request, ExtractedEndpointData $endpointData, JsonResponse $jsonResponse): void
+    protected function runPostRequestHook(Request $request, ExtractedEndpointData $endpointData, mixed $response): void
     {
         if (is_callable(Globals::$__afterResponseCall)) {
-            call_user_func_array(Globals::$__afterResponseCall, [$request, $endpointData, $jsonResponse]);
+            call_user_func_array(Globals::$__afterResponseCall, [$request, $endpointData, $response]);
         }
     }
 

--- a/src/Extracting/Strategies/Responses/ResponseCalls.php
+++ b/src/Extracting/Strategies/Responses/ResponseCalls.php
@@ -2,17 +2,18 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies\Responses;
 
-use Illuminate\Support\Facades\Config;
-use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Dingo\Api\Dispatcher;
 use Dingo\Api\Routing\Route as DingoRoute;
 use Exception;
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
+use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Extracting\DatabaseTransactionHelpers;
 use Knuckles\Scribe\Extracting\ParamHelpers;
 use Knuckles\Scribe\Extracting\Strategies\Strategy;
@@ -89,6 +90,9 @@ class ResponseCalls extends Strategy
 
         try {
             $response = $this->makeApiCall($request, $endpointData->route);
+
+            $this->runPostRequestHook($request, $endpointData, $response);
+
             $response = [
                 [
                     'status' => $response->getStatusCode(),
@@ -167,6 +171,13 @@ class ResponseCalls extends Strategy
     {
         if (is_callable(Globals::$__beforeResponseCall)) {
             call_user_func_array(Globals::$__beforeResponseCall, [$request, $endpointData]);
+        }
+    }
+
+    protected function runPostRequestHook(Request $request, ExtractedEndpointData $endpointData, JsonResponse $jsonResponse): void
+    {
+        if (is_callable(Globals::$__afterResponseCall)) {
+            call_user_func_array(Globals::$__afterResponseCall, [$request, $endpointData, $jsonResponse]);
         }
     }
 

--- a/src/Scribe.php
+++ b/src/Scribe.php
@@ -2,7 +2,6 @@
 
 namespace Knuckles\Scribe;
 
-use Illuminate\Http\JsonResponse;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Commands\GenerateDocumentation;
 use Knuckles\Scribe\Tools\Globals;
@@ -27,7 +26,7 @@ class Scribe
      * Specify a callback that will be executed just after a response call is done
      * (allowing to modify the response).
      *
-     * @param callable(Request, ExtractedEndpointData, JSONResponse): mixed $callable
+     * @param callable(Request, ExtractedEndpointData, mixed): mixed $callable
      */
     public static function afterResponseCall(callable $callable)
     {

--- a/src/Scribe.php
+++ b/src/Scribe.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe;
 
+use Illuminate\Http\JsonResponse;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Commands\GenerateDocumentation;
 use Knuckles\Scribe\Tools\Globals;
@@ -20,6 +21,17 @@ class Scribe
     public static function beforeResponseCall(callable $callable)
     {
         Globals::$__beforeResponseCall = $callable;
+    }
+
+    /**
+     * Specify a callback that will be executed just after a response call is done
+     * (allowing to modify the response).
+     *
+     * @param callable(Request, ExtractedEndpointData, JSONResponse): mixed $callable
+     */
+    public static function afterResponseCall(callable $callable)
+    {
+        Globals::$__afterResponseCall = $callable;
     }
 
     /**

--- a/src/Tools/Globals.php
+++ b/src/Tools/Globals.php
@@ -12,6 +12,8 @@ class Globals
 
     public static $__beforeResponseCall;
 
+    public static $__afterResponseCall;
+
     public static $__bootstrap;
 
     public static $__afterGenerating;


### PR DESCRIPTION
Add the hook **afterResponseCall** allowing to modify the result after the API call (for example to reduce large examples with hundred of lines to 5 maximum, to remove a sensible data, ...).

The doc update is available here : https://github.com/knuckleswtf/scribe-docs/pull/29