### PR TITLE
fix: Respect wrapping of API resources

### DIFF
--- a/src/Extracting/Strategies/ResponseFields/GetFromResponseFieldAttribute.php
+++ b/src/Extracting/Strategies/ResponseFields/GetFromResponseFieldAttribute.php
@@ -19,24 +19,51 @@ class GetFromResponseFieldAttribute extends PhpAttributeStrategy
 
     protected function extractFromAttributes(
         ExtractedEndpointData $endpointData,
-        array $attributesOnMethod, array $attributesOnFormRequest = [], array $attributesOnController = []
-    ): ?array
+        array $attributesOnMethod,
+        array $attributesOnFormRequest = [],
+        array $attributesOnController = []
+    ): ?array {
+        return [
+            ...$this->getNonApiResourceFields($endpointData, $attributesOnMethod, $attributesOnFormRequest, $attributesOnController),
+            ...$this->getApiResourceFields($endpointData)
+        ];
+    }
+
+    protected function getApiResourceFields(ExtractedEndpointData $endpointData): array
     {
-        $attributesOnApiResourceMethods = [];
         $apiResourceAttributes = $endpointData->method->getAttributes(ResponseFromApiResource::class);
 
-        if (!empty($apiResourceAttributes)) {
-            $attributesOnApiResourceMethods = collect($apiResourceAttributes)
-                ->flatMap(function (ReflectionAttribute $attribute) {
-                    $className = $attribute->newInstance()->name;
-                    $method = u::getReflectedRouteMethod([$className, 'toArray']);
-                    return collect($method->getAttributes(ResponseField::class))
-                        ->map(fn (ReflectionAttribute $attr) => $attr->newInstance());
-                });
-        }
+        return collect($apiResourceAttributes)
+            ->flatMap(fn(ReflectionAttribute $attribute) => $this->extractFieldsFromApiResource($attribute, $endpointData))
+            ->toArray();
+    }
 
