### PR TITLE
fix: Undefined array key "properties"

### DIFF
--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -549,11 +549,12 @@ class BaseGenerator extends OpenApiGenerator
                 $schema['items']['properties'] = collect($sample)->mapWithKeys(function ($v, $k) use ($endpoint, $path) {
                     return [$k => $this->generateSchemaForResponseValue($v, $endpoint, "$path.$k")];
                 })->toArray();
-            }
-
-            $required = $this->filterRequiredResponseFields($endpoint, array_keys($schema['items']['properties']), $path);
-            if ($required) {
-                $schema['required'] = $required;
+                
+                $required = $this->filterRequiredResponseFields($endpoint, array_keys($schema['items']['properties']),
+                    $path);
+                if ($required) {
+                    $schema['required'] = $required;
+                }
             }
         }
 


### PR DESCRIPTION
Hey! An happy Scribe user here.

I just tried updating to version 5 and encountered an exception while generating the documents.

I'm not sure about this PR. I haven't explored it enough to understand how the internals work but this PR did resolve my issue.

Please treat this PR as a bug report and don't hesitate to close it down.

<img width="778" alt="Capture d’écran 2025-02-19 à 12 09 56" src="https://github.com/user-attachments/assets/ad01a279-1bf4-45cc-8f56-c50f9d3e9172" />
