### PR TITLE
Add enum list to Open API spec response properties

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -609,6 +609,11 @@ class OpenAPISpecWriter
         ];
         $this->setDescription($schema, $endpoint, $path);
 
+        // Set enum values for the property if they exist
+        if (isset($endpoint->responseFields[$path]->enumValues)) {
+            $schema['enum'] = $endpoint->responseFields[$path]->enumValues;
+        }
+
         if ($schema['type'] === 'array' && !empty($value)) {
             $schema['example'] = json_decode(json_encode($schema['example']), true); // Convert stdClass to array
 

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -744,6 +744,45 @@ class OpenAPISpecWriterTest extends BaseUnitTest
         ], $results['paths']['/path1']['post']['responses']);
     }
 
+    /** @test */
+    public function adds_enum_values_to_response_properties()
+    {
+        $endpointData = $this->createMockEndpointData([
+            'uri' => '/path',
+            'httpMethods' => ['POST'],
+            'responses' => [
+                [
+                    'status' => 200,
+                    'description' => 'This one',
+                    'content' => '{"status": "one"}',
+                ],
+            ],
+            'responseFields' => [
+                'status' => ['enumValues' => ['one', 'two', 'three']],
+            ],
+        ]);
+
+        $groups = [$this->createGroup([$endpointData])];
+
+        $results = $this->generate($groups);
+
+        $this->assertArraySubset([
+            '200' => [
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'properties' => [
+                                'status' => [
+                                    'enum' => ['one', 'two', 'three'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $results['paths']['/path']['post']['responses']);
+    }
+
     protected function createMockEndpointData(array $custom = []): OutputEndpointData
     {
         $faker = Factory::create();


### PR DESCRIPTION
Thanks for all you do! Scribe has been immensely useful and has simplified our documentation workflow significantly.

This PR includes an update which allows enum types defined via `ResponseField` to flow through to the response properties in the Open API spec. For example:

```php
class GetStoreController extends Controller
{
    #[ResponseField("status", enum: StoreStatus::class)]
    #[ResponseFromDataObject(StoreResource::class, Store::class)]
    public function __invoke()
    {
        // etc...
    }
}
```

... results in:

```yaml
openapi: 3.0.3
info:
  title: 'Test API'
  description: ''
  version: 1.0.0
servers:
  -
    url: 'https://devserver.dev'
paths:
  /v1/resolve:
    get:
      summary: 'Get Store'
      operationId: getStore
      description: 'Fetches the essential store information'
      responses:
        200:
          description: ''
          content:
            application/json:
              schema:
                type: object
                example:
                  id: 1
                  status: open
                properties:
                  id:
                    type: integer
                    example: 1
                  status:
                    type: string
                    example: open
                    enum:
                      - open
                      - restricted
                      - closed
                      - permanently_closed

```

Previously (before this commit) the `enum` key was omitted.

There was already a PR to [include the enum values in the query params](https://github.com/knuckleswtf/scribe/pull/818), this simply implements the same behaviour for the response parameters.

Note that this does not work for response bodies where the entire payload is wrapped in a `data` key, I'll try and address this in a later PR.