### PR TITLE
Fix #879 (Comments are ignored for validator parameters with non string/array (e.g. conditional) rule lists)

### DIFF
--- a/src/Extracting/Strategies/GetFromInlineValidatorBase.php
+++ b/src/Extracting/Strategies/GetFromInlineValidatorBase.php
@@ -96,7 +96,6 @@ class GetFromInlineValidatorBase extends Strategy
                 $rules[$paramName] = join('|', $rulesList);
             } else {
                 $rules[$paramName] = [];
-                continue;
             }
 
             $dataFromComment = [];


### PR DESCRIPTION
Fixes #879 