### PR TITLE
fix: fixes elements theme mutlipart form file upload

### DIFF
--- a/resources/views/themes/elements/index.blade.php
+++ b/resources/views/themes/elements/index.blade.php
@@ -111,6 +111,11 @@
                     });
                 }
 
+                // content type has to be unset otherwise file upload won't work
+                if (form.dataset.hasfiles === "1") {
+                    delete headers['Content-Type'];
+                }
+
                 return preflightPromise.then(() => makeAPICall(method, path, body, query, headers, endpointId))
                     .then(([responseStatus, statusText, responseContent, responseHeaders]) => {
                         responsePanel.hidden = false;


### PR DESCRIPTION
When uploading a file the Content-Type header must not be set otherwise the browser cannot set the right boundaries for the multipart formdata payload.

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest_API/Using_FormData_Objects
<img width="804" alt="Bildschirmfoto 2024-06-06 um 12 07 56" src="https://github.com/knuckleswtf/scribe/assets/7114260/293dd67c-4055-4fd3-9229-241bd48c1cf6">

TryItOut editor in `elements` theme is currently setting the Content-Type header and therefore file uploads do not work.

Should resolve https://github.com/knuckleswtf/scribe/issues/764