+    protected function extractFieldsFromApiResource(ReflectionAttribute $attribute, ExtractedEndpointData $endpointData): array
+    {
+        $className = $attribute->newInstance()->name;
+        $method = u::getReflectedRouteMethod([$className, 'toArray']);
+        $wrapKey = $className::$wrap ?? null;
 
-        return collect([...$attributesOnController, ...$attributesOnFormRequest, ...$attributesOnMethod, ...$attributesOnApiResourceMethods])
+        return collect($method->getAttributes(ResponseField::class))
+            ->mapWithKeys(function (ReflectionAttribute $attr) use ($endpointData, $wrapKey) {
+                $data = $attr->newInstance()->toArray();
+                $data['type'] = ResponseFieldTools::inferTypeOfResponseField($data, $endpointData);
+
+                if ($wrapKey !== null) {
+                    $data['name'] = $wrapKey . '.' . $data['name'];
+                }
+
+                return [$data['name'] => $data];
+            })->toArray();
+    }
+
+    protected function getNonApiResourceFields(
+        ExtractedEndpointData $endpointData,
+        array $attributesOnMethod,
+        array $attributesOnFormRequest,
+        array $attributesOnController
+    ): array {
+        return collect([...$attributesOnController, ...$attributesOnFormRequest, ...$attributesOnMethod])
             ->mapWithKeys(function ($attributeInstance) use ($endpointData) {
                 /** @var ResponseField $attributeInstance */
                 $data = $attributeInstance->toArray();

--- a/src/Extracting/Strategies/ResponseFields/GetFromResponseFieldTag.php
+++ b/src/Extracting/Strategies/ResponseFields/GetFromResponseFieldTag.php
@@ -31,7 +31,7 @@ class GetFromResponseFieldTag extends GetFieldsFromTagStrategy
             if($required !== "required"){
                 $description = $required . " " . $description;
             }
-            
+
             $required = $required === "required";
             $description = trim($description);
         }
@@ -57,21 +57,63 @@ class GetFromResponseFieldTag extends GetFieldsFromTagStrategy
      */
     public function getFromTags(array $tagsOnMethod, array $tagsOnClass = []): array
     {
+        $nonApiResourceFields = parent::getFromTags($tagsOnMethod, $tagsOnClass);
+        $apiResourceFields = $this->getApiResourceFields($tagsOnMethod);
+
+        return [...$nonApiResourceFields, ...$apiResourceFields];
+    }
+
+    protected function getApiResourceFields(array $tagsOnMethod): array
+    {
+        $apiResourceClassName = $this->getApiResourceClassName($tagsOnMethod);
+
+        if (empty($apiResourceClassName)) {
+            return [];
+        }
+
+        return $this->extractFieldsFromApiResource($apiResourceClassName);
+    }
+
+    protected function getApiResourceClassName(array $tagsOnMethod): ?string
+    {
         $apiResourceTags = array_values(
             array_filter($tagsOnMethod, function ($tag) {
                 return in_array(strtolower($tag->getName()), ['apiresource', 'apiresourcecollection']);
             })
         );
 
-        if (!empty($apiResourceTags) &&
-            !empty($className = $this->getClassNameFromApiResourceTag($apiResourceTags[0]->getContent()))
-        ) {
-            $method = u::getReflectedRouteMethod([$className, 'toArray']);
-            $docBlock = new DocBlock($method->getDocComment() ?: '');
-            $tagsOnApiResource = $docBlock->getTags();
+        if (empty($apiResourceTags)) {
+            return null;
         }
 
-        return parent::getFromTags(array_merge($tagsOnMethod, $tagsOnApiResource ?? []), $tagsOnClass);
+        return $this->getClassNameFromApiResourceTag($apiResourceTags[0]->getContent());
+    }
+
+    protected function extractFieldsFromApiResource(string $className): array
+    {
+        $method = u::getReflectedRouteMethod([$className, 'toArray']);
+        $docBlock = new DocBlock($method->getDocComment() ?: '');
+        $tagsOnApiResource = $docBlock->getTags();
+
+        $wrapKey = $className::$wrap ?? null;
+        $fields = parent::getFromTags($tagsOnApiResource, []);
+
+        return $this->applyWrapKeyPrefix($fields, $wrapKey);
+    }
+
+    protected function applyWrapKeyPrefix(array $fields, ?string $wrapKey): array
+    {
+        if ($wrapKey === null) {
+            return $fields;
+        }
+
+        $wrappedFields = [];
+        foreach ($fields as $fieldName => $fieldData) {
+            $fieldData['name'] = $wrapKey . '.' . $fieldData['name'];
+            $wrappedFields[$fieldData['name']] = $fieldData;
+        }
+
+        return $wrappedFields;
     }
 
     public function getClassNameFromApiResourceTag(string $apiResourceTag): string

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -205,6 +205,20 @@ class TestController extends Controller
         return new TestEmptyApiResource();
     }
 
+    #[\Knuckles\Scribe\Attributes\ResponseFromApiResource(\Knuckles\Scribe\Tests\Fixtures\TestNestedOuterResource::class)]
+    public function withNestedApiResourceResponse()
+    {
+        return new TestNestedOuterResource();
+    }
+
+    /**
+     * @apiResource \Knuckles\Scribe\Tests\Fixtures\TestNestedOuterResourceWithTags
+     */
+    public function withNestedApiResourceResponseWithTags()
+    {
+        return new TestNestedOuterResourceWithTags();
+    }
+
     /**
      * @group Other😎
      *

--- a/tests/Fixtures/TestNestedInnerResource.php
+++ b/tests/Fixtures/TestNestedInnerResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Knuckles\Scribe\Attributes\ResponseField;
+
+class TestNestedInnerResource extends JsonResource
+{
+    /**
+     * Create a new resource instance.
+     *
+     * @param  mixed  $resource
+     * @return void
+     */
+    public function __construct($resource = [])
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray($request)
+    {
+        return [
+            'inner2' => 'string',
+        ];
+    }
+}

--- a/tests/Fixtures/TestNestedInnerResourceWithTags.php
+++ b/tests/Fixtures/TestNestedInnerResourceWithTags.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TestNestedInnerResourceWithTags extends JsonResource
+{
+    /**
+     * Create a new resource instance.
+     *
+     * @param  mixed  $resource
+     * @return void
+     */
+    public function __construct($resource = [])
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray($request)
+    {
+        return [
+            'inner2' => 'string',
+        ];
+    }
+}

--- a/tests/Fixtures/TestNestedOuterResource.php
+++ b/tests/Fixtures/TestNestedOuterResource.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Knuckles\Scribe\Attributes\ResponseField;
+
+class TestNestedOuterResource extends JsonResource
+{
+    /**
+     * Create a new resource instance.
+     *
+     * @param  mixed  $resource
+     * @return void
+     */
+    public function __construct($resource = [])
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    #[
+        ResponseField('outer1', required: true),
+        ResponseField('outer1.inner1', required: true),
+        ResponseField('outer2', required: true),
+        ResponseField('outer2.inner2', required: true),
+    ]
+    public function toArray($request)
+    {
+        return [
+            'outer1' => [
+                'inner1' => 'string',
+            ],
+            'outer2' => new TestNestedInnerResource($this->resource),
+        ];
+    }
+}

