### PR TITLE
feat: Add description to type as object when generating swagger file

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -596,9 +596,7 @@ class OpenAPISpecWriter
             'type' => $this->convertScribeOrPHPTypeToOpenAPIType(gettype($value)),
             'example' => $value,
         ];
-        if (isset($endpoint->responseFields[$path]->description)) {
-            $schema['description'] = $endpoint->responseFields[$path]->description;
-        }
+        $this->setDescription($schema, $endpoint, $path);
 
         if ($schema['type'] === 'array' && !empty($value)) {
             $schema['example'] = json_decode(json_encode($schema['example']), true); // Convert stdClass to array
@@ -615,5 +613,12 @@ class OpenAPISpecWriter
         }
 
         return $schema;
+    }
+
+    private function setDescription(array &$schema, OutputEndpointData $endpoint, string $path): void
+    {
+        if (isset($endpoint->responseFields[$path]->description)) {
+            $schema['description'] = $endpoint->responseFields[$path]->description;
+        }
     }
 }

--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -586,10 +586,13 @@ class OpenAPISpecWriter
                 $properties[$subField] = $this->generateSchemaForValue($subValue, $endpoint, $subFieldPath);
             }
 
-            return [
+            $schema = [
                 'type' => 'object',
                 'properties' => $this->objectIfEmpty($properties),
             ];
+            $this->setDescription($schema, $endpoint, $path);
+
+            return $schema;
         }
 
         $schema = [
@@ -615,6 +618,9 @@ class OpenAPISpecWriter
         return $schema;
     }
 
+    /**
+     * Set the description for the schema. If the field has a description, it is set in the schema.
+     */
     private function setDescription(array &$schema, OutputEndpointData $endpoint, string $path): void
     {
         if (isset($endpoint->responseFields[$path]->description)) {


### PR DESCRIPTION
When outputting to a swagger file, add a `description` field to the field whose type is object.