### PR TITLE
Replace `mpociot/reflection-docblock` with `barryvdh/reflection-docblock`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,7 +95,7 @@ Scribe uses a strategy pattern for extraction:
 
 ### Key Dependencies
 - `nikic/php-parser` for parsing PHP code
-- `mpociot/reflection-docblock` for DocBlock parsing
+- `barryvdh/reflection-docblock` for DocBlock parsing
 - `fakerphp/faker` for generating examples
 - `symfony/yaml` and `symfony/var-exporter` for data export
 

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "php": ">=8.1",
         "ext-fileinfo": "*",
         "ext-pdo": "*",
+        "barryvdh/reflection-docblock": "^2.4",
         "fakerphp/faker": "^1.23.1",
         "laravel/framework": "^9.21 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "league/flysystem": "^3.0",
-        "mpociot/reflection-docblock": "^1.0.1",
         "nikic/php-parser": "^5.0",
         "nunomaduro/collision": "^6.0 || ^7.0 || ^8.0",
         "parsedown/parsedown": "^1.7",
@@ -58,7 +58,8 @@
             "Knuckles\\Scribe\\": "src/"
         },
         "files": [
-            "src/Config/helpers.php"
+            "src/Config/helpers.php",
+            "src/aliases.php"
         ]
     },
     "autoload-dev": {

--- a/src/Extracting/ParamHelpers.php
+++ b/src/Extracting/ParamHelpers.php
@@ -5,7 +5,6 @@ namespace Knuckles\Scribe\Extracting;
 use Faker\Factory;
 use Faker\Generator;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait ParamHelpers

--- a/src/Extracting/RouteDocBlocker.php
+++ b/src/Extracting/RouteDocBlocker.php
@@ -2,10 +2,10 @@
 
 namespace Knuckles\Scribe\Extracting;
 
+use Barryvdh\Reflection\DocBlock;
 use Illuminate\Routing\Route;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
 use Knuckles\Scribe\Tools\Utils as u;
-use Mpociot\Reflection\DocBlock;
 
 /**
  * Class RouteDocBlocker

--- a/src/Extracting/Shared/ApiResourceResponseTools.php
+++ b/src/Extracting/Shared/ApiResourceResponseTools.php
@@ -2,6 +2,8 @@
 
 namespace Knuckles\Scribe\Extracting\Shared;
 
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -13,8 +15,6 @@ use Illuminate\Support\Arr;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Tools\ErrorHandlingUtils as e;
 use Knuckles\Scribe\Tools\Utils;
-use Mpociot\Reflection\DocBlock;
-use Mpociot\Reflection\DocBlock\Tag;
 
 class ApiResourceResponseTools
 {

--- a/src/Extracting/Strategies/Headers/GetFromHeaderTag.php
+++ b/src/Extracting/Strategies/Headers/GetFromHeaderTag.php
@@ -2,10 +2,10 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies\Headers;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Knuckles\Scribe\Extracting\ParamHelpers;
 use Knuckles\Scribe\Extracting\Strategies\TagStrategyWithFormRequestFallback;
 use Knuckles\Scribe\Tools\Utils;
-use Mpociot\Reflection\DocBlock\Tag;
 
 class GetFromHeaderTag extends TagStrategyWithFormRequestFallback
 {

--- a/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
+++ b/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php
@@ -2,10 +2,10 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies\Metadata;
 
+use Barryvdh\Reflection\DocBlock;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Extracting\RouteDocBlocker;
 use Knuckles\Scribe\Extracting\Strategies\Strategy;
-use Mpociot\Reflection\DocBlock;
 
 class GetFromDocBlocks extends Strategy
 {

--- a/src/Extracting/Strategies/ResponseFields/GetFromResponseFieldTag.php
+++ b/src/Extracting/Strategies/ResponseFields/GetFromResponseFieldTag.php
@@ -2,12 +2,12 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies\ResponseFields;
 
+use Barryvdh\Reflection\DocBlock;
 use Knuckles\Scribe\Extracting\Shared\ResponseFieldTools;
 use Knuckles\Scribe\Extracting\Strategies\GetFieldsFromTagStrategy;
 use Knuckles\Scribe\Extracting\Strategies\Responses\UseApiResourceTags;
 use Knuckles\Scribe\Tools\AnnotationParser as a;
 use Knuckles\Scribe\Tools\Utils as u;
-use Mpociot\Reflection\DocBlock;
 
 class GetFromResponseFieldTag extends GetFieldsFromTagStrategy
 {

--- a/src/Extracting/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Extracting/Strategies/Responses/UseApiResourceTags.php
@@ -2,6 +2,8 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies\Responses;
 
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Support\Arr;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Extracting\DatabaseTransactionHelpers;
@@ -12,8 +14,6 @@ use Knuckles\Scribe\Extracting\Strategies\Strategy;
 use Knuckles\Scribe\Tools\AnnotationParser as a;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
 use Knuckles\Scribe\Tools\Utils;
-use Mpociot\Reflection\DocBlock;
-use Mpociot\Reflection\DocBlock\Tag;
 
 /**
  * Parse an Eloquent API resource response from the docblock ( @apiResource || @apiResourcecollection ).

--- a/src/Extracting/Strategies/Responses/UseResponseFileTag.php
+++ b/src/Extracting/Strategies/Responses/UseResponseFileTag.php
@@ -2,13 +2,13 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies\Responses;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Extracting\RouteDocBlocker;
 use Knuckles\Scribe\Extracting\Shared\ResponseFileTools;
 use Knuckles\Scribe\Extracting\Strategies\Strategy;
 use Knuckles\Scribe\Tools\AnnotationParser as a;
 use Knuckles\Scribe\Tools\Utils;
-use Mpociot\Reflection\DocBlock\Tag;
 
 /**
  * Get a response from a file path in the docblock ( @responseFile ).

--- a/src/Extracting/Strategies/Responses/UseResponseTag.php
+++ b/src/Extracting/Strategies/Responses/UseResponseTag.php
@@ -2,12 +2,12 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies\Responses;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Extracting\RouteDocBlocker;
 use Knuckles\Scribe\Extracting\Strategies\Strategy;
 use Knuckles\Scribe\Tools\AnnotationParser as a;
 use Knuckles\Scribe\Tools\Utils;
-use Mpociot\Reflection\DocBlock\Tag;
 
 /**
  * Get a response from the docblock ( @response ).

--- a/src/Extracting/Strategies/Responses/UseTransformerTags.php
+++ b/src/Extracting/Strategies/Responses/UseTransformerTags.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies\Responses;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Support\Arr;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Extracting\DatabaseTransactionHelpers;
@@ -11,7 +12,6 @@ use Knuckles\Scribe\Extracting\Shared\TransformerResponseTools;
 use Knuckles\Scribe\Extracting\Strategies\Strategy;
 use Knuckles\Scribe\Tools\AnnotationParser as a;
 use Knuckles\Scribe\Tools\Utils;
-use Mpociot\Reflection\DocBlock\Tag;
 
 /**
  * Parse a transformer response from the docblock ( @transformer || @transformercollection ).

--- a/src/Extracting/Strategies/TagStrategyWithFormRequestFallback.php
+++ b/src/Extracting/Strategies/TagStrategyWithFormRequestFallback.php
@@ -2,12 +2,12 @@
 
 namespace Knuckles\Scribe\Extracting\Strategies;
 
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Routing\Route;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Scribe\Extracting\FindsFormRequestForMethod;
 use Knuckles\Scribe\Extracting\RouteDocBlocker;
-use Mpociot\Reflection\DocBlock;
-use Mpociot\Reflection\DocBlock\Tag;
 
 abstract class TagStrategyWithFormRequestFallback extends Strategy
 {

--- a/src/GroupedEndpoints/GroupedEndpointsFromApp.php
+++ b/src/GroupedEndpoints/GroupedEndpointsFromApp.php
@@ -2,6 +2,8 @@
 
 namespace Knuckles\Scribe\GroupedEndpoints;
 
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -20,8 +22,6 @@ use Knuckles\Scribe\Tools\ErrorHandlingUtils as e;
 use Knuckles\Scribe\Tools\PathConfig;
 use Knuckles\Scribe\Tools\Utils;
 use Knuckles\Scribe\Tools\Utils as u;
-use Mpociot\Reflection\DocBlock;
-use Mpociot\Reflection\DocBlock\Tag;
 use Symfony\Component\Yaml\Yaml;
 
 class GroupedEndpointsFromApp implements GroupedEndpointsContract

--- a/src/Tools/Utils.php
+++ b/src/Tools/Utils.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe\Tools;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Closure;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -19,7 +20,6 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\StorageAttributes;
-use Mpociot\Reflection\DocBlock\Tag;
 use ReflectionFunction;
 
 class Utils

--- a/src/aliases.php
+++ b/src/aliases.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Backwards-compatibility aliases for the DocBlock classes.
+ *
+ * Scribe used to parse docblocks with mpociot/reflection-docblock, and its strategy API exposes
+ * that package's classes — UseTransformerTags::getTransformerResponseFromTag() takes a Tag,
+ * RouteDocBlocker::getDocBlocksFromRoute() returns DocBlocks, and so on. Custom strategies out
+ * there therefore type-hint Mpociot\Reflection\DocBlock and Mpociot\Reflection\DocBlock\Tag.
+ *
+ * That package has been unmaintained since 2016
+ *
+ * They are deprecated and will be removed in the next major version: type-hint
+ * Barryvdh\Reflection\DocBlock and Barryvdh\Reflection\DocBlock\Tag instead.
+ *
+ * This is registered as an autoloader rather than aliasing eagerly so that we never shadow the
+ * real classes: if mpociot/reflection-docblock is still installed as some other package's
+ * dependency, Composer's autoloader resolves those names first and this one is never reached.
+ */
+
+spl_autoload_register(function (string $class): void {
+    static $aliases = [
+        'Mpociot\Reflection\DocBlock' => Barryvdh\Reflection\DocBlock::class,
+        'Mpociot\Reflection\DocBlock\Context' => Barryvdh\Reflection\DocBlock\Context::class,
+        'Mpociot\Reflection\DocBlock\Description' => Barryvdh\Reflection\DocBlock\Description::class,
+        'Mpociot\Reflection\DocBlock\Location' => Barryvdh\Reflection\DocBlock\Location::class,
+        'Mpociot\Reflection\DocBlock\Tag' => Barryvdh\Reflection\DocBlock\Tag::class,
+    ];
+
+    if (isset($aliases[$class])) {
+        class_alias($aliases[$class], $class);
+    }
+});

--- a/tests/Strategies/BodyParameters/GetFromBodyParamTagTest.php
+++ b/tests/Strategies/BodyParameters/GetFromBodyParamTagTest.php
@@ -2,12 +2,12 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\BodyParameters;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Routing\Route;
 use Knuckles\Scribe\Extracting\Strategies\BodyParameters\GetFromBodyParamTag;
 use Knuckles\Scribe\Tests\ArraySubsetAsserts;
 use Knuckles\Scribe\Tests\Fixtures\TestController;
 use Knuckles\Scribe\Tools\DocumentationConfig;
-use Mpociot\Reflection\DocBlock\Tag;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Strategies/Headers/GetFromHeaderTagTest.php
+++ b/tests/Strategies/Headers/GetFromHeaderTagTest.php
@@ -2,10 +2,10 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\Headers;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Knuckles\Scribe\Extracting\Strategies\Headers\GetFromHeaderTag;
 use Knuckles\Scribe\Tests\ArraySubsetAsserts;
 use Knuckles\Scribe\Tools\DocumentationConfig;
-use Mpociot\Reflection\DocBlock\Tag;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Strategies/Metadata/GetFromDocBlocksTest.php
+++ b/tests/Strategies/Metadata/GetFromDocBlocksTest.php
@@ -2,10 +2,10 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\Metadata;
 
+use Barryvdh\Reflection\DocBlock;
 use Knuckles\Scribe\Extracting\Strategies\Metadata\GetFromDocBlocks;
 use Knuckles\Scribe\Tests\ArraySubsetAsserts;
 use Knuckles\Scribe\Tools\DocumentationConfig;
-use Mpociot\Reflection\DocBlock;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Strategies/QueryParameters/GetFromQueryParamTagTest.php
+++ b/tests/Strategies/QueryParameters/GetFromQueryParamTagTest.php
@@ -2,12 +2,12 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\QueryParameters;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Routing\Route;
 use Knuckles\Scribe\Extracting\Strategies\QueryParameters\GetFromQueryParamTag;
 use Knuckles\Scribe\Tests\ArraySubsetAsserts;
 use Knuckles\Scribe\Tests\Fixtures\TestController;
 use Knuckles\Scribe\Tools\DocumentationConfig;
-use Mpociot\Reflection\DocBlock\Tag;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Strategies/ResponseFields/GetFromResponseFieldTagTest.php
+++ b/tests/Strategies/ResponseFields/GetFromResponseFieldTagTest.php
@@ -2,12 +2,12 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\ResponseFields;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
 use Knuckles\Camel\Extraction\ResponseCollection;
 use Knuckles\Scribe\Extracting\Strategies\ResponseFields\GetFromResponseFieldTag;
 use Knuckles\Scribe\Tests\ArraySubsetAsserts;
 use Knuckles\Scribe\Tools\DocumentationConfig;
-use Mpociot\Reflection\DocBlock\Tag;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Strategies/Responses/UseApiResourceTagsTest.php
+++ b/tests/Strategies/Responses/UseApiResourceTagsTest.php
@@ -2,6 +2,7 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\Responses;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Database\Eloquent\Factory;
 use Illuminate\Database\Eloquent\LegacyFactoryServiceProvider;
 use Illuminate\Database\Schema\Blueprint;
@@ -15,7 +16,6 @@ use Knuckles\Scribe\Tests\Fixtures\TestPet;
 use Knuckles\Scribe\Tests\Fixtures\TestUser;
 use Knuckles\Scribe\Tools\DocumentationConfig;
 use Knuckles\Scribe\Tools\Utils;
-use Mpociot\Reflection\DocBlock\Tag;
 
 /**
  * @internal

--- a/tests/Strategies/Responses/UseResponseFileTagTest.php
+++ b/tests/Strategies/Responses/UseResponseFileTagTest.php
@@ -2,10 +2,10 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\Responses;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Knuckles\Scribe\Extracting\Strategies\Responses\UseResponseFileTag;
 use Knuckles\Scribe\Tests\ArraySubsetAsserts;
 use Knuckles\Scribe\Tools\DocumentationConfig;
-use Mpociot\Reflection\DocBlock\Tag;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Strategies/Responses/UseResponseTagTest.php
+++ b/tests/Strategies/Responses/UseResponseTagTest.php
@@ -2,10 +2,10 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\Responses;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Knuckles\Scribe\Extracting\Strategies\Responses\UseResponseTag;
 use Knuckles\Scribe\Tests\ArraySubsetAsserts;
 use Knuckles\Scribe\Tools\DocumentationConfig;
-use Mpociot\Reflection\DocBlock\Tag;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Strategies/Responses/UseTransformerTagsTest.php
+++ b/tests/Strategies/Responses/UseTransformerTagsTest.php
@@ -2,12 +2,12 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\Responses;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Database\Eloquent\Factory;
 use Knuckles\Scribe\Extracting\Strategies\Responses\UseTransformerTags;
 use Knuckles\Scribe\Tests\BaseLaravelTest;
 use Knuckles\Scribe\Tests\Fixtures\TestUser;
 use Knuckles\Scribe\Tools\DocumentationConfig;
-use Mpociot\Reflection\DocBlock\Tag;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**

--- a/tests/Strategies/UrlParameters/GetFromUrlParamTagTest.php
+++ b/tests/Strategies/UrlParameters/GetFromUrlParamTagTest.php
@@ -2,10 +2,10 @@
 
 namespace Knuckles\Scribe\Tests\Strategies\UrlParameters;
 
+use Barryvdh\Reflection\DocBlock\Tag;
 use Knuckles\Scribe\Extracting\Strategies\UrlParameters\GetFromUrlParamTag;
 use Knuckles\Scribe\Tests\ArraySubsetAsserts;
 use Knuckles\Scribe\Tools\DocumentationConfig;
-use Mpociot\Reflection\DocBlock\Tag;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Unit/DocBlockAliasesTest.php
+++ b/tests/Unit/DocBlockAliasesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Unit;
+
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Tag;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Scribe's strategy API used to expose mpociot/reflection-docblock's classes, so custom strategies
+ * type-hint them. src/aliases.php keeps those names working now that we're on
+ * barryvdh/reflection-docblock. Deprecated — to be removed in the next major version.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+class DocBlockAliasesTest extends TestCase
+{
+    /**
+     * @dataProvider legacyClassNames
+     */
+    #[DataProvider('legacyClassNames')]
+    public function test_legacy_docblock_class_names_still_resolve(string $legacy, string $current)
+    {
+        $this->assertTrue(class_exists($legacy));
+        $this->assertSame($current, (new \ReflectionClass($legacy))->getName());
+    }
+
+    public static function legacyClassNames(): array
+    {
+        return [
+            ['Mpociot\Reflection\DocBlock', DocBlock::class],
+            ['Mpociot\Reflection\DocBlock\Context', DocBlock\Context::class],
+            ['Mpociot\Reflection\DocBlock\Description', DocBlock\Description::class],
+            ['Mpociot\Reflection\DocBlock\Location', DocBlock\Location::class],
+            ['Mpociot\Reflection\DocBlock\Tag', Tag::class],
+        ];
+    }
+
+    public function test_objects_from_scribe_satisfy_legacy_type_hints()
+    {
+        $docBlock = new DocBlock("/**\n * Do a thing.\n *\n * @bodyParam name string required\n */");
+
+        $this->assertInstanceOf('Mpociot\Reflection\DocBlock', $docBlock);
+        $this->assertInstanceOf('Mpociot\Reflection\DocBlock\Tag', $docBlock->getTags()[0]);
+    }
+}


