### PR TITLE
fix: allow blade syntax in baseUrl config

### DIFF
--- a/resources/views/themes/elements/endpoint.blade.php
+++ b/resources/views/themes/elements/endpoint.blade.php
@@ -1,6 +1,7 @@
 @php
     use Knuckles\Scribe\Tools\Utils as u;
     /** @var  Knuckles\Camel\Output\OutputEndpointData $endpoint */
+    use Illuminate\Support\Facades\Blade as Blade;
 @endphp
 
 <div class="sl-stack sl-stack--vertical sl-stack--8 HttpOperation sl-flex sl-flex-col sl-items-stretch sl-w-full">
@@ -15,7 +16,7 @@
         </div>
 
         <div class="sl-relative">
-            <div title="{{ rtrim($baseUrl, '/') . '/'. ltrim($endpoint->uri, '/') }}"
+            <div title="{{ rtrim(Blade::render($baseUrl), '/') . '/'. ltrim($endpoint->uri, '/') }}"
                      class="sl-stack sl-stack--horizontal sl-stack--3 sl-inline-flex sl-flex-row sl-items-center sl-max-w-full sl-font-mono sl-py-2 sl-pr-4 sl-bg-canvas-50 sl-rounded-lg"
                 >
                     @foreach($endpoint->httpMethods as $method)
@@ -27,7 +28,7 @@
                     @endforeach
                     <div class="sl-flex sl-overflow-x-hidden sl-text-lg sl-select-all">
                         <div dir="rtl"
-                             class="sl-overflow-x-hidden sl-truncate sl-text-muted">{{ rtrim($baseUrl, '/') }}</div>
+                             class="sl-overflow-x-hidden sl-truncate sl-text-muted">{{ rtrim(Blade::render($baseUrl), '/') }}</div>
                         <div class="sl-flex-1 sl-font-semibold">/{{ ltrim($endpoint->uri, '/') }}</div>
                     </div>
 


### PR DESCRIPTION
Fixes #943

This PR allows the use of Blade syntax in the `baseUrl` configuration by rendering the value through the Blade facade before displaying it.

### Changes
- Added Blade facade import
- Wrapped `baseUrl` values in `Blade::render()` to process any Blade syntax

### Notes
- Tested with Laravel only, compatibility with Dingo API has not been verified
- This enables dynamic baseUrl values using Blade syntax like `{{ config('app.url') }}` or `{{ config('app.tenant_url') }}`

### References
- Issue #943: Support blade syntax in config baseUrl

Let me know if any changes are needed!