### PR TITLE
Fix parsing no content into null instead of 'null'

### DIFF
--- a/src/Attributes/Response.php
+++ b/src/Attributes/Response.php
@@ -18,7 +18,11 @@ class Response
     {
         return  [
             "status" => $this->status,
-            "content" => is_string($this->content) ? $this->content : json_encode($this->content, JSON_THROW_ON_ERROR),
+            "content" => match (true) {
+                is_null($this->content) => null,
+                is_string($this->content) => $this->content,
+                default => json_encode($this->content, JSON_THROW_ON_ERROR),
+            },
             "description" => $this->description,
         ];
     }

--- a/tests/Strategies/Responses/UseResponseAttributesTest.php
+++ b/tests/Strategies/Responses/UseResponseAttributesTest.php
@@ -73,6 +73,10 @@ class UseResponseAttributesTest extends BaseLaravelTest
                 'status' => 201,
                 'content' => json_encode(["all" => "good"]),
             ],
+            [
+                'status' => 404,
+                'content' => null,
+            ]
         ], $results);
     }
 
@@ -246,6 +250,7 @@ class ResponseAttributesTestController
 {
     #[Response(["all" => "good"], 200, "Success")]
     #[Response('{"all":"good"}', 201)]
+    #[Response(status: 404)]
     public function plainResponseAttributes()
     {
 


### PR DESCRIPTION
Hello 👋 
Thank you for the package, we are really enjoying all the work you put into it. I hope you will accept this small change which we think might be a bug :) 


## Problem
When having a response with no content in it, it ends up showing as plaintext in openapi spec.

```php
#[Response(status: 404, description: 'Organization not found')]
```

Will be generated as 
```yaml
        404:
          description: 'Organization not found'
          content:
            text/plain:
              schema:
                type: string
                example: 'null'
```

## solution
To fix this problem, we make sure that if the content is null, we pass `null` forward when converting the attribute to an array. Previously the `null` value was passed through `json_encode` which will convert it into `'null'`. 

After this solution, we end up with 
```yaml
        404:
          description: 'Organization not found'
          content:
            application/json:
              schema:
                type: object
                nullable: true
```                
