### PR TITLE
fix: Handle null example in array body parameter and add regression test

### DIFF
--- a/camel/Output/OutputEndpointData.php
+++ b/camel/Output/OutputEndpointData.php
@@ -255,7 +255,12 @@ class OutputEndpointData extends BaseDTO
             $finalParameters = ['[]' => $finalParameters['[]']];
             // At this point, the examples are likely [[], []],
             // but have been correctly set in clean parameters, so let's update them
-            if ($finalParameters['[]']['example'][0] === [] && ! empty($cleanParameters)) {
+            if (
+                is_array($finalParameters['[]']['example'])
+                && isset($finalParameters['[]']['example'][0])
+                && $finalParameters['[]']['example'][0] === []
+                && ! empty($cleanParameters)
+            ) {
                 $finalParameters['[]']['example'] = $cleanParameters;
             }
         }

--- a/tests/Unit/OutputEndpointDataTest.php
+++ b/tests/Unit/OutputEndpointDataTest.php
@@ -110,4 +110,32 @@ class OutputEndpointDataTest extends BaseUnitTest
             ],
         ], $nested);
     }
+
+    /** @test */
+    public function does_not_crash_when_explicit_array_body_parameter_has_null_example()
+    {
+        // Reproduces: "Trying to access array offset on value of type null" at OutputEndpointData.php:258
+        // This happens when the user explicitly declares a "[]" parameter without providing an example.
+        $parameters = [
+            '[]' => Parameter::create([
+                'name' => '[]',
+                'type' => 'object[]',
+                'description' => 'List of items',
+                'required' => true,
+                // 'example' intentionally omitted → defaults to null
+            ]),
+            '[].name' => Parameter::create([
+                'name' => '[].name',
+                'type' => 'string',
+                'description' => 'Item name',
+                'required' => true,
+                'example' => 'John',
+            ]),
+        ];
+        $cleanParameters = [['name' => 'John']];
+
+        $nested = OutputEndpointData::nestArrayAndObjectFields($parameters, $cleanParameters);
+
+        $this->assertArrayHasKey('[]', $nested);
+    }
 }


### PR DESCRIPTION
This PR fixes #1056

When a user explicitly declares a [] body/query parameter without providing an example, combined with child parameters like [].name, e.g.:

```php
/**
 * @bodyParam [].name string required Name.
 */
```
Scribe would crash with:

```
    ErrorException: Trying to access array offset on value of type null
```

**Fix:** Added is_array() and isset() checks before accessing [0] on the example value.

**Test:** Added a regression test in OutputEndpointDataTest that reproduces the crash scenario.