### PR DESCRIPTION
#### Summary

Scribe's docblock parser, `mpociot/reflection-docblock`, emits `Implicitly marking parameter $x as nullable is deprecated` on PHP 8.4+. This PR swaps it for `barryvdh/reflection-docblock`, which is the same phpDocumentor 2.x codebase, actively maintained, and free of those deprecations.

The old class names are kept working through aliases, so **custom strategies do not break** — see the section below.

This is the same move as #1049 (`erusev/parsedown` → `parsedown/parsedown`), for the same reason.

#### Motivation

The test suite reports two deprecations on PHP 8.4/8.5:

```
Mpociot\Reflection\DocBlock\Tag::createInstance(): Implicitly marking parameter
$docblock as nullable is deprecated, the explicit nullable type must be used instead
```

PHPUnit attributes them to `UseResponseFileTagTest` only because that is where the package's classes happen to be compiled first.

This is a PHP 8.4 issue ([Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)).

In PHP 9 implicitly nullable parameters become a **compile-time fatal error**, at which point the package stops loading and Scribe stops working entirely.

#### Why `barryvdh/reflection-docblock`

It is the same lineage — another fork of phpDocumentor's ReflectionDocBlock 2.x — but a live one, and it is what `barryvdh/laravel-ide-helper` uses (which requires `^2.4`, so the constraint here matches).

