### PR TITLE
Updated scalar view to support configuration using html_attributes config

### DIFF
--- a/resources/views/external/scalar.blade.php
+++ b/resources/views/external/scalar.blade.php
@@ -1,27 +1,24 @@
 <!doctype html>
 <html>
+
 <head>
     <title>{!! $metadata['title'] !!}</title>
-    <meta charset="utf-8"/>
-    <meta
-        name="viewport"
-        content="width=device-width, initial-scale=1"/>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
         body {
             margin: 0;
         }
     </style>
 </head>
+
 <body>
 
-<script
-    id="api-reference"
-@foreach($htmlAttributes as $attribute => $value)
-    {{-- Attributes specified first override later ones --}}
-    {!! $attribute !!}="{!! $value !!}"
-@endforeach
-    data-url="{!! $metadata['openapi_spec_url'] !!}">
-</script>
-<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script id="api-reference" data-url="{!! $metadata['openapi_spec_url'] !!}"></script>
+    <script>
+        document.getElementById('api-reference').dataset.configuration = JSON.stringify({!! json_encode($htmlAttributes) !!});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
 </body>
+
 </html>


### PR DESCRIPTION
I was having issues configuring Scalar using the html_attributes property in the config which I created issue #949 for. After doing a bit of debugging I found out that the Scalar view didn't set the html_attributes property as the config properly and have updated the view to support this