### PR TITLE
Add domain option to the laravel config section so docs can live on a separate hostname

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -61,7 +61,7 @@ return [
         'add_routes' => true,
 
         // Domain to use for the docs endpoint for example: https://docs.yourdomain.com/.
-        'domain' => null,
+        'domain' => env('SCRIBE_DOCS_DOMAIN', null),
 
         // URL path to use for the docs endpoint (if `add_routes` is true).
         // By default, `/docs` opens the HTML page, `/docs.postman` opens the Postman collection, and `/docs.openapi` the OpenAPI spec.

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -60,6 +60,9 @@ return [
         // Whether to automatically create a docs route for you to view your generated docs. You can still set up routing manually.
         'add_routes' => true,
 
+        // Domain to use for the docs endpoint for example: https://docs.yourdomain.com/.
+        'domain' => null,
+
         // URL path to use for the docs endpoint (if `add_routes` is true).
         // By default, `/docs` opens the HTML page, `/docs.postman` opens the Postman collection, and `/docs.openapi` the OpenAPI spec.
         'docs_url' => '/docs',

--- a/routes/laravel.php
+++ b/routes/laravel.php
@@ -4,10 +4,12 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
 
+$domain = config('scribe.laravel.domain', null);
 $prefix = config('scribe.laravel.docs_url', '/docs');
 $middleware = config('scribe.laravel.middleware', []);
 
-Route::middleware($middleware)
+Route::domain($domain)
+    ->middleware($middleware)
     ->group(function () use ($prefix) {
         Route::view($prefix, 'scribe.index')->name('scribe');
 


### PR DESCRIPTION
Current behaviour
The laravel section of config/scribe.php lets you tweak docs_url, asset folder, middleware, etc., but there’s no way to put the generated documentation behind a different domain or sub-domain. Today you have to copy the route declaration and wrap it in Route::domain() yourself each time you publish the config.

Impact
Non-breaking: existing installations keep working as domain defaults to null.
Zero maintenance cost: publishing the config once exposes the new env var for developers who need it.