### PR TITLE
fix: generatePostmanCollection quietly failing due to invalid utf-8 characters

### DIFF
--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -129,7 +129,7 @@ class Writer
                 data_set($collection, $key, $value);
             }
         }
-        return json_encode($collection, JSON_PRETTY_PRINT);
+        return json_encode($collection, JSON_PRETTY_PRINT|JSON_INVALID_UTF8_SUBSTITUTE);
     }
 
     /**


### PR DESCRIPTION
Scribe has been unable to generate postman collections where I work. Tracked down the issue to generatePostmanCollection inside of the Writer class where json_encode was quietly failing.

This PR just enables the JSON_INVALID_UTF8_SUBSTITUTE flag to address the issue. 

![Screenshot 2025-06-05 at 13 59 35](https://github.com/user-attachments/assets/de229599-796b-4a07-8446-8132a02ed458)


NOTE: That the JSON_INVALID_UTF8_IGNORE flag also fixes the issue.

