### PR TITLE
feat: Add `afterExtracting()` hook for post-processing endpoint data

### DIFF
--- a/src/Extracting/Extractor.php
+++ b/src/Extracting/Extractor.php
@@ -17,6 +17,7 @@ use Knuckles\Camel\Output\OutputEndpointData;
 use Knuckles\Scribe\Extracting\Strategies\StaticData;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
 use Knuckles\Scribe\Tools\DocumentationConfig;
+use Knuckles\Scribe\Tools\Globals;
 use Knuckles\Scribe\Tools\RoutePatternMatcher;
 
 class Extractor
@@ -95,6 +96,10 @@ class Extractor
 
         $this->fetchResponseFields($endpointData, $routeRules);
         $this->mergeInheritedMethodsData('responseFields', $endpointData, $inheritedDocsOverrides);
+
+        if (is_callable(Globals::$__afterExtracting)) {
+            call_user_func_array(Globals::$__afterExtracting, [$endpointData]);
+        }
 
         self::$routeBeingProcessed = null;
 

--- a/src/Scribe.php
+++ b/src/Scribe.php
@@ -95,4 +95,15 @@ class Scribe
     {
         Globals::$__normalizeEndpointUrlUsing = $callable;
     }
+
+    /**
+     * Specify a callback that will be executed after all extraction strategies have run for a route.
+     * This allows you to modify the extracted endpoint data before it is saved.
+     *
+     * @param  callable(ExtractedEndpointData): void  $callable
+     */
+    public static function afterExtracting(callable $callable)
+    {
+        Globals::$__afterExtracting = $callable;
+    }
 }

--- a/src/Tools/Globals.php
+++ b/src/Tools/Globals.php
@@ -19,4 +19,6 @@ class Globals
     public static $__instantiateFormRequestUsing;
 
     public static $__normalizeEndpointUrlUsing;
+
+    public static $__afterExtracting;
 }

--- a/tests/Unit/AfterExtractingHookTest.php
+++ b/tests/Unit/AfterExtractingHookTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Unit;
+
+use Illuminate\Routing\Route;
+use Knuckles\Camel\Extraction\ExtractedEndpointData;
+use Knuckles\Scribe\Config\Defaults;
+use Knuckles\Scribe\Extracting\Extractor;
+use Knuckles\Scribe\Scribe;
+use Knuckles\Scribe\Tests\BaseLaravelTest;
+use Knuckles\Scribe\Tests\Fixtures\TestController;
+use Knuckles\Scribe\Tools\DocumentationConfig;
+use Knuckles\Scribe\Tools\Globals;
+
+class AfterExtractingHookTest extends BaseLaravelTest
+{
+    protected array $config = [
+        'strategies' => [
+            'metadata' => [
+                ...Defaults::METADATA_STRATEGIES,
+            ],
+            'headers' => [
+                ...Defaults::HEADERS_STRATEGIES,
+            ],
+            'urlParameters' => [
+                ...Defaults::URL_PARAMETERS_STRATEGIES,
+            ],
+            'queryParameters' => [
+                ...Defaults::QUERY_PARAMETERS_STRATEGIES,
+            ],
+            'bodyParameters' => [
+                ...Defaults::BODY_PARAMETERS_STRATEGIES,
+            ],
+            'responses' => [],
+            'responseFields' => [
+                ...Defaults::RESPONSE_FIELDS_STRATEGIES,
+            ],
+        ],
+    ];
+
+    protected function tearDown(): void
+    {
+        Globals::$__afterExtracting = null;
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function can_use_after_extracting_hook()
+    {
+        $route = new Route(['GET'], 'api/test', ['uses' => [TestController::class, 'withEndpointDescription']]);
+
+        Scribe::afterExtracting(static function (ExtractedEndpointData $endpointData) {
+            $endpointData->metadata->title = 'Modified Title';
+            $endpointData->headers['X-Modified-By'] = 'Hook';
+        });
+
+        $extractor = new Extractor(new DocumentationConfig($this->config));
+        $parsed = $extractor->processRoute($route);
+
+        $this->assertSame('Modified Title', $parsed->metadata->title);
+        $this->assertSame('Hook', $parsed->headers['X-Modified-By']);
+    }
+
+    /** @test */
+    public function after_extracting_hook_is_called_only_once_per_route()
+    {
+        $route = new Route(['GET'], 'api/test', ['uses' => [TestController::class, 'withEndpointDescription']]);
+
+        $callCount = 0;
+        Scribe::afterExtracting(function (ExtractedEndpointData $endpointData) use (&$callCount) {
+            $callCount++;
+        });
+
+        $extractor = new Extractor(new DocumentationConfig($this->config));
+        $extractor->processRoute($route);
+
+        $this->assertSame(1, $callCount);
+    }
+
+    /** @test */
+    public function after_extracting_hook_can_access_route_middlewares()
+    {
+        $route = new Route(['GET'], 'api/test', ['uses' => [TestController::class, 'withEndpointDescription']]);
+        $route->middleware(['auth:agent_api', 'throttle:60,1']);
+
+        Scribe::afterExtracting(static function (ExtractedEndpointData $endpointData) {
+            $middlewares = $endpointData->route->gatherMiddleware();
+            if (in_array('auth:agent_api', $middlewares, true)) {
+                $endpointData->metadata->description .= 'Requires authentication: `Agent`';
+            } elseif (in_array('auth:api', $middlewares, true)) {
+                $endpointData->metadata->description .= 'Requires authentication: `User`';
+            }
+        });
+
+        $extractor = new Extractor(new DocumentationConfig($this->config));
+        $parsed = $extractor->processRoute($route);
+
+        $this->assertStringContainsString('Requires authentication: `Agent`', $parsed->metadata->description);
+    }
+}


### PR DESCRIPTION
#### Summary
This PR introduces a new lifecycle hook: `Scribe::afterExtracting()`. This hook allows users to make programmatic changes to extracted endpoint data after all strategies have finished their execution, but before the data is finalized.  Closes #1067

#### Motivation
Previously, users who wanted to make small, context-aware changes to extracted data (like appending info to descriptions based on middleware or route names) had to either create a full custom strategy or use hooks intended for other purposes (like `beforeResponseCall`). This new hook provides a clean, "middle-ground" solution for such cases.

#### Changes
- **`src/Tools/Globals.php`**: Added a static property `$__afterExtracting` to store the callback.
- **`src/Scribe.php`**: Added a public static method `afterExtracting(callable $callable)` to allow easy registration of the hook.
- **`src/Extracting/Extractor.php`**: Integrated the hook call at the end of `processRoute()`. It is called once for each route and receives the `ExtractedEndpointData` object.

#### Example Usage
In your `AppServiceProvider` or a dedicated Scribe bootstrap file:

```php
use Knuckles\Scribe\Scribe;
use Knuckles\Camel\Extraction\ExtractedEndpointData;

Scribe::afterExtracting(function (ExtractedEndpointData $endpointData) {
    // Access the Laravel route and its middleware
    $middlewares = $endpointData->route->gatherMiddleware();
    
    if (in_array('auth:agent_api', $middlewares, true)) {
        $endpointData->metadata->description .= "🔒 **Requires Authentication:** `Agent`";
    } elseif (in_array('auth:api', $middlewares, true)) {
        $endpointData->metadata->description .= "🔒 **Requires Authentication:** `User`";
    }
});
```