### PR TITLE
Resolve fully qualified names

### DIFF
--- a/src/Extracting/MethodAstParser.php
+++ b/src/Extracting/MethodAstParser.php
@@ -5,6 +5,8 @@ namespace Knuckles\Scribe\Extracting;
 use Exception;
 use PhpParser\Node;
 use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
 use ReflectionFunctionAbstract;
 use Throwable;
@@ -48,6 +50,13 @@ class MethodAstParser
             $ast = $parser->parse($sourceCode);
         } catch (Throwable $error) {
             throw new Exception("Parse error: {$error->getMessage()}");
+        }
+
+        $traverser = new NodeTraverser(new NameResolver(options: ['replaceNodes' => false]));
+        try {
+            $traverser->traverse($ast);
+        } catch (Throwable $error) {
+            throw new Exception("Traverse error: {$error->getMessage()}");
         }
 
         return $ast;


### PR DESCRIPTION
<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

Add traverser after parse step, so an extra attribute `resolvedName` is added to eg. `PhpParser\Node\Name` which contains `PhpParser\Node\Name\FullyQualified`.

This makes it easier to add package specific strategies without re-implementing quite some logic or changing existing code.

### Before
```
PhpParser\Node\Name^ {#2660
  #attributes: array:7 [
    "startLine" => 37
    "startTokenPos" => 120
    "startFilePos" => 1202
    "endLine" => 37
    "endTokenPos" => 120
    "endFilePos" => 1208
  ]
  +name: "Validator"
}
```

### After
```
PhpParser\Node\Name^ {#2660
  #attributes: array:7 [
    "startLine" => 37
    "startTokenPos" => 120
    "startFilePos" => 1202
    "endLine" => 37
    "endTokenPos" => 120
    "endFilePos" => 1208
    "resolvedName" => PhpParser\Node\Name\FullyQualified^ {#3807
      #attributes: array:6 [
        "startLine" => 37
        "startTokenPos" => 120
        "startFilePos" => 1202
        "endLine" => 37
        "endTokenPos" => 120
        "endFilePos" => 1208
      ]
      +name: "Illuminate\Support\Facades\Validator"
    }
  ]
  +name: "Validator"
}
```