Diffing the two sources with the namespace normalized, the changes are purely additive plus the fixes we need:

- `?DocBlock` / `?Location` / `?Context` everywhere — the deprecations this PR is about
- `preg_split($pattern, $subject, -1, ...)` instead of `null` for the limit argument — a separate PHP 8.1 deprecation
- new `ContextFactory`, `TemplateTag`, `SuppressWarningsTag`, generics support, `DocBlock::deleteTag()`

Explicit nullable types landed in v2.2.0, so `--prefer-lowest` builds are clean too.

---

### ⚠️ Backwards compatibility ⚠️

Scribe's strategy API exposes these classes to userland. Custom strategies in the wild type-hint them:

```php
UseApiResourceTags::getApiResourceResponseFromTags(Tag $apiResourceTag, ...)
UseTransformerTags::getTransformerResponseFromTag(Tag $transformerTag, ...)
GetFromDocBlocks::getMetadataFromDocBlock(DocBlock $methodDocBlock, DocBlock $classDocBlock)
RouteDocBlocker::getDocBlocksFromRoute()   // returns DocBlock instances
```

A bare namespace change would therefore break every custom strategy that does `use Mpociot\Reflection\DocBlock\Tag;`, in a minor release. To avoid that, **`src/aliases.php` registers an autoloader that aliases the five old class names to the new ones**:

