### PR TITLE
Introduce Adding examples to the OAS3 Media Type Object (Request / Response)

### DIFF
--- a/camel/Extraction/Example.php
+++ b/camel/Extraction/Example.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Knuckles\Camel\Extraction;
+
+
+use Knuckles\Camel\BaseDTO;
+
+class Example extends BaseDTO
+{
+    public ?string $type;
+
+    public array $meta;
+
+    public ?string $content;
+
+    public ?string $description;
+
+    public function __construct(array $parameters = [])
+    {
+        if (is_array($parameters['type'] ?? null)) {
+            $parameters['type'] = $parameters['type'];
+        }
+
+        $parameters['meta'] = $parameters['meta'] ?? [];
+        
+        if (is_array($parameters['content'] ?? null)) {
+            $parameters['content'] = json_encode($parameters['content'], JSON_UNESCAPED_SLASHES);
+        }
+
+        parent::__construct($parameters);
+    }
+
+    public function fullDescription()
+    {
+        return $this->description;
+    }
+}

--- a/camel/Extraction/ExampleCollection.php
+++ b/camel/Extraction/ExampleCollection.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Knuckles\Camel\Extraction;
+
+use Knuckles\Camel\BaseDTOCollection;
+
+/**
+ * @extends BaseDTOCollection<Response>
+ */
+class ExampleCollection extends BaseDTOCollection
+{
+    public static string $base = Example::class;
+}

--- a/camel/Extraction/ExtractedEndpointData.php
+++ b/camel/Extraction/ExtractedEndpointData.php
@@ -68,6 +68,8 @@ class ExtractedEndpointData extends BaseDTO
      */
     public array $responseFields = [];
 
+    public ExampleCollection $examples;
+
     /**
      * Authentication info for this endpoint. In the form [{where}, {name}, {sample}]
      * Example: ["queryParameters", "api_key", "njiuyiw97865rfyvgfvb1"]
@@ -84,6 +86,7 @@ class ExtractedEndpointData extends BaseDTO
     {
         $parameters['metadata'] = $parameters['metadata'] ?? new Metadata([]);
         $parameters['responses'] = $parameters['responses'] ?? new ResponseCollection([]);
+        $parameters['examples'] = $parameters['examples'] ?? new ExampleCollection([]);
 
         parent::__construct($parameters);
 

--- a/camel/Output/OutputEndpointData.php
+++ b/camel/Output/OutputEndpointData.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Knuckles\Camel\BaseDTO;
+use Knuckles\Camel\Extraction\ExampleCollection;
 use Knuckles\Camel\Extraction\Metadata;
 use Knuckles\Camel\Extraction\ResponseCollection;
 use Knuckles\Camel\Extraction\ResponseField;
@@ -77,6 +78,8 @@ class OutputEndpointData extends BaseDTO
      */
     public array $responseFields = [];
 
