### PR TITLE
Made the bullet lists capitalization consistent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Scribe helps you generate API documentation for humans from your Laravel codebas
   - Pretty single-page HTML doc, with human-friendly text, code samples, and in-browser API tester ("Try It Out")
   - Generates Postman collection and OpenAPI spec
 - Smarts. Scribe can:
-  - extract request parameter details from FormRequests or validation rules
-  - safely call API endpoints to get sample responses
-  - generate sample responses from Eloquent API Resources or Transformers
+  - Extract request parameter details from FormRequests or validation rules
+  - Safely call API endpoints to get sample responses
+  - Generate sample responses from Eloquent API Resources or Transformers
 - Customisable to different levels:
   - Customise the UI by adjusting text, ordering, examples, or change the UI itself
   - Add custom strategies to adjust how data is extracted


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

I edited the README so that the bullet lists would have consistent capitalization. Two of the three lists had each point start with capital letters, while one list did not. With this PR, the starting word of each bullet point is capitalized.