### PR TITLE
add str replace for external_laravel with theme "elements"

### DIFF
--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -178,6 +178,7 @@ class Writer
         $contents = str_replace('href="../docs/collection.json"', 'href="{{ route("' . $this->paths->outputPath('postman', '.') . '") }}"', $contents);
         $contents = str_replace('href="../docs/openapi.yaml"', 'href="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
         $contents = str_replace('url="../docs/openapi.yaml"', 'url="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
+        // With Elements theme, we'd have <elements-api apiDescriptionUrl="../docs/openapi.yaml" 
         $contents = str_replace('Url="../docs/openapi.yaml"', 'Url="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
 
         file_put_contents("$this->laravelTypeOutputPath/index.blade.php", $contents);

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -178,6 +178,7 @@ class Writer
         $contents = str_replace('href="../docs/collection.json"', 'href="{{ route("' . $this->paths->outputPath('postman', '.') . '") }}"', $contents);
         $contents = str_replace('href="../docs/openapi.yaml"', 'href="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
         $contents = str_replace('url="../docs/openapi.yaml"', 'url="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
+        $contents = str_replace('Url="../docs/openapi.yaml"', 'Url="{{ route("' . $this->paths->outputPath('openapi', '.') . '") }}"', $contents);
 
         file_put_contents("$this->laravelTypeOutputPath/index.blade.php", $contents);
     }


### PR DESCRIPTION
Added another str_replace so that the case for external_laravel with the theme "elements" is also matched.

Without the new str_replace the following is generated in the index.blade.php file:
`<elements-api apiDescriptionUrl="../docs/openapi.yaml" ...`
With the new str_replace the relative url is replaced with a route:
`<elements-api apiDescriptionUrl="{{ route("scribe.openapi") }}" ...`

The problem only occurs if laravel.docs_url is changed manually.
Then the openapi.yaml-file cannot be found.

This is not a problem with scalar and rapidoc, as the attribute (e.g. data-url) matches a lowercase ‘url’ correctly.
