### PR TITLE
refactor: update the message on exist rule validation- form requests

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -549,7 +549,7 @@ trait ParsesValidationRules
                     $parameterData['nullable'] = true;
                     break;
                 case 'exists':
-                    $parameterData['description'] .= " The <code>{$ruleArguments[1]}</code> of an existing record in the {$ruleArguments[0]} table.";
+                    $parameterData['description'] .= " The <code>{$ruleArguments[1]}</code> value must exist.";
                     break;
                 default:
                     // Other rules not supported

--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -549,7 +549,7 @@ trait ParsesValidationRules
                     $parameterData['nullable'] = true;
                     break;
                 case 'exists':
-                    $parameterData['description'] .= " The <code>{$ruleArguments[1]}</code> value must exist.";
+                    $parameterData['description'] .= " The <code>{$ruleArguments[1]}</code> of an existing record";
                     break;
                 default:
                     // Other rules not supported


### PR DESCRIPTION
For security reasons it is important to prevent the database table names from being visible in the documentation. 

Because the documentation can be seen by external clients of the project.


