### PR TITLE
Fix issue with model relations being lost after refresh in getExample…

### DIFF
--- a/src/Extracting/InstantiatesExampleModels.php
+++ b/src/Extracting/InstantiatesExampleModels.php
@@ -69,7 +69,7 @@ trait InstantiatesExampleModels
     protected function getExampleModelFromFactoryCreate(string $type, array $factoryStates = [], array $relations = [])
     {
         $factory = Utils::getModelFactory($type, $factoryStates, $relations);
-        return $factory->create()->load($relations)->refresh();
+        return $factory->create()->refresh()->load($relations);
     }
 
     /**


### PR DESCRIPTION
**Description :**

This PR addresses an issue in the getExampleModelFromFactoryCreate function, where model relations were being loaded before calling refresh(). This caused the loaded relations to be cleared when the model was refreshed, resulting in the loss of relation data.

**Example :**

In a case like this:

`#[ResponseFromApiResource(UserResponse::class, User::class, with: ['job.agency'])]`

The agency relation would be cleared by the refresh(), even though it is part of the relations to be loaded. The loading works, but the refresh wipes out the agency relation. With this fix, this issue is resolved.

**Changes :**

Moved the refresh() call to occur before load() in getExampleModelFromFactoryCreate, ensuring that relations are loaded after the model has been refreshed, preserving the relation data.
This fix will prevent relations from being lost after a model refresh and ensure proper loading of related models.

Let me know if you need further adjustments !
