### PR TITLE
Fix required field generation for wrapped and unwrapped resource collections

### DIFF
--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -230,7 +230,7 @@ class BaseGenerator extends OpenApiGenerator
                     $path
                 );
                 if ($required) {
-                    $schema['required'] = $required;
+                    $schema['items']['required'] = $required;
                 }
             }
         }

--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -490,14 +490,22 @@ class BaseGenerator extends OpenApiGenerator
                         return [$key => $this->generateSchemaForResponseValue($value, $endpoint, $key)];
                     })->toArray();
 
+                    $required = $this->filterRequiredResponseFields($endpoint, array_keys($properties));
+
+                    $items = [
+                        'type' => $this->convertScribeOrPHPTypeToOpenAPIType(gettype($decoded[0])),
+                        'properties' => $this->objectIfEmpty($properties),
+                    ];
+
+                    if ($required) {
+                        $items['required'] = $required;
+                    }
+
                     return [
                         $contentType => [
                             'schema' => [
                                 'type' => 'array',
-                                'items' => [
-                                    'type' => $this->convertScribeOrPHPTypeToOpenAPIType(gettype($decoded[0])),
-                                    'properties' => $this->objectIfEmpty($properties),
-                                ],
+                                'items' => $items,
                                 'example' => $decoded,
                             ],
                         ],


### PR DESCRIPTION
This PR fixes incorrect `required` placement in generated OpenAPI schemas for resource collections.

Previously, `required` was added at the array level (`data.required`) instead of the item level (`data.items.required`).

It also adds support for generating `required` fields for top-level unwrapped resource collections when using `JsonResource::withoutWrapping()`.

<!-- 
Please read the [contribution guidelines](https://scribe.readthedocs.io/en/latest/contributing.html), especially the section on making a pull request, before creating a PR.** Otherwise, your PR may be turned down.
 -->