--- a/tests/Fixtures/TestNestedOuterResourceWithTags.php
+++ b/tests/Fixtures/TestNestedOuterResourceWithTags.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TestNestedOuterResourceWithTags extends JsonResource
+{
+    /**
+     * Create a new resource instance.
+     *
+     * @param  mixed  $resource
+     * @return void
+     */
+    public function __construct($resource = [])
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @responseField outer1 string required First outer string
+     * @responseField outer1.inner1 string required First inner string
+     * @responseField outer2 string required Second outer string
+     * @responseField outer2.inner2 string required Second inner string
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray($request)
+    {
+        return [
+            'outer1' => [
+                'inner1' => 'string',
+            ],
+            'outer2' => new TestNestedInnerResourceWithTags($this->resource),
+        ];
+    }
+}

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -184,8 +184,8 @@ class OutputTest extends BaseLaravelTest
                     $response["header"] = array_filter($response["header"], fn ($header) => $header["key"] !== "access-control-allow-origin");
                     $response['header'] = array_map(
                         fn (array $header) => strtolower($header['key']) === 'content-type'
-                            ? [...$header, 'value' => strtolower($header['value'])]
-                            : $header,
+                        ? [...$header, 'value' => strtolower($header['value'])]
+                        : $header,
                         $response['header']
                     );
                 }
