### PR TITLE
feat: Routes can be marked as deprecated

### DIFF
--- a/camel/Extraction/Metadata.php
+++ b/camel/Extraction/Metadata.php
@@ -13,4 +13,5 @@ class Metadata extends BaseDTO
     public ?string $title;
     public ?string $description;
     public bool $authenticated = false;
+    public bool $deprecated = false;
 }

--- a/camel/Output/OutputEndpointData.php
+++ b/camel/Output/OutputEndpointData.php
@@ -313,6 +313,11 @@ class OutputEndpointData extends BaseDTO
         return $this->metadata->authenticated;
     }
 
+    public function isDeprecated(): bool
+    {
+        return $this->metadata->deprecated;
+    }
+
     public function hasJsonBody(): bool
     {
         if ($this->hasFiles() || empty($this->nestedBodyParameters))

--- a/resources/css/theme-default.style.css
+++ b/resources/css/theme-default.style.css
@@ -1037,6 +1037,10 @@ html {
     background-color: green;
 }
 
+.badge.badge-darkgoldenrod {
+    background-color: darkgoldenrod;
+}
+
 .badge.badge-darkgreen {
     background-color: darkgreen;
 }

--- a/resources/views/components/badges/deprecated.blade.php
+++ b/resources/views/components/badges/deprecated.blade.php
@@ -1,0 +1,3 @@
+@if($deprecated)@component('scribe::components.badges.base', ['colour' => "darkgoldenrod", 'text' => 'deprecated'])
+@endcomponent
+@endif

--- a/resources/views/themes/default/endpoint.blade.php
+++ b/resources/views/themes/default/endpoint.blade.php
@@ -8,6 +8,8 @@
 <p>
 @component('scribe::components.badges.auth', ['authenticated' => $endpoint->isAuthed()])
 @endcomponent
+@component('scribe::components.badges.deprecated', ['deprecated' => $endpoint->isDeprecated()])
+@endcomponent
 </p>
 
 {!! Parsedown::instance()->text($endpoint->metadata->description ?: '') !!}

--- a/resources/views/themes/elements/endpoint.blade.php
+++ b/resources/views/themes/elements/endpoint.blade.php
@@ -37,6 +37,12 @@
                             >requires authentication
                             </div>
                         @endif
+                        @if($endpoint->metadata->deprecated)
+                            <div class="sl-font-prose sl-font-semibold sl-px-1.5 sl-py-0.5 sl-text-on-primary sl-rounded-lg"
+                                 style="background-color: darkgoldenrod"
+                            >deprecated
+                            </div>
+                        @endif
             </div>
         </div>
 

--- a/src/Attributes/Deprecated.php
+++ b/src/Attributes/Deprecated.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Knuckles\Scribe\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
+class Deprecated
+{
+    public function __construct(
+        public ?bool $deprecated = true,
+    )
+    {
+    }
+
+    public function toArray()
+    {
+        return ["deprecated" => $this->deprecated];
+    }
+}

--- a/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
+++ b/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
@@ -29,6 +29,7 @@ class GetFromDocBlocks extends Strategy
             'subgroupDescription' => $this->getEndpointSubGroupDescription($methodDocBlock, $classDocBlock),
             'title' => $title ?: $methodDocBlock->getShortDescription(),
             'description' => $methodDocBlock->getLongDescription()->getContents(),
+            'deprecated' => $this->getDeprecatedStatusFromDocBlock($methodDocBlock, $classDocBlock),
         ];
         if (!is_null($authStatus = $this->getAuthStatusFromDocBlock($methodDocBlock, $classDocBlock))) {
             $metadata['authenticated'] = $authStatus;
@@ -51,6 +52,17 @@ class GetFromDocBlocks extends Strategy
         return $classDocBlock
             ? $this->getAuthStatusFromDocBlock($classDocBlock)
             : null;
+    }
+
+    protected function getDeprecatedStatusFromDocBlock(DocBlock $methodDocBlock, ?DocBlock $classDocBlock = null): bool
+    {
+        foreach ($methodDocBlock->getTags() as $tag) {
+            if (strtolower($tag->getName()) === 'deprecated') {
+                return true;
+            }
+        }
+
+        return $classDocBlock && $this->getDeprecatedStatusFromDocBlock($classDocBlock);
     }
 
     /**

--- a/src/Extracting/Strategies/Metadata/GetFromMetadataAttributes.php
+++ b/src/Extracting/Strategies/Metadata/GetFromMetadataAttributes.php
@@ -4,6 +4,7 @@ namespace Knuckles\Scribe\Extracting\Strategies\Metadata;
 
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Attributes\Authenticated;
+use Knuckles\Scribe\Attributes\Deprecated;
 use Knuckles\Scribe\Attributes\Endpoint;
 use Knuckles\Scribe\Attributes\Group;
 use Knuckles\Scribe\Attributes\Subgroup;
@@ -24,6 +25,7 @@ class GetFromMetadataAttributes extends PhpAttributeStrategy
         Endpoint::class,
         Authenticated::class,
         Unauthenticated::class,
+        Deprecated::class,
     ];
 
     protected function extractFromAttributes(

--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -52,6 +52,10 @@ class BaseGenerator extends OpenApiGenerator
             })['name']],
         ];
 
+        if ($endpoint->metadata->deprecated) {
+            $spec['deprecated'] = true;
+        }
+
         if (count($endpoint->bodyParameters)) {
             $spec['requestBody'] = $this->generateEndpointRequestBodySpec($endpoint);
         }
@@ -549,7 +553,7 @@ class BaseGenerator extends OpenApiGenerator
                 $schema['items']['properties'] = collect($sample)->mapWithKeys(function ($v, $k) use ($endpoint, $path) {
                     return [$k => $this->generateSchemaForResponseValue($v, $endpoint, "$path.$k")];
                 })->toArray();
-                
+
                 $required = $this->filterRequiredResponseFields($endpoint, array_keys($schema['items']['properties']),
                     $path);
                 if ($required) {

--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -145,7 +145,8 @@ class PostmanCollectionWriter
         }
 
         $endpointItem = [
-            'name' => $endpoint->metadata->title !== '' ? $endpoint->metadata->title : ($endpoint->httpMethods[0].' '.$endpoint->uri),
+            'name' => ($endpoint->metadata->title !== '' ? $endpoint->metadata->title : ($endpoint->httpMethods[0].' '.$endpoint->uri))
+                .($endpoint->metadata->deprecated ? ' [DEPRECATED]' : ''),
             'request' => [
                 'url' => $this->generateUrlObject($endpoint),
                 'method' => $method,

--- a/tests/Strategies/Metadata/GetFromDocBlocksTest.php
+++ b/tests/Strategies/Metadata/GetFromDocBlocksTest.php
@@ -52,6 +52,7 @@ DOCBLOCK;
         $results = $strategy->getMetadataFromDocBlock(new DocBlock($methodDocblock), new DocBlock($classDocblock));
 
         $this->assertArrayNotHasKey('authenticated', $results);
+        $this->assertFalse($results['deprecated']);
         $this->assertNull($results['subgroup']);
         $this->assertSame('Group A', $results['groupName']);
         $this->assertSame('Group description.', $results['groupDescription']);
@@ -69,11 +70,13 @@ DOCBLOCK;
   * @authenticated
   * @subgroup Scheiße
   * @subgroupDescription Heilige Scheiße
+  * @deprecated
   */
 DOCBLOCK;
         $results = $strategy->getMetadataFromDocBlock(new DocBlock($methodDocblock), new DocBlock($classDocblock));
 
         $this->assertTrue($results['authenticated']);
