### PR TITLE
Show enum case name in output

### DIFF
--- a/resources/views/components/field-details.blade.php
+++ b/resources/views/components/field-details.blade.php
@@ -71,5 +71,5 @@
 {!! Parsedown::instance()->text(trim($description)) !!}
 @if(!empty($enumValues))
 Must be one of:
-<ul style="list-style-type: square;">{!! implode(" ", array_map(fn($val) => "<li><code>$val</code></li>", $enumValues)) !!}</ul>
+<ul style="list-style-position: inside; list-style-type: square;">{!! implode(" ", array_map(fn($val, $key) => "<li><code>$val ($key)</code></li>", $enumValues, array_keys($enumValues))) !!}</ul>
 @endif

--- a/resources/views/themes/elements/components/field-details.blade.php
+++ b/resources/views/themes/elements/components/field-details.blade.php
@@ -38,7 +38,7 @@
         @endif
         @if(!empty($enumValues))
             Must be one of:
-            <ul style="list-style-position: inside; list-style-type: square;">{!! implode(" ", array_map(fn($val) => "<li><code>$val</code></li>", $enumValues)) !!}</ul>
+            <ul style="list-style-position: inside; list-style-type: square;">{!! implode(" ", array_map(fn($val, $key) => "<li><code>$val ($key)</code></li>", $enumValues, array_keys($enumValues))) !!}</ul>
         @endif
         @if($isArrayBody)
             <div class="sl-flex sl-items-baseline sl-text-base">

--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe\Extracting;
 
+use BackedEnum;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
@@ -208,9 +209,13 @@ trait ParsesValidationRules
             if (enum_exists($type) && method_exists($type, 'tryFrom')) {
                 // $case->value only exists on BackedEnums, not UnitEnums
                 // method_exists($enum, 'tryFrom') implies $enum instanceof BackedEnum
-                // @phpstan-ignore-next-line
-                $cases = array_map(fn ($case) => $case->value, $type::cases());
-                $parameterData['type'] = gettype($cases[0]);
+                $cases = [];
+                foreach ($type::cases() as $case) {
+                    /** @var BackedEnum $case */
+                    $cases[$case->name] = $case->value;
+                }
+                
+                $parameterData['type'] = gettype(reset($cases));
                 $parameterData['enumValues'] = $cases;
                 $parameterData['setter'] = fn () => Arr::random($cases);
             }

--- a/src/Extracting/Strategies/GetFromInlineValidatorBase.php
+++ b/src/Extracting/Strategies/GetFromInlineValidatorBase.php
@@ -90,7 +90,7 @@ class GetFromInlineValidatorBase extends Strategy
                         // $case->value only exists on BackedEnums, not UnitEnums
                         // method_exists($enum, 'tryFrom') implies $enum instanceof BackedEnum
                         // @phpstan-ignore-next-line
-                        $rulesList[] = 'in:' . implode(',', array_map(fn ($case) => $case->value, $enum::cases()));
+                        $rulesList[] = 'in:' . implode(',', array_map(fn ($case) => "$case->value ($case->name)", $enum::cases()));
                     }
                 }
                 $rules[$paramName] = join('|', $rulesList);

--- a/tests/Strategies/GetFromInlineValidatorTest.php
+++ b/tests/Strategies/GetFromInlineValidatorTest.php
@@ -208,7 +208,7 @@ class GetFromInlineValidatorTest extends BaseLaravelTest
             ],
         ];
 
-        $getCase = fn ($case) => $case->value;
+        $getCase = fn ($case) => "$case->value ($case->name)";
 
         $this->assertArraySubset($expected, $results);
         $this->assertTrue(in_array(

--- a/tests/Unit/ValidationRuleParsingTest.php
+++ b/tests/Unit/ValidationRuleParsingTest.php
@@ -551,7 +551,7 @@ class ValidationRuleParsingTest extends BaseLaravelTest
         ]);
         $this->assertEquals('string', $results['enum']['type']);
         $this->assertEquals(
-            ['red', 'green', 'blue'],
+            ['Red' => 'red', 'Green' => 'green', 'Blue' => 'blue'],
             $results['enum']['enumValues']
         );
         $this->assertTrue(in_array(
@@ -570,7 +570,7 @@ class ValidationRuleParsingTest extends BaseLaravelTest
         ]);
         $this->assertEquals('integer', $results['enum']['type']);
         $this->assertEquals(
-            [1, 2, 3],
+            ['One' => 1, 'Two' => 2, 'Three' => 3],
             $results['enum']['enumValues']
         );
         $this->assertTrue(in_array(


### PR DESCRIPTION
In cases where BackedEnums have int type, the output is just a list of numbers, ex:
![image](https://github.com/user-attachments/assets/e67e4929-1a20-48f6-9264-68ad6e238ffa)
With this changes, enums with int type will show the base name of the case:
![image](https://github.com/user-attachments/assets/aa4154ee-a896-43b6-8007-a4870aa9c5d1)