@@ -306,19 +306,19 @@ class OutputTest extends BaseLaravelTest
     public function sorts_groups_and_endpoints_in_the_specified_order()
     {
         $this->setConfig(['groups.order' => [
-            '10. Group 10',
-            '1. Group 1' => [
-                'GET /api/action1b',
-                'GET /api/action1',
-            ],
-            '13. Group 13' => [
-                'SG B' => [
-                    'POST /api/action13d',
-                    'GET /api/action13a',
+                '10. Group 10',
+                '1. Group 1' => [
+                    'GET /api/action1b',
+                    'GET /api/action1',
                 ],
-                'SG A',
-                'PUT /api/action13c',
-            ],
+                '13. Group 13' => [
+                    'SG B' => [
+                        'POST /api/action13d',
+                        'GET /api/action13a',
+                    ],
+                    'SG A',
+                    'PUT /api/action13c',
+                ],
         ]]);
 
         RouteFacade::get('/api/action1', [TestGroupController::class, 'action1']);
@@ -368,16 +368,16 @@ class OutputTest extends BaseLaravelTest
     public function sorts_groups_and_endpoints_in_the_specified_order_with_wildcard()
     {
         $this->setConfig(['groups.order' => [
-            '10. Group 10',
-            '*',
-            '13. Group 13' => [
-                'SG B' => [
-                    'POST /api/action13d',
-                    'GET /api/action13a',
+                '10. Group 10',
+                '*',
+                '13. Group 13' => [
+                    'SG B' => [
+                        'POST /api/action13d',
+                        'GET /api/action13a',
+                    ],
+                    'SG A',
+                    'PUT /api/action13c',
                 ],
-                'SG A',
-                'PUT /api/action13c',
-            ],
         ]]);
 
         RouteFacade::get('/api/action1', [TestGroupController::class, 'action1']);
@@ -620,6 +620,52 @@ class OutputTest extends BaseLaravelTest
         $this->assertEquals('nested-file', $group['endpoints'][2]['uri']);
         $this->assertEquals('multipart/form-data', $group['endpoints'][2]['headers']['Content-Type']);
 
+    }
+
+    /** @test */
+    public function generated_openapi_spec_correctly_handles_nested_api_resource_required_fields()
+    {
+        RouteFacade::get('/api/nested-resource', [TestController::class, 'withNestedApiResourceResponse']);
+
+        $this->setConfig([
+            'openapi.enabled' => true,
+        ]);
+
+        $this->generate();
+
+        $generatedSpec = Yaml::parseFile($this->openapiOutputPath());
+
+        $responseSchema = $generatedSpec['paths']['/api/nested-resource']['get']['responses']['200']['content']['application/json']['schema'];
+
+        $this->assertArrayHasKey('properties', $responseSchema);
+        $this->assertArrayHasKey('data', $responseSchema['properties']);
+        $dataSchema = $responseSchema['properties']['data'];
+
+        // Verify 'outer1' and 'outer2' are in data properties
+        $this->assertArrayHasKey('properties', $dataSchema);
+        $this->assertArrayHasKey('outer1', $dataSchema['properties']);
+        $this->assertArrayHasKey('outer2', $dataSchema['properties']);
+
+        // Verify both are marked as required at the data level
+        $this->assertArrayHasKey('required', $dataSchema);
+        $this->assertContains('outer1', $dataSchema['required']);
+        $this->assertContains('outer2', $dataSchema['required']);
+
+        // Verify 'outer1.inner1' is nested correctly and marked as required
+        $outer1Schema = $dataSchema['properties']['outer1'];
+        $this->assertEquals('object', $outer1Schema['type']);
+        $this->assertArrayHasKey('properties', $outer1Schema);
+        $this->assertArrayHasKey('inner1', $outer1Schema['properties']);
+        $this->assertArrayHasKey('required', $outer1Schema);
+        $this->assertContains('inner1', $outer1Schema['required']);
+
+        // Verify 'outer2.inner2' is nested correctly and marked as required
+        $outer2Schema = $dataSchema['properties']['outer2'];
+        $this->assertEquals('object', $outer2Schema['type']);
+        $this->assertArrayHasKey('properties', $outer2Schema);
+        $this->assertArrayHasKey('inner2', $outer2Schema['properties']);
+        $this->assertArrayHasKey('required', $outer2Schema);
+        $this->assertContains('inner2', $outer2Schema['required']);
     }
 
     protected function postmanOutputPath(bool $staticType = false): string

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -184,8 +184,8 @@ class OutputTest extends BaseLaravelTest
                     $response["header"] = array_filter($response["header"], fn ($header) => $header["key"] !== "access-control-allow-origin");
                     $response['header'] = array_map(
                         fn (array $header) => strtolower($header['key']) === 'content-type'
-                        ? [...$header, 'value' => strtolower($header['value'])]
-                        : $header,
+                            ? [...$header, 'value' => strtolower($header['value'])]
+                            : $header,
                         $response['header']
                     );
                 }
@@ -306,19 +306,19 @@ class OutputTest extends BaseLaravelTest
     public function sorts_groups_and_endpoints_in_the_specified_order()
     {
         $this->setConfig(['groups.order' => [
-                '10. Group 10',
-                '1. Group 1' => [
-                    'GET /api/action1b',
-                    'GET /api/action1',
+            '10. Group 10',
+            '1. Group 1' => [
+                'GET /api/action1b',
+                'GET /api/action1',
+            ],
+            '13. Group 13' => [
+                'SG B' => [
+                    'POST /api/action13d',
+                    'GET /api/action13a',
                 ],
-                '13. Group 13' => [
-                    'SG B' => [
-                        'POST /api/action13d',
-                        'GET /api/action13a',
-                    ],
-                    'SG A',
-                    'PUT /api/action13c',
-                ],
+                'SG A',
+                'PUT /api/action13c',
+            ],
         ]]);
 
         RouteFacade::get('/api/action1', [TestGroupController::class, 'action1']);

--- a/tests/GenerateDocumentation/OutputTest.php
+++ b/tests/GenerateDocumentation/OutputTest.php
@@ -368,16 +368,16 @@ class OutputTest extends BaseLaravelTest
     public function sorts_groups_and_endpoints_in_the_specified_order_with_wildcard()
     {
         $this->setConfig(['groups.order' => [
-                '10. Group 10',
-                '*',
-                '13. Group 13' => [
-                    'SG B' => [
-                        'POST /api/action13d',
-                        'GET /api/action13a',
-                    ],
-                    'SG A',
-                    'PUT /api/action13c',
+            '10. Group 10',
+            '*',
+            '13. Group 13' => [
+                'SG B' => [
+                    'POST /api/action13d',
+                    'GET /api/action13a',
                 ],
+                'SG A',
+                'PUT /api/action13c',
+            ],
         ]]);
 
         RouteFacade::get('/api/action1', [TestGroupController::class, 'action1']);

--- a/tests/Strategies/ResponseFields/GetFromResponseFieldAttributesTest.php
+++ b/tests/Strategies/ResponseFields/GetFromResponseFieldAttributesTest.php
@@ -8,6 +8,7 @@ use Knuckles\Camel\Extraction\ResponseCollection;
 use Knuckles\Scribe\Attributes\ResponseField;
 use Knuckles\Scribe\Attributes\ResponseFromApiResource;
 use Knuckles\Scribe\Extracting\Strategies\ResponseFields\GetFromResponseFieldAttribute;
+use Knuckles\Scribe\Tests\Fixtures\TestNestedOuterResource;
 use Knuckles\Scribe\Tests\Fixtures\TestPet;
 use Knuckles\Scribe\Tests\Fixtures\TestPetApiResource;
 use Knuckles\Scribe\Tools\DocumentationConfig;
@@ -73,15 +74,36 @@ class GetFromResponseFieldAttributesTest extends TestCase
         $results = $this->fetch($endpoint);
 
         $this->assertArraySubset([
-            'id' => [
+            'data.id' => [
                 'type' => '',
                 'description' => 'The id of the pet.',
             ],
-            'species' => [
+            'data.species' => [
                 'type' => 'string',
                 'description' => 'The breed',
             ],
         ], $results);
+    }
+
+    /** @test */
+    public function attributes_from_nested_api_resources_are_correctly_merged()
+    {
+        $endpoint = $this->endpoint(function (ExtractedEndpointData $e) {
+            $e->controller = new ReflectionClass(ResponseFieldAttributeTestController::class);
+            $e->method = $e->controller->getMethod('methodWithNestedApiResourceResponse');
+            $e->responses = new ResponseCollection([]);
+        });
+        $results = $this->fetch($endpoint);
+
+        $this->assertArrayHasKey('data.outer1', $results);
+        $this->assertArrayHasKey('data.outer1.inner1', $results);
+        $this->assertArrayHasKey('data.outer2', $results);
+        $this->assertArrayHasKey('data.outer2.inner2', $results);
+
+        $this->assertTrue($results['data.outer1']['required']);
+        $this->assertTrue($results['data.outer1.inner1']['required']);
+        $this->assertTrue($results['data.outer2']['required']);
+        $this->assertTrue($results['data.outer2.inner2']['required']);
     }
 
     protected function fetch($endpoint): array
@@ -114,6 +136,12 @@ class ResponseFieldAttributeTestController
 
     #[ResponseFromApiResource(TestPetApiResource::class, TestPet::class)]
     public function methodWithApiResourceResponse()
+    {
+    }
+
+
+    #[ResponseFromApiResource(TestNestedOuterResource::class)]
+    public function methodWithNestedApiResourceResponse()
     {
     }
 }

--- a/tests/Strategies/ResponseFields/GetFromResponseFieldTagTest.php
+++ b/tests/Strategies/ResponseFields/GetFromResponseFieldTagTest.php
@@ -110,6 +110,25 @@ class GetFromResponseFieldTagTest extends TestCase
         ], $results);
     }
 
+    /** @test */
+    public function applies_wrap_key_prefix_to_api_resource_fields()
+    {
+        $tags = [
+            new Tag('apiResource', '\\Knuckles\\Scribe\\Tests\\Fixtures\\TestNestedOuterResourceWithTags'),
+        ];
+        $results = $this->fetch($tags);
+
+        $this->assertArrayHasKey('data.outer1', $results);
+        $this->assertArrayHasKey('data.outer1.inner1', $results);
+        $this->assertArrayHasKey('data.outer2', $results);
+        $this->assertArrayHasKey('data.outer2.inner2', $results);
+
+        $this->assertTrue($results['data.outer1']['required']);
+        $this->assertTrue($results['data.outer1.inner1']['required']);
+        $this->assertTrue($results['data.outer2']['required']);
+        $this->assertTrue($results['data.outer2.inner2']['required']);
+    }
+
     protected function fetch($tags, $endpoint = null): array
     {
         $strategy = new GetFromResponseFieldTag(new DocumentationConfig([]));

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -997,9 +997,9 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'httpMethods' => ['GET'],
             'uri' => '/array-response',
             'responses' => [[
-                    'status' => 200,
-                    'content' => '["foo", "bar"]',
-                    'headers' => ['Content-Type' => $customJsonType],
+                'status' => 200,
+                'content' => '["foo", "bar"]',
+                'headers' => ['Content-Type' => $customJsonType],
             ]],
         ]);
 
@@ -1007,9 +1007,9 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'httpMethods' => ['GET'],
             'uri' => '/string-response',
             'responses' => [[
-                    'status' => 200,
-                    'content' => '"a simple string"',
-                    'headers' => ['Content-Type' => $customJsonType],
+                'status' => 200,
+                'content' => '"a simple string"',
+                'headers' => ['Content-Type' => $customJsonType],
             ]],
         ]);
 
