### PR TITLE
feat: add support to 'sometimes' rule

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -79,8 +79,10 @@ trait ParsesValidationRules
 
                 // First pass: process rules which provide no type or example info
                 $firstPassRuleNames = [
+                    "sometimes",
                     "required",
                     "required_*",
+                    "accepted",
                     "same",
                     "different",
                     "nullable",

--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -284,9 +284,9 @@ trait ParsesValidationRules
                     $parameterData['setter'] = fn() => true;
                     break;
 
-                    /*
-                    * Primitive types. No description should be added
-                    */
+                /*
+                * Primitive types. No description should be added
+                */
                 case 'bool':
                 case 'boolean':
                     $parameterData['setter'] = function () {
@@ -327,9 +327,9 @@ trait ParsesValidationRules
                     };
                     break;
 
-                    /**
-                     * Special string types
-                     */
+                /**
+                 * Special string types
+                 */
                 case 'alpha':
                     $parameterData['description'] .= " Must contain only letters.";
                     $parameterData['setter'] = function () {
@@ -426,9 +426,9 @@ trait ParsesValidationRules
                     $parameterData['setter'] = fn() => $this->getFaker()->regexify($arguments[0]);;
                     break;
 
-                    /**
-                     * Special number types.
-                     */
+                /**
+                 * Special number types.
+                 */
                 case 'digits':
                     $parameterData['description'] .= ' ' . $this->getDescription($rule, [':digits' => $arguments[0]]);
                     $parameterData['setter'] = fn() => $this->getFaker()->numerify(str_repeat("#", $arguments[0]));
@@ -440,39 +440,39 @@ trait ParsesValidationRules
                     $parameterData['type'] = 'string';
                     break;
 
-                    /**
-                     * These rules can apply to numbers, strings, arrays or files
-                     */
+                /**
+                 * These rules can apply to numbers, strings, arrays or files
+                 */
                 case 'size':
                     $parameterData['description'] .= ' ' . $this->getDescription(
-                        $rule, [':size' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
-                    );
+                            $rule, [':size' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
+                        );
                     $parameterData['setter'] = $this->getDummyValueGenerator($parameterData['type'], ['size' => $arguments[0]]);
                     break;
                 case 'min':
                     $parameterData['description'] .= ' ' . $this->getDescription(
-                        $rule, [':min' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
-                    );
+                            $rule, [':min' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
+                        );
                     $parameterData['setter'] = $this->getDummyDataGeneratorBetween($parameterData['type'], floatval($arguments[0]), fieldName: $parameterData['name']);
                     break;
                 case 'max':
                     $parameterData['description'] .= ' ' . $this->getDescription(
-                        $rule, [':max' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
-                    );
+                            $rule, [':max' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
+                        );
                     $max = min($arguments[0], 25);
                     $parameterData['setter'] = $this->getDummyDataGeneratorBetween($parameterData['type'], 1, $max, $parameterData['name']);
                     break;
                 case 'between':
                     $parameterData['description'] .= ' ' . $this->getDescription(
-                        $rule, [':min' => $arguments[0], ':max' => $arguments[1]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
-                    );
+                            $rule, [':min' => $arguments[0], ':max' => $arguments[1]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
+                        );
                     // Avoid exponentially complex operations by using the minimum length
                     $parameterData['setter'] = $this->getDummyDataGeneratorBetween($parameterData['type'], floatval($arguments[0]), floatval($arguments[0]) + 1, $parameterData['name']);
                     break;
 
-                    /**
-                     * Special file types.
-                     */
+                /**
+                 * Special file types.
+                 */
                 case 'image':
                     $parameterData['type'] = 'file';
                     $parameterData['description'] .= ' ' . $this->getDescription($rule) . ' ';
@@ -482,9 +482,9 @@ trait ParsesValidationRules
                     };
                     break;
 
-                    /**
-                     * Other rules.
-                     */
+                /**
+                 * Other rules.
+                 */
                 case 'in':
                     $parameterData['enumValues'] = $arguments;
                     $parameterData['setter'] = function () use ($arguments) {
@@ -492,9 +492,9 @@ trait ParsesValidationRules
                     };
                     break;
 
-                    /**
-                     * These rules only add a description. Generating valid examples is too complex.
-                     */
+                /**
+                 * These rules only add a description. Generating valid examples is too complex.
+                 */
                 case 'not_in':
                     $parameterData['description'] .= ' Must not be one of ' . w::getListOfValuesAsFriendlyHtmlString($arguments) . ' ';
                     break;
@@ -598,9 +598,9 @@ trait ParsesValidationRules
             if (isset($parameterData['setter'])) {
                 return $parameterData['setter']();
             } else {
-            return $parameterData['required']
-                ? $this->generateDummyValue($parameterData['type'])
-                : null;
+                return $parameterData['required']
+                    ? $this->generateDummyValue($parameterData['type'])
+                    : null;
             }
         } else if (!is_null($parameterData['example']) && $parameterData['example'] !== self::$MISSING_VALUE) {
             if($parameterData['example'] === 'No-example' && !$parameterData['required']){

--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -47,6 +47,7 @@ trait ParsesValidationRules
                 $parameterData = [
                     'name' => $parameter,
                     'required' => false,
+                    'sometimes' => false,
                     'type' => null,
                     'example' => self::$MISSING_VALUE,
                     'description' => $description,
@@ -266,19 +267,26 @@ trait ParsesValidationRules
             }
 
             switch ($rule) {
+                case 'sometimes':
+                    $parameterData['sometimes'] = true;
+                    break;
                 case 'required':
-                    $parameterData['required'] = true;
+                    if (!$parameterData['sometimes']) {
+                        $parameterData['required'] = true;
+                    }
                     break;
                 case 'accepted':
-                    $parameterData['required'] = true;
+                    if (!$parameterData['sometimes']) {
+                        $parameterData['required'] = true;
+                    }
                     $parameterData['type'] = 'boolean';
                     $parameterData['description'] .= ' Must be accepted.';
                     $parameterData['setter'] = fn() => true;
                     break;
 
-                /*
-                * Primitive types. No description should be added
-                */
+                    /*
+                    * Primitive types. No description should be added
+                    */
                 case 'bool':
                 case 'boolean':
                     $parameterData['setter'] = function () {
@@ -319,9 +327,9 @@ trait ParsesValidationRules
                     };
                     break;
 
-                /**
-                 * Special string types
-                 */
+                    /**
+                     * Special string types
+                     */
                 case 'alpha':
                     $parameterData['description'] .= " Must contain only letters.";
                     $parameterData['setter'] = function () {
@@ -418,9 +426,9 @@ trait ParsesValidationRules
                     $parameterData['setter'] = fn() => $this->getFaker()->regexify($arguments[0]);;
                     break;
 
-                /**
-                 * Special number types.
-                 */
+                    /**
+                     * Special number types.
+                     */
                 case 'digits':
                     $parameterData['description'] .= ' ' . $this->getDescription($rule, [':digits' => $arguments[0]]);
                     $parameterData['setter'] = fn() => $this->getFaker()->numerify(str_repeat("#", $arguments[0]));
@@ -432,39 +440,39 @@ trait ParsesValidationRules
                     $parameterData['type'] = 'string';
                     break;
 
-                /**
-                 * These rules can apply to numbers, strings, arrays or files
-                 */
+                    /**
+                     * These rules can apply to numbers, strings, arrays or files
+                     */
                 case 'size':
                     $parameterData['description'] .= ' ' . $this->getDescription(
-                            $rule, [':size' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
-                        );
+                        $rule, [':size' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
+                    );
                     $parameterData['setter'] = $this->getDummyValueGenerator($parameterData['type'], ['size' => $arguments[0]]);
                     break;
                 case 'min':
                     $parameterData['description'] .= ' ' . $this->getDescription(
-                            $rule, [':min' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
-                        );
+                        $rule, [':min' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
+                    );
                     $parameterData['setter'] = $this->getDummyDataGeneratorBetween($parameterData['type'], floatval($arguments[0]), fieldName: $parameterData['name']);
                     break;
                 case 'max':
                     $parameterData['description'] .= ' ' . $this->getDescription(
-                            $rule, [':max' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
-                        );
+                        $rule, [':max' => $arguments[0]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
+                    );
                     $max = min($arguments[0], 25);
                     $parameterData['setter'] = $this->getDummyDataGeneratorBetween($parameterData['type'], 1, $max, $parameterData['name']);
                     break;
                 case 'between':
                     $parameterData['description'] .= ' ' . $this->getDescription(
-                            $rule, [':min' => $arguments[0], ':max' => $arguments[1]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
-                        );
+                        $rule, [':min' => $arguments[0], ':max' => $arguments[1]], $this->getLaravelValidationBaseTypeMapping($parameterData['type'])
+                    );
                     // Avoid exponentially complex operations by using the minimum length
                     $parameterData['setter'] = $this->getDummyDataGeneratorBetween($parameterData['type'], floatval($arguments[0]), floatval($arguments[0]) + 1, $parameterData['name']);
                     break;
 
-                /**
-                 * Special file types.
-                 */
+                    /**
+                     * Special file types.
+                     */
                 case 'image':
                     $parameterData['type'] = 'file';
                     $parameterData['description'] .= ' ' . $this->getDescription($rule) . ' ';
@@ -474,9 +482,9 @@ trait ParsesValidationRules
                     };
                     break;
 
-                /**
-                 * Other rules.
-                 */
+                    /**
+                     * Other rules.
+                     */
                 case 'in':
                     $parameterData['enumValues'] = $arguments;
                     $parameterData['setter'] = function () use ($arguments) {
@@ -484,9 +492,9 @@ trait ParsesValidationRules
                     };
                     break;
 
-                /**
-                 * These rules only add a description. Generating valid examples is too complex.
-                 */
+                    /**
+                     * These rules only add a description. Generating valid examples is too complex.
+                     */
                 case 'not_in':
                     $parameterData['description'] .= ' Must not be one of ' . w::getListOfValuesAsFriendlyHtmlString($arguments) . ' ';
                     break;
@@ -590,9 +598,9 @@ trait ParsesValidationRules
             if (isset($parameterData['setter'])) {
                 return $parameterData['setter']();
             } else {
-                return $parameterData['required']
-                    ? $this->generateDummyValue($parameterData['type'])
-                    : null;
+            return $parameterData['required']
+                ? $this->generateDummyValue($parameterData['type'])
+                : null;
             }
         } else if (!is_null($parameterData['example']) && $parameterData['example'] !== self::$MISSING_VALUE) {
             if($parameterData['example'] === 'No-example' && !$parameterData['required']){

--- a/tests/Unit/ValidationRuleParsingTest.php
+++ b/tests/Unit/ValidationRuleParsingTest.php
@@ -698,6 +698,85 @@ class ValidationRuleParsingTest extends BaseLaravelTest
 
         $this->assertEquals("Must be a valid date. Must be a date before <code>to_time</code>.", $results['from_time']['description']);
     }
+
+    /** @test */
+    public function sometimes_rule_prevents_required_from_required_rule()
+    {
+        $ruleset = [
+            'optional_field' => 'sometimes|required',
+        ];
+
+        $results = $this->strategy->parse($ruleset);
+
+        $this->assertFalse($results['optional_field']['required'], 'Field with "sometimes|required" should not be required');
+        $this->assertTrue($results['optional_field']['sometimes'], 'Field should have "sometimes" flag set');
+    }
+
+    /** @test */
+    public function sometimes_rule_prevents_required_from_accepted_rule()
+    {
+        $ruleset = [
+            'consent_cgu' => 'sometimes|accepted',
+        ];
+
+        $results = $this->strategy->parse($ruleset);
+
+        $this->assertTrue($results['consent_cgu']['sometimes'], 'Field should have "sometimes" flag set');
+        $this->assertFalse($results['consent_cgu']['required'], 'Field with "sometimes|accepted" should not be required');
+    }
+
+    /** @test */
+    public function required_before_sometimes_remains_required()
+    {
+        $ruleset = [
+            'should_be_required' => 'required|sometimes',
+        ];
+
+        $results = $this->strategy->parse($ruleset);
+
+        $this->assertTrue($results['should_be_required']['required'], 'Field with "required|sometimes" should remain required');
+        $this->assertTrue($results['should_be_required']['sometimes'], 'Field should have "sometimes" flag set');
+    }
+
+    /** @test */
+    public function accepted_before_sometimes_remains_required()
+    {
+        $ruleset = [
+            'should_be_required' => 'accepted|sometimes',
+        ];
+
+        $results = $this->strategy->parse($ruleset);
+
+        $this->assertTrue($results['should_be_required']['required'], 'Field with "accepted|sometimes" should remain required');
+        $this->assertTrue($results['should_be_required']['sometimes'], 'Field should have "sometimes" flag set');
+    }
+
+    /** @test */
+    public function sometimes_with_other_validation_rules()
+    {
+        $ruleset = [
+            'sometimes_email' => 'sometimes|email',
+            'sometimes_numeric' => 'sometimes|numeric|min:5',
+            'sometimes_array' => 'sometimes|array',
+        ];
+
+        $results = $this->strategy->parse($ruleset);
+
+        // All should not be required
+        $this->assertFalse($results['sometimes_email']['required']);
+        $this->assertFalse($results['sometimes_numeric']['required']);
+        $this->assertFalse($results['sometimes_array']['required']);
+
+        // All should have sometimes flag
+        $this->assertTrue($results['sometimes_email']['sometimes']);
+        $this->assertTrue($results['sometimes_numeric']['sometimes']);
+        $this->assertTrue($results['sometimes_array']['sometimes']);
+
+        // Types should be set correctly
+        $this->assertEquals('string', $results['sometimes_email']['type']);
+        $this->assertEquals('number', $results['sometimes_numeric']['type']);
+        $this->assertEquals('object', $results['sometimes_array']['type']);
+    }
 }
 
 class DummyValidationRule implements \Illuminate\Contracts\Validation\Rule


### PR DESCRIPTION
Hello,

I added the support for the "sometimes" validator rule that allow to skip all following validators like "required".

Currently, a field with this following rules was consired as required (but it shouldn't) : 
- `'consent_cgu' => 'sometimes|accepted'`
- `'other_field' => 'sometimes|required|...'` ("filled" rule seems better for this case but "filled_if", "filled_with", ... not existing so it's not an universal solution).

It notably fix this issue without any change to follow Laravel behaviour : https://github.com/knuckleswtf/scribe/issues/343

As Laravel behaviour, the following rules is correctly returned as required : `'badrule'=> 'required|sometimes|...'`

Best regard