### PR TITLE
Feature/required fields for nested objects

### DIFF
--- a/src/Writing/OpenAPISpecWriter.php
+++ b/src/Writing/OpenAPISpecWriter.php
@@ -635,6 +635,11 @@ class OpenAPISpecWriter
                 $schema['items']['properties'] = collect($sample)->mapWithKeys(function ($v, $k) use ($endpoint, $path) {
                     return [$k => $this->generateSchemaForValue($v, $endpoint, "$path.$k")];
                 })->toArray();
+
+                $required = $this->filterRequiredFields($endpoint, array_keys($schema['items']['properties']), $path);
+                if ($required) {
+                    $schema['required'] = $required;
+                }
             }
         }
 

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -599,6 +599,92 @@ class OpenAPISpecWriterTest extends BaseUnitTest
     }
 
     /** @test */
+    public function adds_required_fields_on_objects_wrapped_in_array()
+    {
+        $endpointData = $this->createMockEndpointData([
+            'httpMethods' => ['GEt'],
+            'uri' => '/path1',
+            'responses' => [
+                [
+                    'status' => 200,
+                    'description' => 'List of entities',
+                    'content' => '{"data":[{"name":"Resource name","uuid":"UUID","primary":true}]}',
+                ],
+            ],
+            'responseFields' => [
+                'data' => [
+                    'name' => 'data',
+                    'type' => 'array',
+                    'description' => 'Data wrapper',
+                ],
+                'data.name' => [
+                    'name' => 'Resource name',
+                    'type' => 'string',
+                    'description' => 'Name of the resource object',
+                    'required' => true,
+                ],
+                'data.uuid' => [
+                    'name' => 'Resource UUID',
+                    'type' => 'string',
+                    'description' => 'Unique ID for the resource',
+                    'required' => true,
+                ],
+                'data.primary' => [
+                    'name' => 'Is primary',
+                    'type' => 'bool',
+                    'description' => 'Is primary resource',
+                    'required' => true,
+                ],
+            ],
+        ]);
+
+        $groups = [$this->createGroup([$endpointData])];
+
+        $results = $this->generate($groups);
+
+        $this->assertArraySubset([
+            '200' => [
+                'description' => 'List of entities',
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'data' => [
+                                    'type' => 'array',
+                                    'description' => 'Data wrapper',
+                                    'items' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'name' => [
+                                                'type' => 'string',
+                                                'description' => 'Name of the resource object',
+                                            ],
+                                            'uuid' => [
+                                                'type' => 'string',
+                                                'description' => 'Unique ID for the resource',
+                                            ],
+                                            'primary' => [
+                                                'type' => 'boolean',
+                                                'description' => 'Is primary resource',
+                                            ],
+                                        ],
+                                    ],
+                                    'required' => [
+                                        'name',
+                                        'uuid',
+                                        'primary',
+                                    ]
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $results['paths']['/path1']['get']['responses']);
+    }
+
+    /** @test */
     public function adds_multiple_responses_correctly_using_oneOf()
     {
         $endpointData1 = $this->createMockEndpointData([


### PR DESCRIPTION
Added check for `required` fields to the loop inspecting nested object.

Example input:
```php
use Knuckles\Scribe\Attributes\Endpoint;
use Knuckles\Scribe\Attributes\Group;
use Knuckles\Scribe\Attributes\Response as ResponseDoc;
use Knuckles\Scribe\Attributes\ResponseField;
use Symfony\Component\HttpFoundation\Response;

#[Endpoint('List wallets', 'Lists wallets of current customer.')]
#[ResponseField('data', 'object', 'Wallets', required: true)]
#[ResponseField('data.name', 'string', 'Wallet name', required: true)]
#[ResponseField('data.technical_id', 'string', 'Unique wallet ID', required: true)]
#[ResponseField('data.primary', 'bool', 'Is primary wallet for given currency', required: true)]
#[ResponseField('data.currency', 'string', 'Wallet currency', required: true, enum: ['USD', 'EUR', 'JPY', 'SGD'])]
#[ResponseDoc(
    [
        'data' => [
            [
                'name' => 'Wallet name',
                'technical_id' => '987654',
                'primary' => true,
                'currency' => 'USD',
            ],
        ],
    ],
    Response::HTTP_OK
)]
```

OpenAPI spec **before** (relevant part - 200 response):
```yaml
responses:
        200:
          description: ''
          content:
            application/json:
              schema:
                type: object
                example:
                  data:
                    -
                      name: 'Wallet name'
                      technical_id: '987654'
                      primary: true
                      currency: USD
                properties:
                  data:
                    type: array
                    example:
                      -
                        name: 'Wallet name'
                        technical_id: '987654'
                        primary: true
                        currency: USD
                    description: Wallets
                    enum: []
                    items:
                      type: object
                      properties:
                        name:
                          type: string
                          example: 'Wallet name'
                          description: 'Wallet name'
                          enum: []
                        technical_id:
                          type: string
                          example: '987654'
                          description: 'Unique wallet ID'
                          enum: []
                        primary:
                          type: boolean
                          example: true
                          description: 'Is primary wallet for given currency'
                          enum: []
                        currency:
                          type: string
                          example: USD
                          description: 'Wallet currency'
                          enum:
                            - USD
                            - EUR
                            - JPY
                            - SGD
                required:
                  - data
```

OpenAPI spec after (notice `required` list at the end):
```yaml
responses:
        200:
          description: ''
          content:
            application/json:
              schema:
                type: object
                example:
                  data:
                    -
                      name: 'Wallet name'
                      technical_id: '987654'
                      primary: true
                      currency: USD
                properties:
                  data:
                    type: array
                    example:
                      -
                        name: 'Wallet name'
                        technical_id: '987654'
                        primary: true
                        currency: USD
                    description: Wallets
                    enum: []
                    items:
                      type: object
                      properties:
                        name:
                          type: string
                          example: 'Wallet name'
                          description: 'Wallet name'
                          enum: []
                        technical_id:
                          type: string
                          example: '987654'
                          description: 'Unique wallet ID'
                          enum: []
                        primary:
                          type: boolean
                          example: true
                          description: 'Is primary wallet for given currency'
                          enum: []
                        currency:
                          type: string
                          example: USD
                          description: 'Wallet currency'
                          enum:
                            - USD
                            - EUR
                            - JPY
                            - SGD
                    required:
                      - name
                      - technical_id
                      - primary
                      - currency
                required:
                  - data
```


