### PR TITLE
Ensure Validator facade rules are detected

### DIFF
--- a/src/Extracting/Shared/ValidationRulesFinders/ValidatorMake.php
+++ b/src/Extracting/Shared/ValidationRulesFinders/ValidatorMake.php
@@ -3,10 +3,12 @@
 namespace Knuckles\Scribe\Extracting\Shared\ValidationRulesFinders;
 
 use PhpParser\Node;
+use PhpParser\NodeFinder;
 
 /**
  * This class looks for
  *   $validator = Validator::make($request, ...)
+ *   Validator::make($request, ...)->validate()
  *
  * The variable names (`$validator` and `$request`) don't matter.
  */
@@ -15,20 +17,19 @@ class ValidatorMake
     public static function find(Node $node)
     {
         // Make sure it's an assignment
-        if (!($node instanceof Node\Stmt\Expression)
-            || !($node->expr instanceof Node\Expr\Assign)) {
+        if (! ($node instanceof Node\Stmt\Expression)) {
             return;
         }
 
-        $expr = $node->expr->expr; // Get the expression on the RHS
+        $validatorNode = (new NodeFinder)->findFirst($node, function ($node): bool {
+            return $node instanceof Node\Expr\StaticCall
+                && ! empty($node->class->name)
+                && str_ends_with($node->class->name, 'Validator')
+                && $node->name->name == 'make';
+        });
 
-        if (
-            $expr instanceof Node\Expr\StaticCall
-            && !empty($expr->class->name)
-            && str_ends_with($expr->class->name, "Validator")
-            && $expr->name->name == "make"
-        ) {
-            return $expr->args[1]->value;
+        if ($validatorNode instanceof Node\Expr\StaticCall) {
+            return $validatorNode->args[1]->value;
         }
     }
 }

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -646,6 +646,29 @@ class TestController extends Controller
 
         }
     }
+    public function withInlineValidatorMakeValidate(Request $request)
+    {
+        // Some stuff
+        Validator::make($request, [
+            // The id of the user. Example: 9
+            'user_id' => 'int|required',
+            // The id of the room.
+            'room_id' => ['string', 'in:3,5,6'],
+            // Whether to ban the user forever. Example: false
+            'forever' => 'boolean',
+            // Just need something here. No-example
+            'another_one' => 'numeric',
+            'even_more_param' => 'array',
+            'book.name' => 'string',
+            'book.author_id' => 'integer',
+            'book.pages_count' => 'integer',
+            'ids.*' => 'integer',
+            // The first name of the user. Example: John
+            'users.*.first_name' => ['string'],
+            // The last name of the user. Example: Doe
+            'users.*.last_name' => 'string',
+        ])->validate();
+    }
 
     public function withInlineRequestValidateWithBag(Request $request)
     {

--- a/tests/Strategies/GetFromInlineValidatorTest.php
+++ b/tests/Strategies/GetFromInlineValidatorTest.php
@@ -209,6 +209,19 @@ class GetFromInlineValidatorTest extends BaseLaravelTest
     }
 
     /** @test */
+    public function can_fetch_from_validator_make_validate()
+    {
+        $endpoint = $this->endpoint(function (ExtractedEndpointData $e) {
+            $e->method = new \ReflectionMethod(TestController::class, 'withInlineValidatorMakeValidate');
+        });
+
+        $results = $this->fetchViaBodyParams($endpoint);
+
+        $this->assertArraySubset(self::$expected, $results);
+        $this->assertIsArray($results['ids']['example']);
+    }
+
+    /** @test */
     public function respects_query_params_comment()
     {
         $queryParamsEndpoint = $this->endpoint(function (ExtractedEndpointData $e) {


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

I ran into an issue, that when the `->validate()` method on the validator is called (which throws an exception), scribe does not detect the rules. I made this change for myself and thought it would be useful for others