@@ -1017,9 +1017,9 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'httpMethods' => ['GET'],
             'uri' => '/integer-response',
             'responses' => [[
-                    'status' => 200,
-                    'content' => '123',
-                    'headers' => ['Content-Type' => $customJsonType],
+                'status' => 200,
+                'content' => '123',
+                'headers' => ['Content-Type' => $customJsonType],
             ]],
         ]);
 
@@ -1050,8 +1050,8 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'httpMethods' => ['GET'],
             'uri' => '/text-response',
             'responses' => [[
-                    'status' => 200,
-                    'content' => 'This is a simple text response.',
+                'status' => 200,
+                'content' => 'This is a simple text response.',
             ]],
         ]);
 
@@ -1071,8 +1071,8 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'uri' => '/null-response',
             'httpMethods' => ['GET'],
             'responses' => [[
-                    'status' => 200,
-                    'content' => null,
+                'status' => 200,
+                'content' => null,
             ]],
         ]);
 
@@ -1080,8 +1080,8 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'uri' => '/empty-array-response',
             'httpMethods' => ['GET'],
             'responses' => [[
-                    'status' => 200,
-                    'content' => '[]',
+                'status' => 200,
+                'content' => '[]',
             ]],
         ]);
 
@@ -1754,8 +1754,8 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'uri' => '/null-response',
             'httpMethods' => ['GET'],
             'responses' => [[
-                    'status' => 200,
-                    'content' => null,
+                'status' => 200,
+                'content' => null,
             ]],
         ]);
 

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -663,6 +663,179 @@ class OpenAPISpecWriterTest extends BaseUnitTest
     }
 
     /** @test */