+    public ExampleCollection $examples;
+
     /**
      * The same as bodyParameters, but organized in a hierarchy.
      * So, top-level items first, with a __fields property containing their children, and so on.
@@ -100,6 +103,7 @@ class OutputEndpointData extends BaseDTO
         $parameters['queryParameters'] = array_map(fn($param) => new Parameter($param), $parameters['queryParameters'] ?? []);
         $parameters['urlParameters'] = array_map(fn($param) => new Parameter($param), $parameters['urlParameters'] ?? []);
         $parameters['responseFields'] = array_map(fn($param) => new ResponseField($param), $parameters['responseFields'] ?? []);
+        $parameters['examples'] = new ExampleCollection($parameters['examples'] ?? []);
 
         parent::__construct($parameters);
 

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -248,6 +248,9 @@ INTRO
             Strategies\ResponseFields\GetFromResponseFieldAttribute::class,
             Strategies\ResponseFields\GetFromResponseFieldTag::class,
         ],
+        'examples' => [
+            Strategies\Examples\UseExampleTag::class,
+        ],
     ],
 
     // For response calls, API resource responses and transformer responses,

--- a/src/Config/Defaults.php
+++ b/src/Config/Defaults.php
@@ -73,4 +73,10 @@ class Defaults
         ]);
     }
 
+    public static function examplesStrategies(): StrategyListWrapper
+    {
+        return new StrategyListWrapper([
+            Strategies\Examples\UseExampleTag::class,
+        ]);
+    }
 }

--- a/src/Exceptions/ExampleResponseStatusCodeNotFound.php
+++ b/src/Exceptions/ExampleResponseStatusCodeNotFound.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Knuckles\Scribe\Exceptions;
+
+class ExampleResponseStatusCodeNotFound extends \RuntimeException implements ScribeException
+{
+    public static function forTag(string $tag)
+    {
+        return new self(
+            <<<MESSAGE
+You specified the response example "$tag" field in one of your custom endpoints, but we couldn't find the required status code.
+Did you forgot to define the response status code?
+MESSAGE
+
+        );
+    }
+}

--- a/src/Exceptions/ExampleTypeNotFound.php
+++ b/src/Exceptions/ExampleTypeNotFound.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Knuckles\Scribe\Exceptions;
+
+class ExampleTypeNotFound extends \RuntimeException implements ScribeException
+{
+    public static function forTag(string $tag)
+    {
+        return new self(
+            <<<MESSAGE
+You specified the example "$tag" field in one of your custom endpoints, but we couldn't find the required type.
+Did you forgot to define the response type?
+MESSAGE
+
+        );
+    }
+}

--- a/src/Extracting/Extractor.php
+++ b/src/Extracting/Extractor.php
@@ -11,6 +11,8 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Knuckles\Camel\Extraction\ExampleCollection;
+use Knuckles\Camel\Extraction\RequestCollection;
 use Knuckles\Camel\Extraction\ResponseCollection;
 use Knuckles\Camel\Extraction\ResponseField;
 use Knuckles\Camel\Output\OutputEndpointData;
@@ -97,6 +99,9 @@ class Extractor
 
         $this->fetchResponseFields($endpointData, $routeRules);
         $this->mergeInheritedMethodsData('responseFields', $endpointData, $inheritedDocsOverrides);
+
+        $this->fetchExampleFields($endpointData, $routeRules);
+        $this->mergeInheritedMethodsData('examples', $endpointData, $inheritedDocsOverrides);
 
         self::$routeBeingProcessed = null;
 
@@ -186,6 +191,15 @@ class Extractor
                 }
             }
         });
+    }
+
+    protected function fetchExampleFields(ExtractedEndpointData $endpointData, array $rulesToApply): void
+    {
+        $this->iterateThroughStrategies('examples', $endpointData, $rulesToApply, function ($results) use ($endpointData) {
+            $endpointData->examples->concat($results);
+        });
+
+        $endpointData->examples = new ExampleCollection($endpointData->examples->values());
     }
 
     /**

--- a/src/Extracting/Strategies/Examples/UseExampleTag.php
+++ b/src/Extracting/Strategies/Examples/UseExampleTag.php
@@ -48,7 +48,7 @@ class UseExampleTag extends Strategy
             $meta = [];
 
             if (empty($type) || ! in_array($type, self::TYPES)) {
-                // Status code is required for type response
+                // Type is required
                 throw new ExampleTypeNotFound();
             }
 

--- a/src/Extracting/Strategies/Examples/UseExampleTag.php
+++ b/src/Extracting/Strategies/Examples/UseExampleTag.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Knuckles\Scribe\Extracting\Strategies\Examples;
+
+use Knuckles\Camel\Extraction\ExtractedEndpointData;
+use Knuckles\Scribe\Exceptions\ExampleResponseStatusCodeNotFound;
+use Knuckles\Scribe\Exceptions\ExampleTypeNotFound;
+use Knuckles\Scribe\Extracting\RouteDocBlocker;
+use Knuckles\Scribe\Extracting\Shared\ResponseFileTools;
+use Knuckles\Scribe\Extracting\Strategies\Strategy;
+use Knuckles\Scribe\Tools\AnnotationParser as a;
+use Knuckles\Scribe\Tools\Utils;
+use Mpociot\Reflection\DocBlock\Tag;
+
+/**
+ * Get an example from the docblock ( @example ).
+ */
+class UseExampleTag extends Strategy
+{
+    const TYPES = [
+        'request',
+        'response',
+    ];
+
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
+    {
+        $docBlocks = RouteDocBlocker::getDocBlocksFromRoute($endpointData->route);
+        return $this->getDocBlockExamples($docBlocks['method']->getTags());
+    }
+
+    /**
+     * @param Tag[] $tags
+     */
+    public function getDocBlockExamples(array $tags): ?array
+    {
+        $exampleTags = Utils::filterDocBlockTags($tags, 'example');
+
+        if (empty($exampleTags)) return null;
+
+        $examples = array_map(function (Tag $exampleTag) {
+            $content = $exampleTag->getContent();
+
+            ['fields' => $fields, 'content' => $content] = a::parseIntoContentAndFields($content, ['type', 'scenario', 'file']);
+
+            $description = $fields['scenario'] ?: "";
+            $type = $fields['type'] ?: "";
+            $file = $fields['file'] ?: "";
+            $meta = [];
+
+            if (empty($type) || ! in_array($type, self::TYPES)) {
+                // Status code is required for type response
+                throw new ExampleTypeNotFound();
+            }
+
+            if ($type === 'response') {
+                // Extract the status code
+                preg_match('/status=(\d+)/', $content, $statusMatches);
+
+                if (isset($statusMatches[1])) {
+                    $meta['status'] = (int) $statusMatches[1];
+                } else {
+                    // Status code is required for type response
+                    throw new ExampleResponseStatusCodeNotFound();
+                }
+
+                // Remove the status code
+                $content = preg_replace('/status=(\d+)/', '', $content);
+            }
+
+            if (! empty($file)) {
+                $json = json_decode($content, true) ?? null;
+
+                $content = ResponseFileTools::getResponseContents($file, $json);
+            }
+
+            return ['type' => $type, 'meta' => $meta, 'content' => $content, 'description' => $description];
+        }, $exampleTags);
+
+        return $examples;
+    }
+}

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -527,7 +527,6 @@ class TestController extends Controller
 
         // Do stuff
         if ($validator->fails()) {
-
         }
     }
 
