### PR TITLE
Replace Arr::random with Faker's randomElement

### DIFF
--- a/src/Extracting/ParamHelpers.php
+++ b/src/Extracting/ParamHelpers.php
@@ -75,7 +75,7 @@ trait ParamHelpers
     protected function generateDummyValue(string $type, array $hints = [])
     {
         if (! empty($hints['enumValues'])) {
-            return Arr::random($hints['enumValues']);
+            return $this->getFaker()->randomElement($hints['enumValues']);
         }
 
         $fakeFactory = $this->getDummyValueGenerator($type, $hints);


### PR DESCRIPTION
Using `Arr::random()` bypasses the faker seed from config, causing unnecessary regeneration of scribe yml files in some cases.

