### PR TITLE
Add support for resolving model factories without HasFactory trait or factory() method

### DIFF
--- a/src/Tools/Utils.php
+++ b/src/Tools/Utils.php
@@ -6,6 +6,7 @@ use Closure;
 use DirectoryIterator;
 use Exception;
 use FastRoute\RouteParser\Std;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Routing\Route;
@@ -233,12 +234,50 @@ class Utils
         return substr($typeName, 0, -2);
     }
 
+    public static function findFactoryClassForModel(string $modelName): string
+    {
+        $baseFactoryPath = base_path('database/factories');
+        $targetFactoryFile = class_basename($modelName) . 'Factory.php';
+
+        $rii = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($baseFactoryPath));
+        foreach ($rii as $file) {
+            if ($file->isDir()) continue;
+
+            if ($file->getFilename() === $targetFactoryFile) {
+                $relativePath = str_replace($baseFactoryPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
+                $classPath = str_replace(['/', '\\', '.php'], ['\\', '\\', ''], $relativePath);
+                return 'Database\\Factories\\' . $classPath;
+            }
+        }
+
+        throw CouldntFindFactory::forModel($modelName);
+    }
+
+    public static function resolveFactory(string $modelName): ?Factory
+    {
+        if (method_exists($modelName, 'factory')) {
+            return call_user_func_array([$modelName, 'factory'], []);
+        }
+
+        try {
+            $factoryClass = self::findFactoryClassForModel($modelName);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        if (!class_exists($factoryClass)) {
+            return null;
+        }
+
+        return app($factoryClass)->new();
+    }
+
     /**
      * @param string $modelName
      * @param string[] $states
      * @param string[] $relations
      *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     * @return Factory
      * @throws \Throwable
      */
     public static function getModelFactory(string $modelName, array $states = [], array $relations = [])
@@ -247,7 +286,9 @@ class Utils
         // but the user might write it that way in a comment. Let's be safe.
         $modelName = ltrim($modelName, '\\');
 
-        if (method_exists($modelName, 'factory')) { // Laravel 8 type factory
+        $factory = self::resolveFactory($modelName);
+
+        if ($factory) { // Laravel 8 type factory
             /** @var \Illuminate\Database\Eloquent\Factories\Factory $factory */
             $factory = call_user_func_array([$modelName, 'factory'], []);
             foreach ($states as $state) {


### PR DESCRIPTION
This PR extends Utils::getModelFactory() to support more flexible factory resolution scenarios, particularly for applications that:

Do not use the HasFactory trait on their Eloquent models,
Or define factories in standard locations, such as nested directories under database/factories/.

**✅ Benefits**

- Non-invasive: Fully backward-compatible with existing behavior.
- Supports advanced folder structures: Factory resolution works even if factories are organized by domain or module.
- Improves DX: Makes the developer experience smoother for teams using custom factory setups or avoiding HasFactory for architectural reasons.
- Safe fallback behavior: By returning null from resolveFactory(), the consuming code can choose how to react (e.g., skip, fallback, or throw).
- 
## What's New

- ✅ **`Utils::resolveFactory()`**
  - Attempts to resolve the factory using the model’s `factory()` method (Laravel 8+ style).
  - If not available, recursively searches `database/factories/**` for `{ModelName}Factory.php`, even inside subdirectories.
  - Returns `null` if no factory is found, instead of throwing, giving the caller more control.

- ✅ **`Utils::findFactoryClassForModel()`**
  - Recursively locates the correct factory file and builds its FQCN based on PSR-4 rules.

- 🛠 Updated `getModelFactory()` to use the above methods and maintain compatibility with:
  - Legacy `factory(Model::class)` (Laravel <8),
  - `state()` definitions,
  - Nested relationships (`has()`, `for()`, `hasAttached()`).

---

<img width="792" alt="image" src="https://github.com/user-attachments/assets/7adfc358-d190-4f35-9501-59ede3a00a07" />

