### PR TITLE
fix: multiple responses with the same status code

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -275,17 +275,18 @@ class OpenAPISpecWriter
                 $content = $this->generateResponseContentSpec($response->content, $endpoint);
                 $contentType = array_keys($content)[0];
                 if (isset($responses[$response->status]['content'][$contentType])) {
+                    $newResponseExample = array_replace([
+                        'description' => $this->getResponseDescription($response),
+                    ], $content[$contentType]['schema']);
+
                     // If we've already created the oneOf object, add this response
                     if (isset($responses[$response->status]['content'][$contentType]['schema']['oneOf'])) {
-                        $responses[$response->status]['content'][$contentType]['schema']['oneOf'][] = $content[$contentType];
+                        $responses[$response->status]['content'][$contentType]['schema']['oneOf'][] = $newResponseExample;
                     } else {
                         // Create the oneOf object
                         $existingResponseExample = array_replace([
                             'description' => $responses[$response->status]['description'],
                         ], $responses[$response->status]['content'][$contentType]['schema']);
-                        $newResponseExample = array_replace([
-                            'description' => $this->getResponseDescription($response),
-                        ], $content[$contentType]['schema']);
 
                         $responses[$response->status]['description'] = '';
                         $responses[$response->status]['content'][$contentType]['schema'] = [

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -636,6 +636,100 @@ class OpenAPISpecWriterTest extends BaseUnitTest
         ], $results['paths']['/path1']['post']['responses']);
     }
 
+    /** @test */
+    public function adds_more_than_two_answers_correctly_using_oneOf()
+    {
+        $endpointData1 = $this->createMockEndpointData([
+            'httpMethods' => ['POST'],
+            'uri' => '/path1',
+            'responses' => [
+                [
+                    'status' => 201,
+                    'description' => 'This one',
+                    'content' => '{"this": "one"}',
+                ],
+                [
+                    'status' => 201,
+                    'description' => 'No, that one.',
+                    'content' => '{"that": "one"}',
+                ],
+                [
+                    'status' => 201,
+                    'description' => 'No, another one.',
+                    'content' => '{"another": "one"}',
+                ],
+                [
+                    'status' => 200,
+                    'description' => 'A separate one',
+                    'content' => '{"the other": "one"}',
+                ],
+            ],
+        ]);
+        $groups = [$this->createGroup([$endpointData1])];
+
+        $results = $this->generate($groups);
+
+        $this->assertArraySubset([
+            '200' => [
+                'description' => 'A separate one',
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'the other' => [
+                                    'example' => "one",
+                                    'type' => 'string',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            '201' => [
+                'description' => '',
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'oneOf' => [
+                                [
+                                    'type' => 'object',
+                                    'description' => 'This one',
+                                    'properties' => [
+                                        'this' => [
+                                            'example' => "one",
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'type' => 'object',
+                                    'description' => 'No, that one.',
+                                    'properties' => [
+                                        'that' => [
+                                            'example' => "one",
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'type' => 'object',
+                                    'description' => 'No, another one.',
+                                    'properties' => [
+                                        'another' => [
+                                            'example' => "one",
+                                            'type' => 'string',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $results['paths']['/path1']['post']['responses']);
+    }
+
     protected function createMockEndpointData(array $custom = []): OutputEndpointData
     {
         $faker = Factory::create();


### PR DESCRIPTION
Fixed the oneOf problem when using more than two responses with the same status code. Solving the problem related to this issue: https://github.com/knuckleswtf/scribe/issues/862
