### PR TITLE
Update Scalar to use JS API

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -85,6 +85,8 @@ return [
 
     'external' => [
         'html_attributes' => [],
+        // Configuration specific for the scalar theme: https://scalar.com/products/api-references/configuration
+        'scalar_config' => [],
     ],
 
     'try_it_out' => [

--- a/resources/views/external/scalar.blade.php
+++ b/resources/views/external/scalar.blade.php
@@ -14,14 +14,11 @@
 </head>
 <body>
 
-<script
-    id="api-reference"
-@foreach($htmlAttributes as $attribute => $value)
-    {{-- Attributes specified first override later ones --}}
-    {!! $attribute !!}="{!! $value !!}"
-@endforeach
-    data-url="{!! $metadata['openapi_spec_url'] !!}">
-</script>
+<div id="app"></div>
+
 <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+<script>
+    Scalar.createApiReference('#app', {!! $scalarConfig !!})
+</script>
 </body>
 </html>

--- a/src/Writing/ExternalHtmlWriter.php
+++ b/src/Writing/ExternalHtmlWriter.php
@@ -12,11 +12,17 @@ class ExternalHtmlWriter extends HtmlWriter
     public function generate(array $groupedEndpoints, string $sourceFolder, string $destinationFolder)
     {
         $template = $this->config->get('theme');
+        $metadata = $this->getMetadata();
+
+        $scalarConfig = $this->config->get('external.scalar_config', []);
+        $scalarConfig['url'] = $metadata['openapi_spec_url'];
+
         $output = View::make("scribe::external.{$template}", [
-            'metadata' => $this->getMetadata(),
+            'metadata' => $metadata,
             'baseUrl' => $this->baseUrl,
             'tryItOut' => $this->config->get('try_it_out'),
             'htmlAttributes' => $this->config->get('external.html_attributes', []),
+            'scalarConfig' => \json_encode($scalarConfig),
         ])->render();
 
         if (! is_dir($destinationFolder)) {

--- a/src/Writing/Writer.php
+++ b/src/Writing/Writer.php
@@ -251,6 +251,8 @@ class Writer
         $contents = str_replace('url="../docs/openapi.yaml"', 'url="{{ route("'.$this->paths->outputPath('openapi', '.').'") }}"', $contents);
         // With Elements theme, we'd have <elements-api apiDescriptionUrl="../docs/openapi.yaml"
         $contents = str_replace('Url="../docs/openapi.yaml"', 'Url="{{ route("'.$this->paths->outputPath('openapi', '.').'") }}"', $contents);
+        // Scribe JS API
+        $contents = str_replace('..\/docs\/openapi.yaml', '{{ route("'.$this->paths->outputPath('openapi', '.').'") }}', $contents);
 
         file_put_contents("{$this->laravelTypeOutputPath}/index.blade.php", $contents);
     }


### PR DESCRIPTION
Migrates away from the old way of using Scalar, to the only way that is documented now.

This way allows for configuration to be passed in to Scalar too.
