### PR TITLE
fix: Collection with formdata malformed for API

### DIFF
--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -222,7 +222,7 @@ class PostmanCollectionWriter
             if (!is_array($value)) {
                 $body[] = [
                     'key' => $index,
-                    'value' => $value,
+                    'value' => (string) $value,
                     'type' => 'text',
                     'description' => $paramsFullDetails[$index]->description ?? '',
                 ];


### PR DESCRIPTION
# Fix for #881 

The Postman API accepts the types 'text' and 'file', so passing 'text' with an integer value throws the error from the issue. To fix this the value is always cast to string. The string value is ok for the api and the generated documentation works