### PR TITLE
Add deprecation attribute string support

### DIFF
--- a/camel/Extraction/Metadata.php
+++ b/camel/Extraction/Metadata.php
@@ -13,5 +13,5 @@ class Metadata extends BaseDTO
     public ?string $title;
     public ?string $description;
     public bool $authenticated = false;
-    public bool $deprecated = false;
+    public bool|string $deprecated = false;
 }

--- a/camel/Output/OutputEndpointData.php
+++ b/camel/Output/OutputEndpointData.php
@@ -313,11 +313,6 @@ class OutputEndpointData extends BaseDTO
         return $this->metadata->authenticated;
     }
 
-    public function isDeprecated(): bool
-    {
-        return $this->metadata->deprecated;
-    }
-
     public function hasJsonBody(): bool
     {
         if ($this->hasFiles() || empty($this->nestedBodyParameters))

--- a/resources/views/components/badges/deprecated.blade.php
+++ b/resources/views/components/badges/deprecated.blade.php
@@ -1,3 +1,5 @@
-@if($deprecated)@component('scribe::components.badges.base', ['colour' => "darkgoldenrod", 'text' => 'deprecated'])
+@if($deprecated !== false)
+@php($text = $deprecated === true ? 'deprecated' : "deprecated:$deprecated")
+@component('scribe::components.badges.base', ['colour' => 'darkgoldenrod', 'text' => $text])
 @endcomponent
 @endif

--- a/resources/views/themes/default/endpoint.blade.php
+++ b/resources/views/themes/default/endpoint.blade.php
@@ -8,7 +8,7 @@
 <p>
 @component('scribe::components.badges.auth', ['authenticated' => $endpoint->isAuthed()])
 @endcomponent
-@component('scribe::components.badges.deprecated', ['deprecated' => $endpoint->isDeprecated()])
+@component('scribe::components.badges.deprecated', ['deprecated' => $endpoint->metadata->deprecated])
 @endcomponent
 </p>
 

--- a/resources/views/themes/elements/endpoint.blade.php
+++ b/resources/views/themes/elements/endpoint.blade.php
@@ -37,10 +37,16 @@
                             >requires authentication
                             </div>
                         @endif
-                        @if($endpoint->metadata->deprecated)
+                        @if($endpoint->metadata->deprecated === true)
                             <div class="sl-font-prose sl-font-semibold sl-px-1.5 sl-py-0.5 sl-text-on-primary sl-rounded-lg"
                                  style="background-color: darkgoldenrod"
                             >deprecated
+                            </div>
+                        @endif
+                        @if(is_string($endpoint->metadata->deprecated))
+                            <div class="sl-font-prose sl-font-semibold sl-px-1.5 sl-py-0.5 sl-text-on-primary sl-rounded-lg"
+                                 style="background-color: darkgoldenrod"
+                            >deprecated:{{$endpoint->metadata->deprecated}}
                             </div>
                         @endif
             </div>

--- a/src/Attributes/Deprecated.php
+++ b/src/Attributes/Deprecated.php
@@ -8,7 +8,7 @@ use Attribute;
 class Deprecated
 {
     public function __construct(
-        public ?bool $deprecated = true,
+        public bool|string|null $deprecated = true,
     )
     {
     }

--- a/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
+++ b/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
@@ -54,15 +54,19 @@ class GetFromDocBlocks extends Strategy
             : null;
     }
 
-    protected function getDeprecatedStatusFromDocBlock(DocBlock $methodDocBlock, ?DocBlock $classDocBlock = null): bool
+    protected function getDeprecatedStatusFromDocBlock(DocBlock $methodDocBlock, ?DocBlock $classDocBlock = null): bool|string
     {
         foreach ($methodDocBlock->getTags() as $tag) {
             if (strtolower($tag->getName()) === 'deprecated') {
-                return true;
+                return $tag->getContent() === '' ? true : $tag->getContent();
             }
         }
 
-        return $classDocBlock && $this->getDeprecatedStatusFromDocBlock($classDocBlock);
+        if ($classDocBlock instanceof DocBlock) {
+            return $this->getDeprecatedStatusFromDocBlock($classDocBlock);
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Strategies/Metadata/GetFromDocBlocksTest.php
+++ b/tests/Strategies/Metadata/GetFromDocBlocksTest.php
@@ -83,6 +83,25 @@ DOCBLOCK;
         $this->assertSame('', $results['groupDescription']);
         $this->assertSame('Endpoint title.', $results['title']);
         $this->assertSame("", $results['description']);
+
+        $classDocblock = <<<DOCBLOCK
+/**
+  * @authenticated
+  * @subgroup Scheiße
+  * @subgroupDescription Heilige Scheiße
+  * @deprecated 2025-01-01
+  */
+DOCBLOCK;
+        $results = $strategy->getMetadataFromDocBlock(new DocBlock($methodDocblock), new DocBlock($classDocblock));
+
+        $this->assertTrue($results['authenticated']);
+        $this->assertSame('2025-01-01', $results['deprecated']);
+        $this->assertSame(null, $results['groupName']);
+        $this->assertSame('Scheiße', $results['subgroup']);
+        $this->assertSame('Heilige Scheiße', $results['subgroupDescription']);
+        $this->assertSame('', $results['groupDescription']);
+        $this->assertSame('Endpoint title.', $results['title']);
+        $this->assertSame("", $results['description']);
     }
 
     /** @test */

--- a/tests/Strategies/Metadata/GetFromMetadataAttributesTest.php
+++ b/tests/Strategies/Metadata/GetFromMetadataAttributesTest.php
@@ -144,6 +144,15 @@ class UseMetadataAttributesTest extends TestCase
         $this->assertArraySubset([
             "deprecated" => true,
         ], $results);
+
+        $endpoint = $this->endpoint(function (ExtractedEndpointData $e) {
+            $e->controller = new ReflectionClass(MetadataAttributesTestController6::class);
+            $e->method = $e->controller->getMethod('c1');
+        });
+        $results = $this->fetch($endpoint);
+        $this->assertArraySubset([
+            "deprecated" => "2023-01-01",
+        ], $results);
     }
 
     protected function fetch($endpoint): array
@@ -236,6 +245,14 @@ class MetadataAttributesTestController4
 class MetadataAttributesTestController5
 {
     #[Deprecated]
+    public function c1()
+    {
+    }
+}
+
+#[Deprecated("2023-01-01")]
+class MetadataAttributesTestController6
+{
     public function c1()
     {
     }


### PR DESCRIPTION
Before, the deprecation badge was just a boolean. Now it can be used both as a boolean and a string. With a string, the badge is enhanced with said string to add some context. This does not work with external resources since the OpenAPI specification accepts only a boolean value.

Fix #1018

<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

