### PR TITLE
Use Recursive Spec Merge in OpenAPI `SecurityGenerator` & Fix `OverrideGenerator` base

### DIFF
--- a/src/Writing/CustomTranslationsLoader.php
+++ b/src/Writing/CustomTranslationsLoader.php
@@ -33,7 +33,6 @@ class CustomTranslationsLoader extends FileLoader
             } elseif ($this->files->exists($full = "{$this->hints[$namespace]}/scribe.php")) {
                 $this->scribeTranslationsCache = $this->files->getRequire($full);
                 // getRequire() requires the Scribe file, which will return an array
-                // @phpstan-ignore-next-line nullCoalesce.offset
                 $lines = $this->scribeTranslationsCache[$group] ?? [];
             } else {
                 return [];

--- a/src/Writing/OpenApiSpecGenerators/OverridesGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/OverridesGenerator.php
@@ -4,7 +4,7 @@ namespace Knuckles\Scribe\Writing\OpenApiSpecGenerators;
 
 use Illuminate\Support\Arr;
 
-class OverridesGenerator extends BaseGenerator
+class OverridesGenerator extends OpenApiGenerator
 {
     public function root(array $root, array $groupedEndpoints): array
     {

--- a/src/Writing/OpenApiSpecGenerators/SecurityGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/SecurityGenerator.php
@@ -31,7 +31,7 @@ class SecurityGenerator extends OpenApiGenerator
             default => [],
         };
 
-        return array_merge($root, [
+        return array_merge_recursive($root, [
             // All security schemes must be registered in `components.securitySchemes`...
             'components' => [
                 'securitySchemes' => [


### PR DESCRIPTION
Two changes:

**Change 1: Recursive merge fix in `SecurityGenerator`**
Change to use `array_merge_recursive` rather than `array_merge` in the SecurityGenerator, so that if something is included in the `components` section (or security) before the SecurityGenerator (e.g. by the BaseGenerator), they are preseved as long as the security generator doesn't want to overwrite it.

The use case here is that I am adding `components.schemas` as part of an extension of the BaseGenerator, and these are getting discarded by this array merge currently.

**Change 2: Use `OpenApiGenerator` as the base class for `OverridesGenerator`**
Similarly, the OverridesGenerator extends the BaseGenerator, and I can't see any reason why? This causes it to overwrite some of the changes I have made in `BaseGenerator` particularly with the changes to path spec generation. I've updated to use the `OpenApiGenerator` as the base