### PR TITLE
fix: Possible empty part of Route when path_param is not mandatory

### DIFF
--- a/src/Extracting/Shared/UrlParamsNormalizer.php
+++ b/src/Extracting/Shared/UrlParamsNormalizer.php
@@ -62,7 +62,12 @@ class UrlParamsNormalizer
                 if (!$alreadyFoundResourceParam) {
                     // This is the first resource param (from the end).
                     // We set it to `params/{id}` (or whatever field it's bound to)
-                    $replaceWith = ["$pluralResource/{{$binding}}", "$pluralResource/{{$binding}?}"];
+                    $replaceWith = [
+                        "$pluralResource/{{$binding}}",
+                        "$pluralResource/{{$binding}}",
+                        "$pluralResource/{{$binding}?}",
+                        "$pluralResource/{{$binding}?}",
+                    ];
                     $alreadyFoundResourceParam = true;
                 } else {
                     // Other resource parameters will be `params/{<param>_id}`

--- a/tests/Strategies/UrlParameters/GetFromLaravelAPITest.php
+++ b/tests/Strategies/UrlParameters/GetFromLaravelAPITest.php
@@ -141,6 +141,22 @@ class GetFromLaravelAPITest extends BaseLaravelTest
         $property->setValue($this->app, $oldNamespace);
     }
 
+    /** @test */
+    public function can_infer_correct_uri_from_route_with_optional_parameter_and_named_resource_routename()
+    {
+        $endpoint = $this->endpoint(function (ExtractedEndpointData $e) {
+            $e->method = new \ReflectionMethod(TestController::class, 'dummy');
+            $e->route = app(Router::class)
+                ->addRoute(['GET'], "/users/{user?}/show", ['uses' => [TestController::class, 'dummy']])
+                ->name('users.show')
+            ;
+            $e->uri = UrlParamsNormalizer::normalizeParameterNamesInRouteUri($e->route, $e->method);
+
+        });
+
+        $this->assertEquals('users/{id?}/show', $endpoint->uri);
+    }
+
     protected function endpointForRoute($path, $controller, $method): ExtractedEndpointData
     {
         return $this->endpoint(function (ExtractedEndpointData $e) use ($path, $method, $controller) {


### PR DESCRIPTION
Hello

This PR fixes https://github.com/knuckleswtf/scribe/issues/915

When replacing with `str_replace()` , if `$search` and `$replace` have different number of elements, it is possible to replace with an empty string. 
This PR fixes it.