+    public function applies_required_flag_for_nested_response_fields_with_dot_notation()
+    {
+        $endpointData = $this->createMockEndpointData([
+            'httpMethods' => ['GET'],
+            'uri' => '/api/resource',
+            'responses' => [
+                [
+                    'status' => 200,
+                    'description' => '',
+                    'content' => json_encode([
+                        'status' => [
+                            'technicalValue' => 'active',
+                            'displayValue' => 'Active',
+                        ],
+                    ]),
+                ],
+            ],
+            'responseFields' => [
+                'status.technicalValue' => [
+                    'name' => 'status.technicalValue',
+                    'type' => 'string',
+                    'description' => 'The technical status value',
+                    'required' => true,
+                ],
+                'status.displayValue' => [
+                    'name' => 'status.displayValue',
+                    'type' => 'string',
+                    'description' => 'The display status value',
+                    'required' => false,
+                ],
+            ],
+        ]);
+
+        $groups = [$this->createGroup([$endpointData])];
+        $results = $this->generate($groups);
+
+        $statusSchema = $results['paths']['/api/resource']['get']['responses']['200']['content']['application/json']['schema']['properties']['status'];
+
+        $this->assertEquals('object', $statusSchema['type']);
+        $this->assertArrayHasKey('properties', $statusSchema);
+        $this->assertArrayHasKey('technicalValue', $statusSchema['properties']);
+        $this->assertArrayHasKey('displayValue', $statusSchema['properties']);
+        $this->assertArrayHasKey('required', $statusSchema);
+        $this->assertContains('technicalValue', $statusSchema['required']);
+        $this->assertNotContains('displayValue', $statusSchema['required']);
+    }
+
+    /** @test */
+    public function applies_required_flag_for_nested_response_fields_from_api_resources_with_data_prefix()
+    {
+        $endpointData = $this->createMockEndpointData([
+            'httpMethods' => ['GET'],
+            'uri' => '/api/resource',
+            'responses' => [
+                [
+                    'status' => 200,
+                    'description' => '',
+                    'content' => json_encode([
+                        'data' => [
+                            'status' => [
+                                'technicalValue' => 'active',
+                                'displayValue' => 'Active',
+                            ],
+                        ],
+                    ]),
+                ],
+            ],
+            'responseFields' => [
+                'data.status.technicalValue' => [
+                    'name' => 'data.status.technicalValue',
+                    'type' => 'string',
+                    'description' => 'The technical status value',
+                    'required' => true,
+                ],
+                'data.status.displayValue' => [
+                    'name' => 'data.status.displayValue',
+                    'type' => 'string',
+                    'description' => 'The display status value',
+                    'required' => false,
+                ],
+            ],
+        ]);
+
+        $groups = [$this->createGroup([$endpointData])];
+        $results = $this->generate($groups);
+
+        // For API Resources, the response is wrapped in 'data', so we need to check data.status
+        $dataSchema = $results['paths']['/api/resource']['get']['responses']['200']['content']['application/json']['schema']['properties']['data'];
+        $statusSchema = $dataSchema['properties']['status'];
+
+        $this->assertEquals('object', $statusSchema['type']);
+        $this->assertArrayHasKey('properties', $statusSchema);
+        $this->assertArrayHasKey('technicalValue', $statusSchema['properties']);
+        $this->assertArrayHasKey('displayValue', $statusSchema['properties']);
+        $this->assertArrayHasKey('required', $statusSchema);
+        $this->assertContains('technicalValue', $statusSchema['required']);
+        $this->assertNotContains('displayValue', $statusSchema['required']);
+    }
+
+    /** @test */
+    public function handles_required_params_correctly_for_nested_arrays()
+    {
+        $endpointData = $this->createMockEndpointData([
+            'httpMethods' => ['GET'],
+            'uri' => '/api/scribe-test',
+            'metadata' => [
+                'title' => 'Scribe TEST',
+            ],
+            'responses' => [
+                [
+                    'status' => 200,
+                    'description' => '',
+                    'content' => json_encode([
+                        'data' => [
+                            'outer1' => [
+                                'inner1' => 'string'
+                            ],
+                            'outer2' => [
+                                'inner2' => 'string'
+                            ],
+                        ],
+                    ]),
+                ],
+            ],
+            'responseFields' => [
+                'data.outer1' => [
+                    'name' => 'data.outer1',
+                    'description' => '',
+                    'required' => true,
+                    'type' => 'object',
+                ],
+                'data.outer1.inner1' => [
+                    'name' => 'data.outer1.inner1',
+                    'description' => '',
+                    'required' => true,
+                    'type' => 'string',
+                ],
+                'data.outer2' => [
+                    'name' => 'data.outer2',
+                    'description' => '',
+                    'required' => true,
+                    'type' => 'object',
+                ],
+                'data.outer2.inner2' => [
+                    'name' => 'data.outer2.inner2',
+                    'description' => '',
+                    'required' => true,
+                    'type' => 'string',
+                ],
+            ],
+        ]);
+
+        $groups = [$this->createGroup([$endpointData])];
+        $results = $this->generate($groups);
+
+        $dataSchema = $results['paths']['/api/scribe-test']['get']['responses']['200']['content']['application/json']['schema']['properties']['data'];
+
+        // outer1
+        $this->assertEquals('object', $dataSchema['properties']['outer1']['type']);
+        $this->assertContains('outer1', $dataSchema['required']);
+        // outer1.inner1
+        $this->assertEquals('string', $dataSchema['properties']['outer1']['properties']['inner1']['type']);
+        $this->assertContains('inner1', $dataSchema['properties']['outer1']['required']);
+
+        // outer2
+        $this->assertEquals('object', $dataSchema['properties']['outer2']['type']);
+        $this->assertContains('outer2', $dataSchema['required']);
+        // outer2.inner2
+        $this->assertEquals('string', $dataSchema['properties']['outer2']['properties']['inner2']['type']);
+        $this->assertContains('inner2', $dataSchema['properties']['outer2']['required']);
+    }
+
+    /** @test */
     public function adds_responses_correctly_as_array_of_objects()
     {
         $endpointData1 = $this->createMockEndpointData([
@@ -824,9 +997,9 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'httpMethods' => ['GET'],
             'uri' => '/array-response',
             'responses' => [[
-                'status' => 200,
-                'content' => '["foo", "bar"]',
-                'headers' => ['Content-Type' => $customJsonType],
+                    'status' => 200,
+                    'content' => '["foo", "bar"]',
+                    'headers' => ['Content-Type' => $customJsonType],
             ]],
         ]);
 
@@ -834,9 +1007,9 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'httpMethods' => ['GET'],
             'uri' => '/string-response',
             'responses' => [[
-                'status' => 200,
-                'content' => '"a simple string"',
-                'headers' => ['Content-Type' => $customJsonType],
+                    'status' => 200,
+                    'content' => '"a simple string"',
+                    'headers' => ['Content-Type' => $customJsonType],
             ]],
         ]);
 
