### PR TITLE
fix: crash when API resource __construct enforces type in ResponseFromApiResource

### DIFF
--- a/src/Attributes/ResponseFromApiResource.php
+++ b/src/Attributes/ResponseFromApiResource.php
@@ -44,7 +44,6 @@ class ResponseFromApiResource
             return $this->collection;
         }
 
-        $className = $this->name;
-        return (new $className(new \Illuminate\Http\Resources\MissingValue)) instanceof ResourceCollection;
+        return is_subclass_of($this->name, ResourceCollection::class);
     }
 }


### PR DESCRIPTION
When using the ResponseFromApiResource attribute, scribe will crash if you overwrite the API resources __construct method to add proper type. Example:
```php
class UserResource extends JsonResource
{
    public function __construct(User $resource) // Passing in User here will crash scribe
    {
        parent::__construct($resource);
    }

    public function toArray(Request $request): array
    {
        return [
            'id' => $this->id,
        ];
    }
}
```

This will give the following error
```
TypeError App\Http\Resources\UserResource::__construct(): Argument #1 ($resource) must be of type App\Models\User, Illuminate\Http\Resources\MissingValue given, called in /var/www/vendor/knuckleswtf/scribe/src/Attributes/ResponseFromApiResource.php on line 48
```

This PR fixes this issue, as scribe no longer instantiates a new resource class instance with MissingValue as first parameter to check if it's an instance of ResourceCollection.