+        $this->assertTrue($results['deprecated']);
         $this->assertSame(null, $results['groupName']);
         $this->assertSame('Scheiße', $results['subgroup']);
         $this->assertSame('Heilige Scheiße', $results['subgroupDescription']);
@@ -91,6 +94,7 @@ DOCBLOCK;
   * Endpoint title.
   * This is the endpoint description.
   * @authenticated
+  * @deprecated
   * @group Group from method
   */
 DOCBLOCK;
@@ -103,6 +107,7 @@ DOCBLOCK;
         $results = $strategy->getMetadataFromDocBlock(new DocBlock($methodDocblock), new DocBlock($classDocblock));
 
         $this->assertTrue($results['authenticated']);
+        $this->assertTrue($results['deprecated']);
         $this->assertSame('Group from method', $results['groupName']);
         $this->assertSame("", $results['groupDescription']);
         $this->assertSame("This is the endpoint description.", $results['description']);

--- a/tests/Strategies/Metadata/GetFromMetadataAttributesTest.php
+++ b/tests/Strategies/Metadata/GetFromMetadataAttributesTest.php
@@ -5,6 +5,7 @@ namespace Knuckles\Scribe\Tests\Strategies\QueryParameters;
 use Closure;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Attributes\Authenticated;
+use Knuckles\Scribe\Attributes\Deprecated;
 use Knuckles\Scribe\Attributes\Endpoint;
 use Knuckles\Scribe\Attributes\Group;
 use Knuckles\Scribe\Attributes\Subgroup;