@@ -844,9 +1017,9 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'httpMethods' => ['GET'],
             'uri' => '/integer-response',
             'responses' => [[
-                'status' => 200,
-                'content' => '123',
-                'headers' => ['Content-Type' => $customJsonType],
+                    'status' => 200,
+                    'content' => '123',
+                    'headers' => ['Content-Type' => $customJsonType],
             ]],
         ]);
 
@@ -877,8 +1050,8 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'httpMethods' => ['GET'],
             'uri' => '/text-response',
             'responses' => [[
-                'status' => 200,
-                'content' => 'This is a simple text response.',
+                    'status' => 200,
+                    'content' => 'This is a simple text response.',
             ]],
         ]);
 
@@ -898,8 +1071,8 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'uri' => '/null-response',
             'httpMethods' => ['GET'],
             'responses' => [[
-                'status' => 200,
-                'content' => null,
+                    'status' => 200,
+                    'content' => null,
             ]],
         ]);
 
@@ -907,8 +1080,8 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'uri' => '/empty-array-response',
             'httpMethods' => ['GET'],
             'responses' => [[
-                'status' => 200,
-                'content' => '[]',
+                    'status' => 200,
+                    'content' => '[]',
             ]],
         ]);
 
@@ -1581,8 +1754,8 @@ class OpenAPISpecWriterTest extends BaseUnitTest
             'uri' => '/null-response',
             'httpMethods' => ['GET'],
             'responses' => [[
-                'status' => 200,
-                'content' => null,
+                    'status' => 200,
+                    'content' => null,
             ]],
         ]);
 


