### PR TITLE
fix PHP deprecation, send value to escape parameter of str_getcsv function

### DIFF
--- a/src/Extracting/ParsesValidationRules.php
+++ b/src/Extracting/ParsesValidationRules.php
@@ -818,7 +818,7 @@ trait ParsesValidationRules
             if (in_array(mb_strtolower($rule), ['regex', 'date', 'date_format'])) {
                 $ruleArguments = [$argumentsString];
             } else {
-                $ruleArguments = str_getcsv($argumentsString);
+                $ruleArguments = str_getcsv($argumentsString, escape: '\\');
             }
         }
 


### PR DESCRIPTION
I just fix one deprecate error from str_getcsv function, it start on PHP 8.4.
https://onlinephp.io/c/ea2df
https://www.php.net/manual/en/function.str-getcsv.php