### PR TITLE
Improve Laravel dd() Output Rendering in Scribe Documentation

### DIFF
--- a/resources/css/theme-default.style.css
+++ b/resources/css/theme-default.style.css
@@ -894,6 +894,11 @@ html {
     text-shadow: 0 1px 2px rgba(0, 0, 0, .4)
 }
 
+.content blockquote pre.sf-dump,
+.content pre pre.sf-dump {
+    width: 100%;
+}
+
 .content .annotation {
     background-color: #292929;
     color: #fff;

--- a/resources/js/tryitout.js
+++ b/resources/js/tryitout.js
@@ -139,6 +139,17 @@ function handleResponse(endpointId, response, status, headers) {
 
     const responseContentEl = document.querySelector('#execution-response-content-' + endpointId);
 
+    // Check if the response contains Laravel's  dd() default dump output
+    const isLaravelDump = response.includes('Sfdump');
+
+    // If it's a Laravel dd() dump, use innerHTML to render it safely
+    if (isLaravelDump) {
+        responseContentEl.innerHTML = response === '' ? responseContentEl.dataset.emptyResponseText : response;
+    } else {
+        // Otherwise, stick to textContent for regular responses
+        responseContentEl.textContent = response === '' ? responseContentEl.dataset.emptyResponseText : response;
+    }
+
     // Prettify it if it's JSON
     let isJson = false;
     try {
@@ -146,11 +157,12 @@ function handleResponse(endpointId, response, status, headers) {
         if (jsonParsed !== null) {
             isJson = true;
             response = JSON.stringify(jsonParsed, null, 4);
+            responseContentEl.textContent = response;
         }
     } catch (e) {
 
     }
-    responseContentEl.textContent = response === '' ? responseContentEl.dataset.emptyResponseText : response;
+
     isJson && window.hljs.highlightElement(responseContentEl);
     const statusEl = document.querySelector('#execution-response-status-' + endpointId);
     statusEl.textContent = ` (${status})`;


### PR DESCRIPTION
This PR addresses an issue where the output of Laravel's dd() function is rendered as plain text in the generated documentation by Scribe. The changes introduce a selective rendering mechanism that safely treats dd() output as HTML while keeping all other API responses as plain text, ensuring proper security.

- Laravel dd() detection: The script now checks for the presence of sf-dump in the response to identify dd() output.

- Secure rendering: Only the detected dd() output is rendered using innerHTML to display the HTML dump correctly. Other responses continue to use textContent to avoid XSS vulnerabilities.

This update improves the developer experience by ensuring that Laravel debug outputs are correctly formatted in the API documentation, while maintaining security.