### PR TITLE
Add support for `list` validation rule

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -319,6 +319,7 @@ trait ParsesValidationRules
                     $parameterData['type'] = 'number';
                     break;
                 case 'array':
+                case 'list':
                     $parameterData['setter'] = function () {
                         return [$this->generateDummyValue('string')];
                     };


### PR DESCRIPTION
This PR adds support for the `list` validation rule. Currently, the generated type for lists is `string`.

Just whipped this up on a whim. Willing to add tests but I don't know it it will break tests since `list` rule was only added on Laravel 11 and up.