### PR TITLE
Fixes html content not showing in received response

### DIFF
--- a/resources/views/themes/elements/index.blade.php
+++ b/resources/views/themes/elements/index.blade.php
@@ -137,6 +137,9 @@
                             }
                         } catch (e) {}
 
+                        // Replace HTML entities
+                        responseContent = responseContent.replace(/[<>&]/g, (i) => '&#' + i.charCodeAt(0) + ';');
+
                         contentEl.innerHTML = responseContent;
                         isJson && window.hljs.highlightElement(contentEl);
                     })


### PR DESCRIPTION
Replaces html special characters with html entities in response.

If an API response contains html this is currently not visible in Received Response section.

Before
![scribe_before](https://github.com/user-attachments/assets/33b885de-4efc-4aa8-aa34-d7f3b27f20f8)

After
![scribe_after](https://github.com/user-attachments/assets/3e603087-f0ec-4e65-a213-e28def8002ac)


<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

