### PR TITLE
Allow custom output path for `static` and `external_static` instead of only `static`

### DIFF
--- a/src/Writing/HtmlWriter.php
+++ b/src/Writing/HtmlWriter.php
@@ -30,7 +30,7 @@ class HtmlWriter
         // If they're using the default static path,
         // then use '../docs/{asset}', so assets can work via Laravel app or via index.html
         $this->assetPathPrefix = '../docs/';
-        if ($this->config->get('type') == 'static'
+        if (in_array($this->config->get('type'), ['static', 'external_static'])
             && rtrim($this->config->get('static.output_path', ''), '/') != 'public/docs'
         ) {
             $this->assetPathPrefix = './';


### PR DESCRIPTION
When you set type to `external_static` and set custom static output_path, it still points to default path in generated HTML.

Generated part of scalar HTML (before PR, output_path is different from `public/docs`):
```html
<script
    id="api-reference"
    data-url="../docs/openapi.yaml">
</script>
```

