### PR TITLE
Add support for defining Groups and Subgroups as enums

### DIFF
--- a/src/Attributes/Group.php
+++ b/src/Attributes/Group.php
@@ -8,17 +8,32 @@ use Attribute;
 class Group
 {
     public function __construct(
-        public string $name,
+        public mixed $name,
         public ?string $description = '',
         /** You can use the separate #[Authenticated] attribute, or pass authenticated: false to this. */
         public ?bool   $authenticated = null,
     ){
     }
 
+    protected function getName(): string
+    {
+        if (is_string($this->name)) {
+            return $this->name;
+        }
+
+        if (interface_exists('BackedEnum') && is_a($this->name, 'BackedEnum')) {
+            return $this->name->value;
+        }
+
+        throw new \InvalidArgumentException(
+            'The name property of a group must be either a PHP Backed Enum or a string'
+        );
+    }
+
     public function toArray()
     {
         $data = [
-            "groupName" => $this->name,
+            "groupName" => $this->getName(),
             "groupDescription" => $this->description,
         ];
 

--- a/src/Attributes/Subgroup.php
+++ b/src/Attributes/Subgroup.php
@@ -8,15 +8,30 @@ use Attribute;
 class Subgroup
 {
     public function __construct(
-        public string $name,
+        public mixed $name,
         public ?string $description = '',
     ){
+    }
+
+    protected function getName(): string
+    {
+        if (is_string($this->name)) {
+            return $this->name;
+        }
+
+        if (interface_exists('BackedEnum') && is_a($this->name, 'BackedEnum')) {
+            return $this->name->value;
+        }
+
+        throw new \InvalidArgumentException(
+            'The name property of a group must be either a PHP Backed Enum or a string'
+        );
     }
 
     public function toArray()
     {
         return [
-            "subgroup" => $this->name,
+            "subgroup" => $this->getName(),
             "subgroupDescription" => $this->description,
         ];
     }

--- a/src/Attributes/Subgroup.php
+++ b/src/Attributes/Subgroup.php
@@ -24,7 +24,7 @@ class Subgroup
         }
 
         throw new \InvalidArgumentException(
-            'The name property of a group must be either a PHP Backed Enum or a string'
+            'The name property of a subgroup must be either a PHP Backed Enum or a string'
         );
     }
 

--- a/tests/Fixtures/TestGroupBackedEnum.php
+++ b/tests/Fixtures/TestGroupBackedEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+enum TestGroupBackedEnum: string
+{
+    case Users = 'Users';
+    case Admins = 'Admins';
+}

--- a/tests/Strategies/Metadata/GetFromMetadataAttributesTest.php
+++ b/tests/Strategies/Metadata/GetFromMetadataAttributesTest.php
@@ -10,6 +10,7 @@ use Knuckles\Scribe\Attributes\Group;
 use Knuckles\Scribe\Attributes\Subgroup;
 use Knuckles\Scribe\Attributes\Unauthenticated;
 use Knuckles\Scribe\Extracting\Strategies\Metadata\GetFromMetadataAttributes;
+use Knuckles\Scribe\Tests\Fixtures\TestGroupBackedEnum;
 use Knuckles\Scribe\Tools\DocumentationConfig;
 use PHPUnit\Framework\TestCase;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
@@ -80,6 +81,21 @@ class UseMetadataAttributesTest extends TestCase
             "subgroup" => "SG BA",
             "subgroupDescription" => "",
             "title" => "Endpoint B1",
+            "description" => "",
+            "authenticated" => false,
+        ], $results);
+
+        $endpoint = $this->endpoint(function (ExtractedEndpointData $e) {
+            $e->controller = new ReflectionClass(MetadataAttributesTestController::class);
+            $e->method = $e->controller->getMethod('b2');
+        });
+        $results = $this->fetch($endpoint);
+        $this->assertArraySubset([
+            "groupName" => "Users",
+            "groupDescription" => "",
+            "subgroup" => "Admins",
+            "subgroupDescription" => "",
+            "title" => "Endpoint B2",
             "description" => "",
             "authenticated" => false,
         ], $results);
@@ -157,6 +173,13 @@ class MetadataAttributesTestController
     #[Subgroup("SG BA")]
     #[Endpoint("Endpoint B1")]
     public function b1()
+    {
+    }
+
+    #[Group(TestGroupBackedEnum::Users)]
+    #[Subgroup(TestGroupBackedEnum::Admins)]
+    #[Endpoint("Endpoint B2")]
+    public function b2()
     {
     }
 }


### PR DESCRIPTION

## Problem
When defining groups and subgroups, it's nice to have a clear idea of what groups are available to use. PHP Backed Enums are a perfect way of achieving this. Otherwise, developers could mis-type group names easily such as;
```php
#[Group('Users')];
#[Group('User')];  // typo
```

## Solution
By allowing the usage of Backed Enums, it is very clean to be able to define your API Endpoint Groups as an enum;
```php
enum EndpointGroup: string
{
    case Users = 'Users';
    case Invoices = 'Invoices';
}
```
Then in your codebase you can simply do;
```php
#[Group(EndpointGroup::Invoices)]
class InvoiceController
{
   // ...
}
```

### Alternative
An alternative could be to just add `->value` to each enum which would not require any codebase changes however this is not visually pleasing and not as nice of a DX as being able to pass an enum directly.
```php
#[Group(EndpointGroup::Invoices->value)]
class InvoiceController
{
   // ...
}
```