### PR TITLE
fix: handle rare edge case in base OpenApi spec generator after parallel merge

### DIFF
--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -375,7 +375,7 @@ class BaseGenerator extends OpenApiGenerator
                     })->toArray();
 
                     return [
-                        'application/json' => [
+                        $contentType => [
                             'schema' => [
                                 'type' => 'array',
                                 'items' => [


### PR DESCRIPTION
My previous PR #1021 introduced logic that, in a rare scenario, could conflict with the refactoring done in a parallel PR #1029.

This is a one-line fix to ensure both code paths are correctly handled together. 

This is more of a code hygiene / completeness fix than a critical hotfix. There's no need for an urgent release because of this.
