### PR TITLE
Fix: Move required from array schema to object schema inside items

### DIFF
--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -485,20 +485,20 @@ class BaseGenerator extends OpenApiGenerator
 
                 // Non-empty array
                 if (is_object($decoded[0])) {
-                    // If the first item is an object, we assume it's an array of objects'
+                    // If the first item is an object, we assume it's an array of objects
                     $properties = collect($decoded[0])->mapWithKeys(function ($value, $key) use ($endpoint) {
                         return [$key => $this->generateSchemaForResponseValue($value, $endpoint, $key)];
                     })->toArray();
 
-                    $required = $this->filterRequiredResponseFields($endpoint, array_keys($properties));
+                    $requiredFields = $this->filterRequiredResponseFields($endpoint, array_keys($properties));
 
                     $items = [
                         'type' => $this->convertScribeOrPHPTypeToOpenAPIType(gettype($decoded[0])),
                         'properties' => $this->objectIfEmpty($properties),
                     ];
 
-                    if ($required) {
-                        $items['required'] = $required;
+                    if ($requiredFields) {
+                        $items['required'] = $requiredFields;
                     }
 
                     return [

--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -230,7 +230,7 @@ class BaseGenerator extends OpenApiGenerator
                     $path
                 );
                 if ($required) {
-                    $schema['required'] = $required;
+                    $schema['items']['required'] = $required;
                 }
             }
         }
@@ -239,7 +239,7 @@ class BaseGenerator extends OpenApiGenerator
     }
 
     /**
-     * Given an enpoint and a set of object keys at a path, return the properties that are specified as required.
+     * Given an endpoint and a set of object keys at a path, return the properties that are specified as required.
      */
     public function filterRequiredResponseFields(OutputEndpointData $endpoint, array $properties, string $path = ''): array
     {
@@ -490,14 +490,22 @@ class BaseGenerator extends OpenApiGenerator
                         return [$key => $this->generateSchemaForResponseValue($value, $endpoint, $key)];
                     })->toArray();
 
+                    $required = $this->filterRequiredResponseFields($endpoint, array_keys($properties));
+
+                    $items = [
+                        'type' => $this->convertScribeOrPHPTypeToOpenAPIType(gettype($decoded[0])),
+                        'properties' => $this->objectIfEmpty($properties),
+                    ];
+
+                    if ($required) {
+                        $items['required'] = $required;
+                    }
+
                     return [
                         $contentType => [
                             'schema' => [
                                 'type' => 'array',
-                                'items' => [
-                                    'type' => $this->convertScribeOrPHPTypeToOpenAPIType(gettype($decoded[0])),
-                                    'properties' => $this->objectIfEmpty($properties),
-                                ],
+                                'items' => $items,
                                 'example' => $decoded,
                             ],
                         ],

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -885,6 +885,60 @@ class OpenAPISpecWriterTest extends BaseUnitTest
     }
 
     /** @test */
+    public function adds_required_fields_on_bare_array_of_objects()
+    {
+        $endpointData = $this->createMockEndpointData([
+            'httpMethods' => ['GET'],
+            'uri' => '/path1',
+            'responses' => [
+                [
+                    'status' => 200,
+                    'description' => 'Successfully.',
+                    'content' => '[{"id": 1, "name": "John"}, {"id": 2, "name": "Jane"}]',
+                ],
+            ],
+            'responseFields' => [
+                'id' => [
+                    'name' => 'id',
+                    'type' => 'integer',
+                    'description' => 'The ID',
+                    'required' => true,
+                ],
+                'name' => [
+                    'name' => 'name',
+                    'type' => 'string',
+                    'description' => 'The name',
+                    'required' => true,
+                ],
+            ],
+        ]);
+
+        $groups = [$this->createGroup([$endpointData])];
+        $results = $this->generate($groups);
+
+        $this->assertArraySubset([
+            '200' => [
+                'description' => 'Successfully.',
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'array',
+                            'items' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'id' => ['type' => 'integer'],
+                                    'name' => ['type' => 'string'],
+                                ],
+                                'required' => ['id', 'name'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $results['paths']['/path1']['get']['responses']);
+    }
+
+    /** @test */
     public function adds_response_content_type_correctly()
     {
         $endpointData1 = $this->createMockEndpointData([

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -1175,11 +1175,11 @@ class OpenAPISpecWriterTest extends BaseUnitTest
                                                 'description' => 'Is primary resource',
                                             ],
                                         ],
-                                    ],
-                                    'required' => [
-                                        'name',
-                                        'uuid',
-                                        'primary',
+                                        'required' => [
+                                            'name',
+                                            'uuid',
+                                            'primary',
+                                        ],
                                     ],
                                 ],
                             ],
@@ -1483,11 +1483,11 @@ class OpenAPISpecWriterTest extends BaseUnitTest
                                                 'description' => 'Is primary resource',
                                             ],
                                         ],
-                                    ],
-                                    'required' => [
-                                        'name',
-                                        'uuid',
-                                        'primary',
+                                        'required' => [
+                                            'name',
+                                            'uuid',
+                                            'primary',
+                                        ],
                                     ],
                                 ],
                             ],


### PR DESCRIPTION
In the openapi spec, the required array belongs on the object schema inside items, not on the parent array schema ([see data types](https://swagger.io/docs/specification/v3_0/data-models/data-types/#objects))

- Fix `required` field placement in array item schemas. It was being set on the array schema itself instead of inside `items`, but it should have been in the `object` schema. The fix for this is in the function `generateSchemaForResponseValue`.

Example:
Incorrect: `required` object properties are in the array schema
```
lineItems:
  type: array
  required:  # `required` is not a valid keyword on type: array
    - productId
    - quantity
  items:
    type: object
    properties:
      productId:
        type: string
      quantity:
        type: integer
      note:
        type: string
```
Correct: `required` object properties are in the object schema:
```
lineItems:
  type: array
  items:
    type: object
    required:
      - productId
      - quantity
    properties:
      productId:
        type: string
      quantity:
        type: integer
      note:
        type: string
```

- Add missing `required` field support for responses that are arrays of objects. For example, when Laravel APIs return a collection, it's wrapped in a `data` key like `{ "data": [{"name": "foo"}]}` but you can call `JsonResource::withoutWrapping()` to get an array instead: `[{"name": "foo"}]`. The fix for this is in `generateResponseContentSpec`.