### PR TITLE
Allow Blade syntax in base_url config

### DIFF
--- a/src/Writing/HtmlWriter.php
+++ b/src/Writing/HtmlWriter.php
@@ -3,6 +3,7 @@
 namespace Knuckles\Scribe\Writing;
 
 use http\Exception\InvalidArgumentException;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
 use Knuckles\Camel\Output\OutputEndpointData;
@@ -28,7 +29,8 @@ class HtmlWriter
     {
         $this->config = $config ?: new DocumentationConfig(config('scribe', []));
         $this->markdownParser = new MarkdownParser;
-        $this->baseUrl = $this->config->get('base_url') ?? config('app.url');
+        $baseUrl = $this->config->get('base_url') ?? config('app.url');
+        $this->baseUrl = Str::contains($baseUrl, ['{{', '{!!', '@']) ? Blade::render($baseUrl) : $baseUrl;
         // If they're using the default static path,
         // then use '../docs/{asset}', so assets can work via Laravel app or via index.html
         $this->assetPathPrefix = '../docs/';

--- a/tests/Unit/HtmlWriterTest.php
+++ b/tests/Unit/HtmlWriterTest.php
@@ -35,4 +35,30 @@ class HtmlWriterTest extends BaseLaravelTest
         $commit = mb_trim(shell_exec('git rev-parse --short HEAD'));
         $this->assertEquals("Last updated on {$date} (Git commit {$commit})", $lastUpdated);
     }
+
+    /** @test */
+    public function renders_blade_syntax_in_base_url()
+    {
+        config()->set('app.url', 'https://resolved.example.com');
+
+        $writer = new HtmlWriter(new DocumentationConfig([
+            'base_url' => "{{ config('app.url') }}/api",
+            'title' => 'API Docs',
+        ]));
+
+        $baseUrl = (new \ReflectionClass($writer))->getProperty('baseUrl')->getValue($writer);
+        $this->assertEquals('https://resolved.example.com/api', $baseUrl);
+    }
+
+    /** @test */
+    public function leaves_plain_base_url_untouched()
+    {
+        $writer = new HtmlWriter(new DocumentationConfig([
+            'base_url' => 'https://plain.example.com',
+            'title' => 'API Docs',
+        ]));
+
+        $baseUrl = (new \ReflectionClass($writer))->getProperty('baseUrl')->getValue($writer);
+        $this->assertEquals('https://plain.example.com', $baseUrl);
+    }
 }


### PR DESCRIPTION
## Summary

- Renders `base_url` through `Blade::render()` once inside `HtmlWriter::__construct`, so values like `{{ config('app.url') }}` are resolved before reaching any theme view.
- Works for every HTML theme (and `ExternalHtmlWriter` via inheritance) — not just `elements`. Addresses the review feedback left on #944.
- Cheap `Str::contains` guard skips the Blade compiler for plain URLs, avoiding the need for a fully-booted view factory (e.g., when `__components` hint paths aren't registered).

Refs #943.

## Test plan

- [x] `vendor/bin/pest --filter HtmlWriterTest` — added `renders blade syntax in base url` and `leaves plain base url untouched` cases
- [x] `vendor/bin/pest` — full suite passes (324 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)