### PR TITLE
Fix undefined array key "text" in MarkdownParser when writing Blade docs

### DIFF
--- a/src/Tools/MarkdownParser.php
+++ b/src/Tools/MarkdownParser.php
@@ -12,11 +12,15 @@ class MarkdownParser extends \Parsedown
     {
         $block = parent::blockHeader($Line);
         if (isset($block['element']['name'])) {
+            $text = $block['element']['text']
+                ?? $block['element']['handler']['argument']
+                ?? '';
+            $text = is_string($text) ? $text : '';
             $level = (int) mb_trim($block['element']['name'], 'h');
-            $slug = Str::slug($block['element']['text']);
+            $slug = Str::slug($text);
             $block['element']['attributes']['id'] = $slug;
             $this->headings[] = [
-                'text' => $block['element']['text'],
+                'text' => $text,
                 'level' => $level,
                 'slug' => $slug,
             ];


### PR DESCRIPTION
## Problem
`scribe:generate` fails with `Undefined array key "text"` in `MarkdownParser::blockHeader` when writing Blade docs. Parsedown stores ATX header text in `element['handler']['argument']`, not `element['text']`, so the code that assumed `element['text']` triggers the error.

## Solution
Resolve header text from `element['text']` if set, otherwise from `element['handler']['argument']` (Parsedown’s structure), with a string fallback so slug/headings are always defined.