### PR TITLE
Openapi nullable response fields

### DIFF
--- a/camel/Extraction/ResponseField.php
+++ b/camel/Extraction/ResponseField.php
@@ -26,4 +26,7 @@ class ResponseField extends BaseDTO
     public $example;
 
     public array $enumValues = [];
+
+    /** @var boolean */
+    public $nullable;
 }

--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -634,7 +634,7 @@ class BaseGenerator extends OpenApiGenerator
         // prefer explicit values
         if ($field !== null && $field->nullable !== null) {
             if ($field->nullable) {
-                $schema['nullable'] = true;
+                $this->applyNullable($schema, true);
             }
             // false => do not set and do not use example
             return;
@@ -642,7 +642,7 @@ class BaseGenerator extends OpenApiGenerator
 
         // example is null
         if ($value === null) {
-            $schema['nullable'] = true;
+            $this->applyNullable($schema, true);
         }
     }
 

--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -557,6 +557,7 @@ class BaseGenerator extends OpenApiGenerator
                 $schema['required'] = $required;
             }
             $this->setDescription($schema, $endpoint, $path);
+            $this->setNullable($schema, $endpoint, $path, $value);
 
             return $schema;
         }
@@ -566,9 +567,10 @@ class BaseGenerator extends OpenApiGenerator
             'example' => $value,
         ];
         $this->setDescription($schema, $endpoint, $path);
+        $this->setNullable($schema, $endpoint, $path, $value);
 
         // Set enum values for the property if they exist
-        if (isset($endpoint->responseFields[$path]->enumValues)) {
+        if (! empty($endpoint->responseFields[$path]->enumValues)) {
             $schema['enum'] = $endpoint->responseFields[$path]->enumValues;
         }
 
@@ -617,8 +619,30 @@ class BaseGenerator extends OpenApiGenerator
      */
     private function setDescription(array &$schema, OutputEndpointData $endpoint, string $path): void
     {
-        if (isset($endpoint->responseFields[$path]->description)) {
+        if (! empty($endpoint->responseFields[$path]->description)) {
             $schema['description'] = $endpoint->responseFields[$path]->description;
+        }
+    }
+
+    /*
+     * Set the nullable for the schema. If the field is nullable, it is set in the schema.
+     */
+    private function setNullable(array &$schema, OutputEndpointData $endpoint, string $path, mixed $value): void
+    {
+        $field = $endpoint->responseFields[$path] ?? null;
+    
+        // prefer explicite values
+        if ($field && isset($field->nullable)) {
+            if ($field->nullable) {
+                $schema['nullable'] = true;
+            }
+            // false => do not set and do not use example
+            return;
+        }
+    
+        // example is null
+        if ($value === null) {
+            $schema['nullable'] = true;
         }
     }
 

--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -629,17 +629,18 @@ class BaseGenerator extends OpenApiGenerator
      */
     private function setNullable(array &$schema, OutputEndpointData $endpoint, string $path, mixed $value): void
     {
+        /** @var \Knuckles\Camel\Extraction\ResponseField|null $field */
         $field = $endpoint->responseFields[$path] ?? null;
-    
-        // prefer explicite values
-        if ($field && isset($field->nullable)) {
+
+        // prefer explicit values
+        if ($field !== null && $field->nullable !== null) {
             if ($field->nullable) {
                 $schema['nullable'] = true;
             }
             // false => do not set and do not use example
             return;
         }
-    
+
         // example is null
         if ($value === null) {
             $schema['nullable'] = true;

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -199,7 +199,7 @@
               "header": [
                 {
                   "key": "content-type",
-                  "value": "text/html; charset=UTF-8"
+                  "value": "text/html; charset=utf-8"
                 },
                 {
                   "key": "cache-control",
@@ -240,7 +240,7 @@
               "header": [
                 {
                   "key": "content-type",
-                  "value": "text/html; charset=UTF-8"
+                  "value": "text/html; charset=utf-8"
                 },
                 {
                   "key": "cache-control",

--- a/tests/Fixtures/openapi-3_1.yaml
+++ b/tests/Fixtures/openapi-3_1.yaml
@@ -215,7 +215,7 @@ paths:
                                     param: { type: string, example: '4' }
                                     param2: { type: string, example: architecto }
                                     param3: { type: string, example: architecto }
-                                    param4: { type: string, example: null }
+                                    param4: { type: [string, 'null'], example: null }
             tags:
                 - Other😎
             security: []

--- a/tests/Fixtures/openapi.yaml
+++ b/tests/Fixtures/openapi.yaml
@@ -223,7 +223,7 @@ paths:
                                     param: { type: string, example: '4' }
                                     param2: { type: string, example: architecto }
                                     param3: { type: string, example: architecto }
-                                    param4: { type: string, example: null }
+                                    param4: { type: string, example: null, nullable: true }
             tags:
                 - Other😎
             security: []

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -182,6 +182,12 @@ class OutputTest extends BaseLaravelTest
             foreach ($group["item"] as &$endpoint) {
                 foreach ($endpoint["response"] as &$response) {
                     $response["header"] = array_filter($response["header"], fn ($header) => $header["key"] !== "access-control-allow-origin");
+                    $response['header'] = array_map(
+                        fn (array $header) => strtolower($header['key']) === 'content-type'
+                            ? [...$header, 'value' => strtolower($header['value'])]
+                            : $header,
+                        $response['header']
+                    );
                 }
             }
         }


### PR DESCRIPTION
(Reworked) Fix for https://github.com/knuckleswtf/scribe/issues/1032

Note: Also suppresses empty `description` and empty `enum` when not given in ResponseField-Attribute