### PR TITLE
Update description for 'exists' validation rule

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -781,7 +781,7 @@ trait ParsesValidationRules
                     break;
 
                 case 'exists':
-                    $parameterData['description'] .= " The <code>{$ruleArguments[1]}</code> of an existing record in the {$ruleArguments[0]} table.";
+                    $parameterData['description'] .= " Must match an existing stored value.";
 
                     break;
 


### PR DESCRIPTION
Removed references to database attributes that should not be public.

Per https://github.com/knuckleswtf/scribe/issues/974, (only the private portion, not the ignoring feature).