@@ -125,6 +126,24 @@ class UseMetadataAttributesTest extends TestCase
         $this->assertArraySubset([
             "title" => "Endpoint C"
         ], $results);
+
+        $endpoint = $this->endpoint(function (ExtractedEndpointData $e) {
+            $e->controller = new ReflectionClass(MetadataAttributesTestController4::class);
+            $e->method = $e->controller->getMethod('c1');
+        });
+        $results = $this->fetch($endpoint);
+        $this->assertArraySubset([
+            "deprecated" => true,
+        ], $results);
+
+        $endpoint = $this->endpoint(function (ExtractedEndpointData $e) {
+            $e->controller = new ReflectionClass(MetadataAttributesTestController5::class);
+            $e->method = $e->controller->getMethod('c1');
+        });
+        $results = $this->fetch($endpoint);
+        $this->assertArraySubset([
+            "deprecated" => true,
+        ], $results);
     }
 
     protected function fetch($endpoint): array
@@ -201,6 +220,22 @@ class MetadataAttributesTestController2
 #[Endpoint("Endpoint C")]
 class MetadataAttributesTestController3
 {
+    public function c1()
+    {
+    }
+}
+
+#[Deprecated]
+class MetadataAttributesTestController4
+{
+    public function c1()
+    {
+    }
+}
+
+class MetadataAttributesTestController5
+{
+    #[Deprecated]
     public function c1()
     {
     }

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -129,6 +129,22 @@ class OpenAPISpecWriterTest extends BaseUnitTest
     }
 
     /** @test */
+    public function adds_deprecation_info_correctly()
+    {
+        $endpointData1 = $this->createMockEndpointData(['uri' => 'path1', 'httpMethods' => ['GET'], 'metadata.deprecated' => true]);
+        $endpointData2 = $this->createMockEndpointData(['uri' => 'path2', 'httpMethods' => ['GET'], 'metadata.deprecated' => false]);
+        $groups = [$this->createGroup([$endpointData1, $endpointData2])];
+
+        $results = $this->generate($groups);
+
+        $this->assertIsArray($results['paths']);
+        $this->assertCount(2, $results['paths']);
+        $this->assertArrayHasKey('deprecated', $results['paths']['/path1']['get']);
+        $this->assertTrue(true, $results['paths']['/path1']['get']['deprecated']);
+        $this->assertArrayNotHasKey('deprecated', $results['paths']['/path2']['get']);
+    }
+
+    /** @test */
     public function adds_url_parameters_correctly_as_parameters_on_path_item_object()
     {
         $endpointData1 = $this->createMockEndpointData([


### PR DESCRIPTION
In OpenAPI 3.0 it is possible to specify paths as deprecated. It is possible to implement this using custom spec generators, themes. 

But I think it would be useful to implement native support.

### Changes

1. Updated `Metadata` DTO
2. Updated Metadata strategies for DocBlock/Attributes
3. Updated base OpenApiSpecGenerator
4. Updated PostmanCollectionGenerator _(Since Postman doesn't have a way to mark methods as deprecated, I decided to add the [DEPRECATED] suffix to method names.)_
5. Updated `default` and `elements` themes
6. Updated tests

### Usage

Just add a annotation `@deprecated` in method/class/route DocBlock:
```PHP
/**
 * Update Role
 *
 * @deprecated
 */
public function update(string $id, CreateUpdateRoleRequest $request): Role
{
    $data = $request->validated();
    $model = $this->roleService->getModel($id, ['permissions']);

    return $this->roleService->updateRole($model, $data);
}
```
You can also use attributes:
```PHP
#[Deprecated]
public function create(CreateUpdateRoleRequest $request): Role
{
    $data = $request->validated();

    return $this->roleService->createRole($data);
}
 ```

### Examples

<details><summary>Default theme</summary><img src="https://github.com/user-attachments/assets/c194b149-2f11-4e01-998e-549e889e80e2" /></details>

<details><summary>Elements theme</summary>
<img src="https://github.com/user-attachments/assets/debef2fb-995b-439b-883f-46bbc1c7fc5a" />
</details>

<details><summary>External elements, scalar, rapidoc</summary>
<img src="https://github.com/user-attachments/assets/1f903492-437c-474b-aa3f-511ed2cbde78" />
<img src="https://github.com/user-attachments/assets/68f5e6ff-9d7f-4276-b087-054cbb5f18cf" />
<img src="https://github.com/user-attachments/assets/842a1a74-bae3-47b4-a93c-9c8dda0f9dd1" />
</details>