@@ -585,7 +584,7 @@ class TestController extends Controller
     {
         return null;
     }
-    
+
     public function withInjectedModelFullParamName(TestPost $testPost)
     {
         return null;
@@ -608,6 +607,116 @@ class TestController extends Controller
         return null;
     }
      */
+
+    /**
+     * @example
+     * type="response"
+     * status=200
+     * {
+     *   "id": 4,
+     *   "name": "banana",
+     *   "color": "red",
+     *   "weight": "1 kg",
+     *   "delicious": true,
+     *   "responseTag": true
+     * }
+     */
+    public function withExampleTagTypeResponse()
+    {
+        return '';
+    }
+
+    /**
+     * @example
+     * type="response"
+     * status=200
+     * {
+     *   "id": 4,
+     *   "name": "banana",
+     *   "color": "red",
+     *   "weight": "1 kg",
+     *   "delicious": true,
+     *   "responseTag": true
+     * }
+     * 
+     * @example
+     * type="response"
+     * status=200
+     * {
+     *   "id": 5,
+     *   "name": "banana",
+     *   "color": "green",
+     *   "weight": "1 kg",
+     *   "delicious": true,
+     *   "responseTag": true
+     * }
+     */
+    public function withMultipleExampleTagTypeResponse()
+    {
+        return '';
+    }
+
+    /**
+     * @example
+     * type="response"
+     * {
+     *   "id": 4,
+     *   "name": "banana",
+     *   "color": "red",
+     *   "weight": "1 kg",
+     *   "delicious": true,
+     *   "responseTag": true
+     * }
+     */
+    public function withExampleTagTypeResponseWithoutStatusCode()
+    {
+        return '';
+    }
+
+    /**
+     * @example
+     * type="request"
+     * {
+     *   "id": 4,
+     *   "name": "banana",
+     *   "color": "red",
+     *   "weight": "1 kg",
+     *   "delicious": true,
+     *   "requestTag": true
+     * }
+     */
+    public function withExampleTagTypeRequest()
+    {
+        return '';
+    }
+
+    /**
+     * @example
+     * type="request"
+     * {
+     *   "id": 4,
+     *   "name": "banana",
+     *   "color": "red",
+     *   "weight": "1 kg",
+     *   "delicious": true,
+     *   "requestTag": true
+     * }
+     * 
+     * @example
+     * type="request"
+     * {
+     *   "id": 5,
+     *   "name": "banana",
+     *   "color": "green",
+     *   "weight": "1 kg",
+     *   "delicious": true,
+     *   "requestTag": true
+     * }
+     */
+    public function withMultipleExampleTagTypeRequest()
+    {
+        return '';
+    }
 }
 
 /**
@@ -616,4 +725,4 @@ enum Category: string
     case Fruits = 'fruits';
     case People = 'people';
 }
-*/
+ */

