### PR TITLE
fix: RequestValidateFacade Variable could not be converted to string

### DIFF
--- a/src/Extracting/Shared/ValidationRulesFinders/RequestValidateFacade.php
+++ b/src/Extracting/Shared/ValidationRulesFinders/RequestValidateFacade.php
@@ -25,13 +25,14 @@ class RequestValidateFacade
 
         if (
             $expr instanceof Node\Expr\StaticCall
-            && in_array((string) $expr->class, ['Request', \Illuminate\Support\Facades\Request::class])
+            && $expr->class instanceof Node\Name
+            && in_array($expr->class->name, ['Request', \Illuminate\Support\Facades\Request::class])
         ) {
-            if ($expr->name->name == "validate") {
+            if ($expr->name->name === "validate") {
                 return $expr->args[0]->value;
             }
 
-            if ($expr->name->name == "validateWithBag") {
+            if ($expr->name->name === "validateWithBag") {
                 return $expr->args[1]->value;
             }
         }


### PR DESCRIPTION
This PR fixes a bug when RequestValidateFacade is parsing controller methods in specific context.

Given this exemple :

```php
#[Group('ExampleGroup')]
#[ResponseFromApiResource(ExampleResource::class, ExampleModel::class, collection: true, paginate: 20)]
public function handle(Request $req, EnumType $type, int $val): ResourceCollection
{
    $modelType = match ($type) {
        EnumType::OPTION_A => ModelA::class,
    };

    // Ensure presence in DB or fail to 404
    $model = $modelType::findOrFail($val);

    return ExampleResource::collection($model);
}
```

When generating doc with artisan `RequestValidateFacade` will end in the exception 
```
Object of class PhpParser\Node\Expr\Variable could not be converted to string

  at vendor/knuckleswtf/scribe/src/Extracting/Shared/ValidationRulesFinders/RequestValidateFacade.php:28
     24▕         }
     25▕ 
     26▕         if (
     27▕             $expr instanceof Node\Expr\StaticCall
  ➜  28▕             && in_array((string) $expr->class, ['Request', \Illuminate\Support\Facades\Request::class])
     29▕         ) {
     30▕             if ($expr->name->name == "validate") {
     31▕                 return $expr->args[0]->value;
     32▕             }

      +22 vendor frames
```

Because line 28 is calling toString method on `$expr->class` but it has no toString method in `PhpParser\Node\Expr\Variable` object. It is `$model = $modelType::findOrFail($val);` which causes the problem.

Thi PR ensure we check class name onto the right objects to avoid this bug. 