```php
spl_autoload_register(function (string $class): void {
    static $aliases = [
        'Mpociot\Reflection\DocBlock'              => Barryvdh\Reflection\DocBlock::class,
        'Mpociot\Reflection\DocBlock\Context'      => Barryvdh\Reflection\DocBlock\Context::class,
        'Mpociot\Reflection\DocBlock\Description'  => Barryvdh\Reflection\DocBlock\Description::class,
        'Mpociot\Reflection\DocBlock\Location'     => Barryvdh\Reflection\DocBlock\Location::class,
        'Mpociot\Reflection\DocBlock\Tag'          => Barryvdh\Reflection\DocBlock\Tag::class,
    ];

    if (isset($aliases[$class])) {
        class_alias($aliases[$class], $class);
    }
});
```

Existing type hints, `instanceof` checks and subclasses keep working unchanged — `tests/Unit/DocBlockAliasesTest.php` covers all five names plus the type-hint case.

It is deliberately an autoloader rather than an eager `class_alias()` call: if `mpociot/reflection-docblock` is still installed as some other package's dependency, Composer's own autoloader resolves those names first and this fallback is never reached, so we never shadow the real classes.

### 📌 Important Notice

**This shim is a compatibility measure for the 5.x line only. I'd recommend dropping `src/aliases.php` (and its entry in the `files` autoload section) in 6.0**, leaving `Barryvdh\Reflection\DocBlock{,\Tag}` as the only supported type hints.

