### PR TITLE
Fix display of boolean examples on the elements theme

### DIFF
--- a/resources/views/themes/elements/components/field-details.blade.php
+++ b/resources/views/themes/elements/components/field-details.blade.php
@@ -49,12 +49,12 @@
                 @endif
             </div>
         @endif
-        @if(!$hasChildren && !is_null($example) && $example != '')
+        @if(!$hasChildren && !is_null($example) && $example !== '')
             <div class="sl-stack sl-stack--horizontal sl-stack--2 sl-flex sl-flex-row sl-items-baseline sl-text-muted">
                 <span>Example:</span> <!-- <span> important for spacing -->
                 <div class="sl-flex sl-flex-1 sl-flex-wrap" style="gap: 4px;">
                     <div class="sl-max-w-full sl-break-all sl-px-1 sl-bg-canvas-tint sl-text-muted sl-rounded sl-border">
-                        {{ is_array($example) ? json_encode($example) : $example }}
+                        {{ is_array($example) || is_bool($example) ? json_encode($example) : $example }}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This **PR** fix the rendering of boolean examples with the **elements theme**. Currently, there's an issue and boolean example cases like `false` and `true` aren't rendering in the right way. At next you can see an image showing this issue:

### Previous to this PR
![Screenshot 2024-09-05 at 11-27-01 The Giga Provisioning API](https://github.com/user-attachments/assets/daa7ab29-7c41-4ac5-8439-7afe81ae33a8)

In this image you can see that a `false` example value is not rendered and `true` is rendered like `1`.

### After this PR
![Screenshot 2024-09-05 at 11-27-52 The Giga Provisioning API](https://github.com/user-attachments/assets/c28c9a58-79b9-4d2d-8815-f77e7572ee08)

In this image you can see that boolean example cases are now rendering nicely.