### PR TITLE
feat: Allow opt in suppressing of model events when generating response data with factories

### DIFF
--- a/src/Extracting/InstantiatesExampleModels.php
+++ b/src/Extracting/InstantiatesExampleModels.php
@@ -45,6 +45,7 @@ trait InstantiatesExampleModels
 
         $strategies = [
             'factoryCreate' => fn () => $this->getExampleModelFromFactoryCreate($type, $factoryStates, $relations, $withCount),
+            'factoryCreateQuietly' => fn () => $this->getExampleModelFromFactoryCreate($type, $factoryStates, $relations, $withCount, true),
             'factoryMake' => fn () => $this->getExampleModelFromFactoryMake($type, $factoryStates, $relations),
             'databaseFirst' => fn () => $this->getExampleModelFromDatabaseFirst($type, $relations),
         ];
@@ -71,7 +72,7 @@ trait InstantiatesExampleModels
      * @param  string[]  $withCount
      * @return null|Model
      */
-    protected function getExampleModelFromFactoryCreate(string $type, array $factoryStates = [], array $relations = [], array $withCount = [])
+    protected function getExampleModelFromFactoryCreate(string $type, array $factoryStates = [], array $relations = [], array $withCount = [], bool $quietly = false)
     {
         // Since $relations and $withCount refer to the same underlying relationships in the model,
         // combining them ensures that all required relationships are initialized when passed to the factory.
@@ -79,7 +80,9 @@ trait InstantiatesExampleModels
 
         $factory = Utils::getModelFactory($type, $factoryStates, $allRelations);
 
-        return $factory->create()->refresh()->load($relations)->loadCount($withCount);
+        $factory = $quietly ? Model::withoutEvents(fn () => $factory->create()) : $factory->create();
+
+        return $factory->refresh()->load($relations)->loadCount($withCount);
     }
 
     /**

--- a/tests/Strategies/Responses/UseResponseAttributesTest.php
+++ b/tests/Strategies/Responses/UseResponseAttributesTest.php
@@ -317,9 +317,13 @@ class UseResponseAttributesTest extends BaseLaravelTest
         ], $results);
     }
 
-    #[TestWith(['factoryCreate', true])]
-    #[TestWith(['factoryCreateQuietly', false])]
-    public function test_it_can_suppress_model_events_using_factory_create_quietly(string $modelFactoryStrategy, bool $expectModelEvents)
+    /**
+     * @test
+     *
+     * @testWith ["factoryCreate", true]
+     *           ["factoryCreateQuietly", false]
+     */
+    public function it_can_suppress_model_events_using_factory_create_quietly(string $modelFactoryStrategy, bool $expectModelEvents)
     {
         Schema::create('test_users', function (Blueprint $table) {
             $table->id();
@@ -333,7 +337,6 @@ class UseResponseAttributesTest extends BaseLaravelTest
         TestUser::creating(function () use (&$modelEventFired) {
             $modelEventFired = true;
         });
-
         $documentationConfig = ['examples' => ['models_source' => [$modelFactoryStrategy]]];
 
         $results = $this->fetch($this->endpoint('apiResourceAttributesIncludeChildren'), $documentationConfig);

--- a/tests/Strategies/Responses/UseResponseAttributesTest.php
+++ b/tests/Strategies/Responses/UseResponseAttributesTest.php
@@ -22,6 +22,7 @@ use Knuckles\Scribe\Tests\Fixtures\TestUserApiResource;
 use Knuckles\Scribe\Tools\DocumentationConfig;
 use Knuckles\Scribe\Tools\Utils;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
+use PHPUnit\Framework\Attributes\TestWith;
 
 /**
  * @internal
@@ -316,6 +317,42 @@ class UseResponseAttributesTest extends BaseLaravelTest
         ], $results);
     }
 
+    #[TestWith(['factoryCreate', true])]
+    #[TestWith(['factoryCreateQuietly', false])]
+    public function test_it_can_suppress_model_events_using_factory_create_quietly(string $modelFactoryStrategy, bool $expectModelEvents)
+    {
+        Schema::create('test_users', function (Blueprint $table) {
+            $table->id();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('email');
+            $table->integer('parent_id')->nullable();
+        });
+
+        $modelEventFired = false;
+        TestUser::creating(function () use (&$modelEventFired) {
+            $modelEventFired = true;
+        });
+
+        $documentationConfig = ['examples' => ['models_source' => [$modelFactoryStrategy]]];
+
+        $results = $this->fetch($this->endpoint('apiResourceAttributesIncludeChildren'), $documentationConfig);
+        $this->assertArraySubset([
+            [
+                'status' => 200,
+                'content' => json_encode([
+                    'data' => [
+                        'id' => 4,
+                        'name' => 'Tested Again',
+                        'email' => 'a@b.com',
+                        'children' => [],
+                    ],
+                ]),
+            ],
+        ], $results);
+        $this->assertSame($expectModelEvents, $modelEventFired);
+    }
+
     /** @test */
     public function can_parse_apiresource_attributes_and_load_children_and_children_count_using_factory_create()
     {
@@ -370,7 +407,7 @@ class UseResponseAttributesTest extends BaseLaravelTest
 
     protected function fetch($endpoint, array $documentationConfig = []): array
     {
-        $strategy = new UseResponseAttributes(new DocumentationConfig([]));
+        $strategy = new UseResponseAttributes(new DocumentationConfig($documentationConfig));
 
         return $strategy($endpoint, []);
     }


### PR DESCRIPTION
This PR adds the ability to generate factory response data without model events dispatching and downstream listeners executing.  Generation time can be very slow in a project with a large amount of model event listeners when using factories (example: a pipeline that generates documentation upon PR merge). 

Documentation PR: https://github.com/knuckleswtf/scribe-docs/pull/35