--- a/tests/Fixtures/openapi.yaml
+++ b/tests/Fixtures/openapi.yaml
@@ -176,6 +176,54 @@ paths:
                                 example: ""
             tags:
                 - 'Group A'
+    '/api/withExampleTagTypeResponse':
+        get:
+            summary: ''
+            operationId: getApiWithExampleTagTypeResponse
+            description: ''
+            parameters:
+                -
+                    in: header
+                    name: Custom-Header
+                    description: ''
+                    example: NotSoCustom
+                    schema:
+                        type: string
+            responses:
+                200:
+                    description: ''
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+                                example: ''
+            tags:
+                - 'Group A'
+            security: []
+    '/api/withExampleTagTypeRequest':
+        get:
+            summary: ''
+            operationId: getApiWithExampleTagTypeRequest
+            description: ''
+            parameters:
+                -
+                    in: header
+                    name: Custom-Header
+                    description: ''
+                    example: NotSoCustom
+                    schema:
+                        type: string
+            responses:
+                200:
+                    description: ''
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+                                example: ''
+            tags:
+                - 'Group A'
+            security: []
     '/api/echoesUrlParameters/{param}/{param2}/{param3}/{param4}':
         get:
             summary: ''

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -47,6 +47,7 @@ class OutputTest extends BaseLaravelTest
                 ))
                 ->toArray(),
             'responseFields' => Defaults::responseFieldsStrategies()->toArray(),
+            'examples' => Defaults::examplesStrategies()->toArray(),
         ],
         ]);
         $this->setConfig(['database_connections_to_transact' => []]);
@@ -211,6 +212,8 @@ class OutputTest extends BaseLaravelTest
         RouteFacade::get('/api/withQueryParameters', [TestController::class, 'withQueryParameters']);
         RouteFacade::get('/api/withAuthTag', [TestController::class, 'withAuthenticatedTag']);
         RouteFacade::get('/api/echoesUrlParameters/{param}/{param2}/{param3?}/{param4?}', [TestController::class, 'echoesUrlParameters']);
