### PR TITLE
Fix: Don't pre-urlencode Postman collection query keys/values

### DIFF
--- a/src/Writing/PostmanCollectionWriter.php
+++ b/src/Writing/PostmanCollectionWriter.php
@@ -318,8 +318,8 @@ class PostmanCollectionWriter
                 }
             } else {
                 $query[] = [
-                    'key' => urlencode($name),
-                    'value' => $parameterData->example !== null ? urlencode($parameterData->example) : '',
+                    'key' => $name,
+                    'value' => $parameterData->example !== null ? (string) $parameterData->example : '',
                     'description' => strip_tags($parameterData->description),
                     // Default query params to disabled if they aren't required and have empty values
                     'disabled' => ! $parameterData->required && empty($parameterData->example),
@@ -329,9 +329,12 @@ class PostmanCollectionWriter
 
         $base['query'] = $query;
 
-        // Create raw url-parameter (Insomnia uses this on import)
+        // Create raw url-parameter (Insomnia uses this on import).
+        // Per Postman Collection v2.1, query[].key/value are stored raw and the client
+        // encodes them when sending. The raw URL string still needs encoding to be a
+        // syntactically valid URL, so we only encode it here.
         $queryString = collect($base['query'])->map(function ($queryParamData) {
-            return $queryParamData['key'].'='.$queryParamData['value'];
+            return rawurlencode($queryParamData['key']).'='.rawurlencode($queryParamData['value']);
         })->implode('&');
         $base['raw'] = sprintf('%s/%s%s', $base['host'], $base['path'], $queryString ? "?{$queryString}" : null);
 
@@ -344,7 +347,7 @@ class PostmanCollectionWriter
             return [
                 'id' => $name,
                 'key' => $name,
-                'value' => urlencode($parameter->example),
+                'value' => $parameter->example,
                 'description' => $parameter->description,
             ];
         })->values()->toArray();

--- a/tests/Fixtures/collection.json
+++ b/tests/Fixtures/collection.json
@@ -170,12 +170,12 @@
                 },
                 {
                   "key": "url_encoded",
-                  "value": "%2B+%5B%5D%26%3D",
+                  "value": "+ []&=",
                   "description": "Used for testing that URL parameters will be URL-encoded where needed.",
                   "disabled": false
                 }
               ],
-              "raw": "{{baseUrl}}/api/withQueryParameters?location_id=architecto&user_id=me&page=4&filters=architecto&url_encoded=%2B+%5B%5D%26%3D"
+              "raw": "{{baseUrl}}/api/withQueryParameters?location_id=architecto&user_id=me&page=4&filters=architecto&url_encoded=%2B%20%5B%5D%26%3D"
             },
             "method": "GET",
             "header": [

--- a/tests/Unit/PostmanCollectionWriterTest.php
+++ b/tests/Unit/PostmanCollectionWriterTest.php
@@ -208,6 +208,64 @@ class PostmanCollectionWriterTest extends BaseUnitTest
     }
 
     /** @test */
+    public function query_parameter_keys_and_values_are_not_pre_url_encoded()
+    {
+        // Per Postman Collection v2.1 spec, query[].key/value are stored as raw strings
+        // and the Postman client encodes them when sending. Pre-encoding here causes
+        // a double-encode on send (e.g. `,` → `%2C` → `%252C` at the server).
+        $endpointData = $this->createMockEndpointData('fake/{id}');
+        $endpointData->urlParameters['id'] = new Parameter([
+            'name' => 'id',
+            'description' => '',
+            'required' => true,
+            'example' => 'foo bar',
+        ]);
+        $endpointData->queryParameters = [
+            'include' => new Parameter([
+                'name' => 'include',
+                'type' => 'string',
+                'description' => 'Comma-separated relationships',
+                'required' => false,
+                'example' => 'customer,reward',
+            ]),
+            'filter[email]' => new Parameter([
+                'name' => 'filter[email]',
+                'type' => 'string',
+                'description' => 'Filter',
+                'required' => false,
+                'example' => 'test@example.com',
+            ]),
+        ];
+        $endpointData->cleanQueryParameters = Extractor::cleanParams($endpointData->queryParameters);
+
+        $endpoints = $this->createMockEndpointGroup([$endpointData]);
+        $collection = $this->generate(endpoints: [$endpoints]);
+
+        $url = data_get($collection, 'item.0.item.0.request.url');
+
+        // Query objects keep raw values — Postman encodes on send.
+        $this->assertContains([
+            'key' => 'include',
+            'value' => 'customer,reward',
+            'description' => 'Comma-separated relationships',
+            'disabled' => false,
+        ], $url['query']);
+        $this->assertContains([
+            'key' => 'filter[email]',
+            'value' => 'test@example.com',
+            'description' => 'Filter',
+            'disabled' => false,
+        ], $url['query']);
+
+        // URL variables also stored raw.
+        $this->assertSame('foo bar', $url['variable'][0]['value']);
+
+        // Raw URL is encoded for HTTP validity.
+        $this->assertStringContainsString('include=customer%2Creward', $url['raw']);
+        $this->assertStringContainsString('filter%5Bemail%5D=test%40example.com', $url['raw']);
+    }
+
+    /** @test */
     public function auth_info_is_added_correctly()
     {
         $endpointData1 = $this->createMockEndpointData('some/path');


### PR DESCRIPTION
## Summary

`PostmanCollectionWriter::generateUrlObject()` calls `urlencode()` on every query parameter key and value (and on URL parameter values) before writing them to the collection. Per the [Postman Collection v2.1 schema](https://schema.postman.com/json/collection/v2.1.0/collection.json), `query[].key` / `query[].value` and `variable[].value` are stored as raw strings — the Postman client encodes them when it assembles the outgoing HTTP request.

Pre-encoding here causes a double-encode on send. For example:

```php
/**
 * @queryParam include string Example: customer,reward
 */
```

Generates this in `collection.json`:

```json
{ "key": "include", "value": "customer%2Creward" }
```

When the user clicks **Send**, Postman encodes the value again → server receives `?include=customer%252Creward`. Frameworks decode once → `customer%2Creward`, which strict request parsers (e.g. Spatie QueryBuilder, which splits includes on a literal `,`) reject as a single unknown include.

URL parameter values had the same issue.

## What changed

- `query[].key`, `query[].value`, `variable[].value` are now stored unencoded.
- The `raw` URL field still needs to be a syntactically valid URL, so `rawurlencode()` is applied only when assembling that string. (Switched to `rawurlencode` because `urlencode` encodes spaces as `+`, which is only valid in `application/x-www-form-urlencoded` bodies — not query strings per RFC 3986.)

## Tests

- All 10 existing tests in `PostmanCollectionWriterTest` pass unchanged. They only used plain alphanumeric values (`5`, `34`, `foobar`) where pre-encoding was a no-op, which is why this latent bug went unnoticed.
- Adds a regression test (`query_parameter_keys_and_values_are_not_pre_url_encoded`) covering comma + bracket + space cases, asserting:
  - `query[]` entries store raw values
  - `variable[]` entries store raw values
  - `raw` URL is encoded for HTTP validity

## Related

- Closes #877 (asks why query params are URL-encoded in the Postman collection — this is the answer: it shouldn't be).

## Notes for reviewers

This is a behavioral change visible in generated Postman collections. Users who imported a previously-generated collection and observed `%2C` / `%5B` / `%5D` in the displayed key/value will now see literal `,` / `[` / `]`. Postman renders both forms identically when sending, so no user-facing regression — only the underlying double-encode bug is fixed.