### PR DESCRIPTION
## Purpose

This PR fixes the response field extraction to correctly respect Laravel's wrapping of API resources.

## Problem

I noticed that with nested API resources, the `ResponseField` attributes didn't correctly propagate their `required` status to the OpenAPI schema.

```php
class TestNestedOuterResource extends JsonResource
{
    #[
        ResponseField('outer1', required: true),
        ResponseField('outer1.inner1', required: true),
        ResponseField('outer2', required: true),
        ResponseField('outer2.inner2', required: true),
    ]
    public function toArray($request)
    {
        return [
            'outer1' => [
                'inner1' => 'string',
            ],
            'outer2' => new TestNestedInnerResource($this->resource),
        ];
    }
}
```

Setting the `inner` response fields to required did not mark them as required in the OpenAPI schema.

The reason was this fallback: https://github.com/knuckleswtf/scribe/blob/9b307b3cb617ee23f93e71dcef8f3da4c1c44060/src/Writing/OpenApiSpecGenerators/BaseGenerator.php#L607 Which always looked for the `$property` instead of the full path. Because the `data.` prefix was not considered when processing the ResponseField attributes.


## Changes

1. **`GetFromResponseFieldAttribute`**: Now respects `$wrap` property from API resources
2. **`GetFromResponseFieldTag`**: Now respects `$wrap` property when processing `@apiResource` tags
3. Both strategies now:
   - Read the `public static $wrap` property from the resource class
   - Apply the appropriate prefix to the field

Plus unit and integration test cases.

## Impact

With my changes
- Laravel's resource wrapping is respected
- It still works correctly when you customize the static $wrap property of the resource class
- It still works correctly when you disable wrapping via `JsonResource::withoutWrapping();`
- Response fields of nested resources are working correctly (see example with `TestNestedInnerResource`)

Hope this helps! 😊