**📝 This must be documented in the 6.0 upgrade guide** — users will need to update their imports.

---

#### Changes

- **`composer.json`** — replaced `mpociot/reflection-docblock: ^1.0.1` with `barryvdh/reflection-docblock: ^2.4`; registered `src/aliases.php` in the `files` autoload section.
- **`src/aliases.php`** (new) — deprecated BC aliases for the five `Mpociot\Reflection\*` class names, registered as a fallback autoloader.
- **`src/`** (12 files) — `Mpociot\Reflection\…` → `Barryvdh\Reflection\…` imports in `RouteDocBlocker`, `ApiResourceResponseTools`, `GroupedEndpointsFromApp`, `Tools\Utils`, `TagStrategyWithFormRequestFallback` and the `GetFromDocBlocks` / `GetFromHeaderTag` / `GetFromResponseFieldTag` / `UseResponseTag` / `UseResponseFileTag` / `UseApiResourceTags` / `UseTransformerTags` strategies. Import-only changes; no logic touched.
- **`tests/`** (10 files) — the same import change.
- **`tests/Unit/DocBlockAliasesTest.php`** (new) — asserts the legacy class names still resolve to the new classes and that objects Scribe produces still satisfy the old type hints.
- **`.github/copilot-instructions.md`** — updated the dependency reference.