+        RouteFacade::get('/api/withExampleTagTypeResponse', [TestController::class, 'withExampleTagTypeResponse']);
+        RouteFacade::get('/api/withExampleTagTypeRequest', [TestController::class, 'withExampleTagTypeRequest']);
 
         $this->setConfig([
             'openapi.enabled' => true,

--- a/tests/Strategies/Examples/UseExampleTagTest.php
+++ b/tests/Strategies/Examples/UseExampleTagTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Strategies\Examples;
+
+use Knuckles\Scribe\Extracting\Strategies\Responses\UseResponseTag;
+use Knuckles\Scribe\Tools\DocumentationConfig;
+use Mpociot\Reflection\DocBlock\Tag;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use Knuckles\Scribe\Exceptions\ExampleResponseStatusCodeNotFound;
+use Knuckles\Scribe\Exceptions\ExampleTypeNotFound;
+use Knuckles\Scribe\Extracting\Strategies\Examples\UseExampleTag;
+use PHPUnit\Framework\TestCase;
+
+class UseExampleTagTest extends TestCase
+{
+    use ArraySubsetAsserts;
+
+    /**
+     * @test
+     * @dataProvider exampleResponseTags
+     */
+    public function allows_multiple_example_tags_with_type_response_for_multiple_statuses_and_scenarios(array $tags, array $expected)
+    {
+        $strategy = new UseExampleTag(new DocumentationConfig([]));
+        $results = $strategy->getDocBlockExamples($tags);
+
+        $this->assertEquals($expected[0]['status'], $results[0]['meta']['status']);
+        $this->assertEquals($expected[1]['status'], $results[1]['meta']['status']);
+        $this->assertEquals($expected[0]['description'], $results[0]['description']);
+        $this->assertEquals($expected[1]['description'], $results[1]['description']);
+        $this->assertEquals($expected[0]['content'], json_decode($results[0]['content'], true));
+        $this->assertEquals($expected[1]['content'], json_decode($results[1]['content'], true));
+    }
+
+    /**
+     * @test
+     * @dataProvider exampleRequestTags
+     */
+    public function allows_multiple_example_tags_with_type_request_for_multiple_scenarios(array $tags, array $expected)
+    {
+        $strategy = new UseExampleTag(new DocumentationConfig([]));
+        $results = $strategy->getDocBlockExamples($tags);
+
+        $this->assertEquals('request', $results[0]['type']);
+        $this->assertEquals('request', $results[1]['type']);
+        $this->assertEquals($expected[0]['description'], $results[0]['description']);
+        $this->assertEquals($expected[1]['description'], $results[1]['description']);
+        $this->assertEquals($expected[0]['content'], json_decode($results[0]['content'], true));
+        $this->assertEquals($expected[1]['content'], json_decode($results[1]['content'], true));
+    }
+
+    /**
+     * @test
+     * @dataProvider exampleFileTags
+     */
+    public function allows_multiple_examples_with_files_for_multiple_statuses_and_scenarios(array $tags, array $expected)
+    {
+        $filePath = __DIR__ . '/../../Fixtures/response_test.json';
+        $filePath2 = __DIR__ . '/../../Fixtures/response_error_test.json';
+
+        $strategy = new UseExampleTag(new DocumentationConfig([]));
+        $results = $strategy->getDocBlockExamples($tags);
+
+        $this->assertArraySubset([
+            [
+                'type' => 'request',
+                'meta' => [],
+                'description' => $expected[0]['description'],
+                'content' => file_get_contents($filePath),
+            ],
+            [
+                'type' => 'response',
+                'meta' => [
+                    'status' => 401,
+                ],
+                'description' => $expected[1]['description'],
+                'content' => file_get_contents($filePath2),
+            ],
+        ], $results);
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidExampleTags
+     */
+    public function will_throw_an_exception_when_missing_or_invalid_type_attribue(array $tags)
+    {
+        $this->expectException(ExampleTypeNotFound::class);
+
+        $strategy = new UseExampleTag(new DocumentationConfig([]));
+        $strategy->getDocBlockExamples($tags);
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidExampleResponseTags
+     */
+    public function will_throw_an_exception_when_missing_reponse_status_code_attribue(array $tags)
+    {
+        $this->expectException(ExampleResponseStatusCodeNotFound::class);
+
+        $strategy = new UseExampleTag(new DocumentationConfig([]));
+        $strategy->getDocBlockExamples($tags);
+    }
+
+    public static function exampleResponseTags()
+    {
+        $response1 = '{
+       "id": 4,
+       "name": "banana"
+     }';
+        $response2 = '{
+        "message": "Unauthorized"
+     }';
+        return [
+            "with fields" => [
+                [
+                    new Tag('example', "type=response status=200 scenario=\"success\" $response1"),
+                    new Tag('example', "type=response status=401 scenario='auth problem' $response2"),
+                ],
+                [
+                    [
+                        'status' => 200,
+                        'description' => 'success',
+                        'content' => [
+                            'id' => 4,
+                            'name' => 'banana',
+                        ],
+                    ],
+                    [
+                        'status' => 401,
+                        'description' => 'auth problem',
+                        'content' => [
+                            'message' => 'Unauthorized',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public static function exampleRequestTags()
+    {
+        $request1 = '{
+       "id": 4,
+       "name": "banana"
+     }';
+        $request2 = '{
+        "message": "Unauthorized"
+     }';
+        return [
+            "with fields" => [
+                [
+                    new Tag('example', "type=request scenario=\"with customer filters\" $request1"),
+                    new Tag('example', "type=request scenario='with company filters' $request2"),
+                ],
+                [
+                    [
+                        'description' => 'with customer filters',
+                        'content' => [
+                            'id' => 4,
+                            'name' => 'banana',
+                        ],
+                    ],
+                    [
+                        'description' => 'with company filters',
+                        'content' => [
+                            'message' => 'Unauthorized',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public static function exampleFileTags()
+    {
+        return [
+            "with fields" => [
+                [
+                    new Tag('example', 'type="request" scenario="user update" file="tests/Fixtures/response_test.json"'),
+                    new Tag('example', 'type="response" status=401 scenario=\'auth problem\' file="tests/Fixtures/response_error_test.json"'),
+                ],
+                [
+                    [
+                        'description' => 'user update',
+                    ],
+                    [
+                        'status' => 401,
+                        'description' => 'auth problem',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public static function invalidExampleTags()
+    {
+        return [
+            "with fields" => [
+                [
+                    new Tag('example', "scenario=\"with customer filters\""),
+                    new Tag('example', "type=invalid scenario='with company filters'"),
+                ],
+            ],
+        ];
+    }
+    
+    public static function invalidExampleResponseTags()
+    {
+        return [
+            "with fields" => [
+                [
+                    new Tag('example', "type=response"),
+                    new Tag('example', "type=response scenario='Successful response'"),
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/ExtractorTest.php
+++ b/tests/Unit/ExtractorTest.php
@@ -42,6 +42,9 @@ class ExtractorTest extends BaseUnitTest
             'responseFields' => [
                 Strategies\ResponseFields\GetFromResponseFieldTag::class,
             ],
+            'examples' => [
+                Strategies\Examples\UseExampleTag::class,
+            ],
         ],
     ];
 

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -557,6 +557,265 @@ class OpenAPISpecWriterTest extends BaseUnitTest
         ], $results['paths']['/path2']['put']['responses']);
     }
 
+    /** @test */
+    public function adds_examples_correctly_as_examples_on_media_type_object()
+    {
+        $endpointData1 = $this->createMockEndpointData([
+            'httpMethods' => ['POST'],
+            'uri' => '/path1',
+            'examples' => [
+                [
+                    'type' => 'response',
+                    'meta' => [
+                        'status' => 204,
+                    ],
+                    'description' => 'Successfully updated.',
+                    'content' => '{"this": "should be ignored"}',
+                ],
+                [
+                    'type' => 'response',
+                    'meta' => [
+                        'status' => 201,
+                    ],
+                    'description' => '',
+                    'content' => '{"this": "shouldn\'t be ignored", "and this": "too", "sub level 0": { "sub level 1 key 1": "sl0_sl1k1", "sub level 1 key 2": [ { "sub level 2 key 1": "sl0_sl1k2_sl2k1", "sub level 2 key 2": { "sub level 3 key 1": "sl0_sl1k2_sl2k2_sl3k1" } } ], "sub level 1 key 3": { "sub level 2 key 1": "sl0_sl1k3_sl2k2", "sub level 2 key 2": { "sub level 3 key 1": "sl0_sl1k3_sl2k2_sl3k1", "sub level 3 key null": null, "sub level 3 key integer": 99 } } } }',
+                ],
+                [
+                    'type' => 'response',
+                    'meta' => [
+                        'status' => 201,
+                    ],
+                    'description' => '',
+                    'content' => '{"this": "also"}',
+                ],
+                [
+                    'type' => 'response',
+                    'meta' => [
+                        'status' => 200,
+                    ],
+                    'description' => 'Successfully retrieved.',
+                    'content' => '{"this": "shouldn\'t be ignored"}',
+                ],
+                [
+                    'type' => 'response',
+                    'meta' => [
+                        'status' => 200,
+                    ],
+                    'description' => 'Successfully completed.',
+                    'content' => '{"this": "also shouldn\'t be ignored"}',
+                ],
+            ],
+        ]);
+        $endpointData2 = $this->createMockEndpointData([
+            'httpMethods' => ['PUT'],
+            'uri' => '/path2',
+            'bodyParameters' => [
+                'stringParam' => [
+                    'name' => 'stringParam',
+                    'description' => 'String param',
+                    'required' => false,
+                    'example' => 'hahoho',
+                    'type' => 'string',
+                ],
+            ],
+            'examples' => [
+                [
+                    'type' => 'request',
+                    'meta' => [],
+                    'description' => 'Task 1',
+                    'content' => '{"this": "shouldn\'t be ignored"}',
+                ],
+                [
+                    'type' => 'request',
+                    'meta' => [],
+                    'description' => 'Task 2',
+                    'content' => '{"this": "also shouldn\'t be ignored"}',
+                ],
+            ],
+        ]);
+        $groups = [$this->createGroup([$endpointData1, $endpointData2])];
+
+        $results = $this->generate($groups);
+
+        $this->assertCount(3, $results['paths']['/path1']['post']['responses']);
+        $this->assertCount(2, $results['paths']['/path1']['post']['responses'][200]['content']['application/json']['examples']);
+        $this->assertArraySubset([
+            '200' => [
+                "description" => "Okayy",
+                "content" => [
+                    "application/json" => [
+                        "schema" => [
+                            "type" => "object",
+                            "properties" => [
+                                "random" => [
+                                    "type" => "string",
+                                    "example" => "json",
+                                ]
+                            ]
+                        ],
+                        "examples" => [
+                            "response-example-1" => [
+                                "summary" => "Successfully retrieved.",
+                                "value" => [
+                                    "this" => "shouldn't be ignored",
+                                ],
+                            ],
+                            "response-example-2" => [
+                                "summary" => "Successfully completed.",
+                                "value" => [
+                                    "this" => "also shouldn't be ignored",
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            '204' => [
+                'description' => 'Successfully updated.',
+            ],
+            '201' => [
+                "description" => "",
+                "content" => [
+                    "application/json" => [
+                        "schema" => [
+                            "type" => "object",
+                            "properties" => [
+                                "this" => [
+                                    "type" => "string",
+                                    "example" => "shouldn't be ignored",
+                                ],
+                                "and this" => [
+                                    "type" => "string",
+                                    "example" => "too",
+                                ],
+                                "sub level 0" => [
+                                    "type" => "object",
+                                    "properties" => [
+                                        "sub level 1 key 1" => [
+                                            "type" => "string",
+                                            "example" => "sl0_sl1k1",
+                                        ],
+                                        "sub level 1 key 2" => [
+                                            "type" => "array",
+                                            "example" => [
+                                                [
+                                                    "sub level 2 key 1" => "sl0_sl1k2_sl2k1",
+                                                    "sub level 2 key 2" => [
+                                                        "sub level 3 key 1" => "sl0_sl1k2_sl2k2_sl3k1",
+                                                    ],
+                                                ],
+                                            ],
+                                            "items" => [
+                                                "type" => "object",
+                                                "properties" => [
+                                                    "sub level 2 key 1" => [
+                                                        "type" => "string",
+                                                        "example" => "sl0_sl1k2_sl2k1",
+                                                    ],
+                                                    "sub level 2 key 2" => [
+                                                        "type" => "object",
+                                                        "properties" => [
+                                                            "sub level 3 key 1" => [
+                                                                "type" => "string",
+                                                                "example" => "sl0_sl1k2_sl2k2_sl3k1",
+                                                            ],
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ],
+                                        "sub level 1 key 3" => [
+                                            "type" => "object",
+                                            "properties" => [
+                                                "sub level 2 key 1" => [
+                                                    "type" => "string",
+                                                    "example" => "sl0_sl1k3_sl2k2",
+                                                ],
+                                                "sub level 2 key 2" => [
+                                                    "type" => "object",
+                                                    "properties" => [
+                                                        "sub level 3 key 1" => [
+                                                            "type" => "string",
+                                                            "example" => "sl0_sl1k3_sl2k2_sl3k1",
+                                                        ],
+                                                        "sub level 3 key null" => [
+                                                            "type" => "string",
+                                                            "example" => null,
+                                                        ],
+                                                        "sub level 3 key integer" => [
+                                                            "type" => "integer",
+                                                            "example" => 99,
+                                                        ],
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ],
+                        "examples" => [
+                            "response-example-1" => [
+                                "summary" => "Response 1",
+                                "value" => [
+                                    "this" => "shouldn't be ignored",
+                                    "and this" => "too",
+                                    "sub level 0" => [
+                                        "sub level 1 key 1" => "sl0_sl1k1",
+                                        "sub level 1 key 2" => [
+                                            [
+                                                "sub level 2 key 1" => "sl0_sl1k2_sl2k1",
+                                                "sub level 2 key 2" => [
+                                                    "sub level 3 key 1" => "sl0_sl1k2_sl2k2_sl3k1",
+                                                ]
+                                            ]
+                                        ],
+                                        "sub level 1 key 3" => [
+                                            "sub level 2 key 1" => "sl0_sl1k3_sl2k2",
+                                            "sub level 2 key 2" => [
+                                                "sub level 3 key 1" => "sl0_sl1k3_sl2k2_sl3k1",
+                                                "sub level 3 key null" => null,
+                                                "sub level 3 key integer" => 99,
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                            "response-example-2" => [
+                                "summary" => "Response 2",
+                                "value" => [
+                                    "this" => "also"
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ], $results['paths']['/path1']['post']['responses']);
+        $this->assertCount(1, $results['paths']['/path2']['put']['responses']);
+        $this->assertEquals([
+            '200' => [
+                "description" => "Okayy",
+                "content" => [
+                    "application/json" => [
+                        "schema" => [
+                            "type" => "object",
+                            "example" => [
+                                "random" => "json",
+                            ],
+                            "properties" => [
+                                "random" => [
+                                    "type" => "string",
+                                    "example" => "json"
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ], $results['paths']['/path2']['put']['responses']);
+    }
+
     protected function createMockEndpointData(array $custom = []): OutputEndpointData
     {
         $faker = Factory::create();
@@ -583,6 +842,7 @@ class OpenAPISpecWriterTest extends BaseUnitTest
                 ],
             ],
             'responseFields' => [],
+            'examples' => [],
         ];
 
         foreach ($custom as $key => $value) {


### PR DESCRIPTION
This PR introduces to create an entire request or response examples by leveraging existing OAS3 capabilities by allowing multiple examples with arbitrary names.

Having multiple examples will increase user experience as it allows consumers to see different ways that an API can be consumed / requested.

This is by default supported in most documentation tooling to help users pick which example they'd like to see. We could also expand examples into Objects and Parameters at a later stage.

### Before:
![Screenshot 2024-05-18 163231](https://github.com/knuckleswtf/scribe/assets/11263156/ab554822-46fa-4a26-9bee-8e3a09d3decb)

### After:

Scalar:

![image](https://github.com/knuckleswtf/scribe/assets/11263156/e0f2ef61-bc62-4ca7-b711-53484a09b15b)

![image](https://github.com/knuckleswtf/scribe/assets/11263156/6903e3b9-2ec5-4dc2-a258-aa840e211a25)

Rapidoc

![image](https://github.com/knuckleswtf/scribe/assets/11263156/f799eb83-de73-424b-89a3-cbf84824fc1c)

![image](https://github.com/knuckleswtf/scribe/assets/11263156/485ec035-e11a-463b-b318-2e726fa3ae06)

Stoplight

![image](https://github.com/knuckleswtf/scribe/assets/11263156/a6ffdbc4-7c25-4db5-abb3-b491a1e61772)

![image](https://github.com/knuckleswtf/scribe/assets/11263156/f79c86b7-e596-4bf5-9697-b5ea41f030cc)

Swagger

![image](https://github.com/knuckleswtf/scribe/assets/11263156/c957eb87-ee92-4c68-be2d-54df683abc66)

![image](https://github.com/knuckleswtf/scribe/assets/11263156/0c57f34b-cdaf-4b11-99d2-a3cd7c96a5cf)

I can update the docs, if we can agree on this implementation.

Thank you!