### PR TITLE
Add support for Laravel's JSON:API resources

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -211,6 +211,15 @@ return [
         'models_source' => ['factoryCreate', 'factoryMake', 'databaseFirst'],
     ],
 
+    // Settings for Laravel's JSON:API resources (Laravel 12.45+). Ignored on older versions.
+    'json_api' => [
+        // For endpoints returning a JSON:API resource, Scribe documents the `include` and `fields[<type>]`
+        // query parameters, based on the relationships and attributes the resource declares.
+        // Anything you documented yourself (say, an `@queryParam include`) always wins; set this to
+        // false if you'd rather not have these parameters in your docs at all.
+        'document_query_parameters' => true,
+    ],
+
     // The strategies Scribe will use to extract information about your routes at each stage.
     // Use configureStrategy() to specify settings for a strategy in the list.
     // Use removeStrategies() to remove an included strategy.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,11 @@ parameters:
         - identifier: return.type
           path: camel\BaseDTOCollection.php
         - identifier: argument.templateType
+        # Laravel's JSON:API resources only exist from 12.45/13.x, but we support 9.x upwards.
+        # Every use of them is guarded by JsonApiResourceTools::isSupported().
+        - identifier: class.notFound
+          path: src\Extracting\Shared\JsonApiResourceTools.php
+          reportUnmatched: false
         - '#Call to an undefined method ReflectionType::getName\(\).#'
         - '#Call to an undefined method Illuminate\\Contracts\\Foundation\\Application::forgetInstance\(\)#'
         - '#Access to an undefined property Illuminate\\Support\\HigherOrderCollectionProxy#'

--- a/src/Extracting/Shared/ApiResourceResponseTools.php
+++ b/src/Extracting/Shared/ApiResourceResponseTools.php
@@ -11,6 +11,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
+use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
 use Knuckles\Scribe\Tools\ErrorHandlingUtils as e;
 use Knuckles\Scribe\Tools\Utils;
 use Mpociot\Reflection\DocBlock;
@@ -25,36 +26,127 @@ class ApiResourceResponseTools
         ExtractedEndpointData $endpointData,
         array $pagination,
         array $additionalData,
+        array $with = [],
+        bool $documentJsonApiQueryParameters = false,
     ) {
-        $resource = static::getApiResourceOrCollectionInstance(
+        $response = static::fetchResponse(
+            $apiResourceClass,
+            $isCollection,
+            $modelInstantiator,
+            $endpointData,
+            $pagination,
+            $additionalData,
+            $with,
+            $documentJsonApiQueryParameters,
+        );
+
+        return $response?->getContent();
+    }
+
+    /**
+     * Same as `fetch()`, but hands you the whole response, so you can read its headers.
+     * Returns null if a JSON:API resource couldn't be rendered (a warning is printed in that case).
+     *
+     * @param  string[]  $with  The relations the example model was loaded with. Only used for JSON:API resources.
+     */
+    public static function fetchResponse(
+        string $apiResourceClass,
+        bool $isCollection,
+        ?callable $modelInstantiator,
+        ExtractedEndpointData $endpointData,
+        array $pagination,
+        array $additionalData,
+        array $with = [],
+        bool $documentJsonApiQueryParameters = false,
+    ): ?JsonResponse {
+        $instantiate = fn () => static::getApiResourceOrCollectionInstance(
             $apiResourceClass,
             $isCollection,
             $modelInstantiator,
             $pagination,
             $additionalData
         );
-        $response = static::callApiResourceAndGetResponse($resource, $endpointData);
 
-        return $response->getContent();
+        if (! JsonApiResourceTools::isJsonApiResourceClass($apiResourceClass)) {
+            return static::callApiResourceAndGetResponse($instantiate(), $endpointData);
+        }
+
+        // JSON:API only renders the relationships listed in the `include` query parameter.
+        $queryParameters = JsonApiResourceTools::queryParametersForRequest($with);
+
+        // A JSON:API resource needs an id and a type, so it blows up if we couldn't find a model for it.
+        // It does so with a TypeError, which isn't an Exception, so it would escape the `catch` in
+        // GroupedEndpointsFromApp and take down the whole generation, not just this endpoint.
+        try {
+            $resource = $instantiate();
+            $response = static::callApiResourceAndGetResponse($resource, $endpointData, $queryParameters);
+        } catch (\Throwable $e) {
+            c::warn(
+                "Couldn't render your JSON:API resource {$apiResourceClass}. "
+                .'JSON:API responses need an id and a type, so make sure Scribe can find an example model for the resource '
+                .'(via `@apiResourceModel`, the `model:` parameter, or an `@mixin` annotation in the resource\'s docblock).'
+            );
+            e::dumpExceptionIfVerbose($e);
+
+            return null;
+        }
+
+        JsonApiResourceTools::documentRequestHeaders($resource, $endpointData);
+
+        if ($documentJsonApiQueryParameters) {
+            JsonApiResourceTools::documentQueryParameters(
+                $resource, $endpointData, static::createRequest($endpointData, $queryParameters), $with
+            );
+        }
+
+        return $response;
     }
 
-    public static function callApiResourceAndGetResponse(JsonResource $resource, ExtractedEndpointData $endpointData): JsonResponse
-    {
-        $uri = Utils::getUrlWithBoundParameters($endpointData->route->uri(), $endpointData->cleanUrlParameters);
-        $method = $endpointData->route->methods()[0];
-        $request = Request::create($uri, $method);
-        $request->headers->add(['Accept' => 'application/json']);
-        // Set the route properly, so it works for users who have code that checks for the route.
-        $request->setRouteResolver(fn () => $endpointData->route);
+    /**
+     * @param  array<string, string>  $queryParameters
+     */
+    public static function callApiResourceAndGetResponse(
+        JsonResource $resource,
+        ExtractedEndpointData $endpointData,
+        array $queryParameters = [],
+    ): JsonResponse {
+        $request = static::createRequest($endpointData, $queryParameters);
+        $request->headers->add([
+            'Accept' => JsonApiResourceTools::isJsonApiResource($resource)
+                ? JsonApiResourceTools::CONTENT_TYPE
+                : 'application/json',
+        ]);
 
         $previousBoundRequest = app('request');
         app()->bind('request', fn () => $request);
 
-        $response = $resource->toResponse($request);
+        try {
+            return $resource->toResponse($request);
+        } finally {
+            // Rendering a resource can throw (a JSON:API one with no model does), and leaving our
+            // synthetic request bound would then hand it to every endpoint extracted after this one.
+            app()->bind('request', fn () => $previousBoundRequest);
+        }
+    }
 
-        app()->bind('request', fn () => $previousBoundRequest);
+    /**
+     * Build the synthetic request we render the resource against.
+     *
+     * @param  array<string, string>  $queryParameters
+     */
+    public static function createRequest(ExtractedEndpointData $endpointData, array $queryParameters = []): Request
+    {
+        $uri = Utils::getUrlWithBoundParameters($endpointData->route->uri(), $endpointData->cleanUrlParameters);
+        if ($queryParameters) {
+            // Passing these to `Request::create()` as parameters would put them in the body for non-GET routes.
+            $uri .= (str_contains($uri, '?') ? '&' : '?').http_build_query($queryParameters);
+        }
 
-        return $response;
+        $request = Request::create($uri, $endpointData->route->methods()[0]);
+        // Set the route properly, so it works for users who have code that checks for the route.
+        $request->setRouteResolver(fn () => $endpointData->route);
+
+        return $request;
     }
 
     public static function getApiResourceOrCollectionInstance(

--- a/src/Extracting/Shared/JsonApiResourceTools.php
+++ b/src/Extracting/Shared/JsonApiResourceTools.php
@@ -1,0 +1,395 @@
+<?php
+
+namespace Knuckles\Scribe\Extracting\Shared;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\JsonApi\AnonymousResourceCollection as JsonApiResourceCollection;
+use Illuminate\Http\Resources\JsonApi\JsonApiRequest;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+use Knuckles\Camel\Extraction\ExtractedEndpointData;
+use Knuckles\Camel\Extraction\Parameter;
+use Knuckles\Scribe\Extracting\Extractor;
+use Knuckles\Scribe\Tools\DocumentationConfig;
+
+/**
+ * Helpers for Laravel's JSON:API resources (`Illuminate\Http\Resources\JsonApi`), added in 12.45.
+ */
+class JsonApiResourceTools
+{
+    public const CONTENT_TYPE = 'application/vnd.api+json';
+
+    public static function isSupported(): bool
+    {
+        return class_exists(JsonApiResource::class);
+    }
+
+    public static function shouldDocumentQueryParameters(DocumentationConfig $config): bool
+    {
+        return (bool) $config->get('json_api.document_query_parameters', true);
+    }
+
+    public static function isJsonApiResourceClass(string $apiResourceClass): bool
+    {
+        return static::isSupported() && is_a($apiResourceClass, JsonApiResource::class, true);
+    }
+
+    public static function isJsonApiResource(JsonResource $resource): bool
+    {
+        return static::isSupported()
+            && ($resource instanceof JsonApiResource || $resource instanceof JsonApiResourceCollection);
+    }
+
+    /**
+     * A JSON:API resource only renders the relationships asked for in the `include` query parameter,
+     * so we ask for the same relations the example model was loaded with (`with=` / `with:`).
+     *
+     * @param  string[]  $with
+     * @return array<string, string>
+     */
+    public static function queryParametersForRequest(array $with): array
+    {
+        $with = array_values(array_filter(array_map('mb_trim', $with)));
+
+        return $with ? ['include' => implode(',', $with)] : [];
+    }
+
+    /**
+     * The response headers worth documenting for a JSON:API response, ie its content type.
+     *
+     * @return array<string, string>
+     */
+    public static function responseHeaders(string $apiResourceClass, JsonResponse $response): array
+    {
+        if (! static::isJsonApiResourceClass($apiResourceClass)) {
+            return [];
+        }
+
+        return array_filter(['content-type' => $response->headers->get('content-type')]);
+    }
+
+    /**
+     * JSON:API clients are expected to send `Accept: application/vnd.api+json`, so that's what we document.
+     *
+     * A value the user picked themselves wins, with one exception: the generic `application/json`,
+     * which is what the package's own config ships with (the StaticData headers strategy), so on a
+     * JSON:API endpoint it's a leftover default rather than a choice.
+     */
+    public static function documentRequestHeaders(JsonResource $resource, ExtractedEndpointData $endpointData): void
+    {
+        if (! static::isJsonApiResource($resource)) {
+            return;
+        }
+
+        $current = $endpointData->headers['Accept'] ?? null;
+
+        if ($current === null || mb_strtolower(mb_trim($current)) === 'application/json') {
+            $endpointData->headers['Accept'] = static::CONTENT_TYPE;
+        }
+    }
+
+    /**
+     * Document the `include` and `fields[<type>]` query parameters a JSON:API resource responds to.
+     *
+     * @param  string[]  $with  The relations the example model was loaded with; used as the example value.
+     */
+    public static function documentQueryParameters(
+        JsonResource $resource,
+        ExtractedEndpointData $endpointData,
+        Request $request,
+        array $with = [],
+    ): void {
+        if (! static::isJsonApiResource($resource)) {
+            return;
+        }
+
+        $added = false;
+
+        if ($relationships = static::declaredRelationships($resource, $request)) {
+            $added = static::addParameter($endpointData, 'include', new Parameter([
+                'name' => 'include',
+                'description' => sprintf(
+                    'Comma-separated list of relationships to include in the response. Available relationships: %s. '
+                    .'Nested relationships are supported, using dot notation (for instance, `author.company`).',
+                    static::asCodeList($relationships)
+                ),
+                // Not `enumValues`: that would render as "Must be one of", and turn into an OpenAPI `enum`,
+                // which would declare the perfectly valid `include=a,b` invalid.
+                'example' => $with ? implode(',', $with) : null,
+                'exampleWasSpecified' => (bool) $with,
+            ]));
+        }
+
+        foreach (static::sparseFieldsets($resource, $request, $with) as $type => $attributes) {
+            $added = static::addParameter($endpointData, "fields[{$type}]", new Parameter([
+                'name' => "fields[{$type}]",
+                'description' => sprintf(
+                    'Comma-separated list of the attributes to return for `%s` resources. Available attributes: %s.',
+                    $type, static::asCodeList($attributes)
+                ),
+                // No example on purpose: unlike `include`, a sparse fieldset doesn't change the example
+                // response (we document the full attribute list, ie what you get without it), so putting
+                // it in the example request would show a parameter that makes no difference.
+                'example' => null,
+                'exampleWasSpecified' => false,
+            ])) || $added;
+        }
+
+        if ($added) {
+            // So that response calls (which run after this strategy) actually send the parameters.
+            $endpointData->cleanQueryParameters = Extractor::cleanParams($endpointData->queryParameters);
+        }
+    }
+
+    /**
+     * The resource types we can document a sparse fieldset for, mapped to their attribute names:
+     * the resource itself, plus the resources of the relationships the example model was loaded with.
+     *
+     * Related resources are limited to those in `$with` because attribute names have to come from
+     * `toAttributes()`, which reads off the model (`['name' => $this->name]`), so we need a loaded
+     * related model to call it on.
+     *
+     * @param  string[]  $with
+     * @return array<string, string[]>
+     */
+    protected static function sparseFieldsets(JsonResource $resource, Request $request, array $with = []): array
+    {
+        if (! ($element = static::underlyingResource($resource))) {
+            return [];
+        }
+
+        $fieldsets = [];
+
+        if (($type = static::resourceType($resource, $request)) && ($attributes = static::attributeNames($resource, $request))) {
+            $fieldsets[$type] = $attributes;
+        }
+
+        if (! $element->resource instanceof Model) {
+            return $fieldsets;
+        }
+
+        foreach ($with as $relation) {
+            // A nested relation (`with=author.company`) ends up in the response's `included` at
+            // every level, so we walk it segment by segment, documenting each type on the way.
+            $parentResource = $element;
+            $parentModel = $element->resource;
+
+            foreach (explode('.', mb_trim($relation)) as $name) {
+                $related = static::relatedResource($parentResource, $parentModel, $name, $request);
+                if (! $related) {
+                    // Nothing more to walk: the relation wasn't loaded, or its resource class
+                    // isn't statically known (an int key or a Closure in `toRelationships()`).
+                    break;
+                }
+
+                [$relatedResource, $relatedModel, $type, $attributes] = $related;
+
+                if ($type && $attributes && ! isset($fieldsets[$type])) {
+                    $fieldsets[$type] = $attributes;
+                }
+
+                $parentResource = $relatedResource;
+                $parentModel = $relatedModel;
+            }
+        }
+
+        return $fieldsets;
+    }
+
+    /**
+     * Resolve one segment of a relation path into the resource handling it, the model behind it,
+     * and the type and attribute names to document for it.
+     *
+     * @return array{JsonApiResource, Model, ?string, string[]}|null
+     */
+    protected static function relatedResource(
+        JsonApiResource $parentResource,
+        Model $parentModel,
+        string $name,
+        Request $request,
+    ): ?array {
+        $relatedResourceClass = static::declaredRelationshipResources($parentResource, $request)[$name] ?? null;
+
+        if (! $relatedResourceClass || ! $parentModel->relationLoaded($name)) {
+            return null;
+        }
+
+        $related = $parentModel->getRelation($name);
+        $relatedModel = $related instanceof EloquentCollection ? $related->first() : $related;
+        if (! $relatedModel instanceof Model) {
+            return null;
+        }
+
+        try {
+            $relatedResource = new $relatedResourceClass($relatedModel);
+
+            return [
+                $relatedResource,
+                $relatedModel,
+                $relatedResource->resolveResourceType(JsonApiRequest::createFrom($request)),
+                static::namesFromDeclaration($relatedResource->toAttributes($request)),
+            ];
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Names of the relationships the resource declares.
+     *
+     * @return string[]
+     */
+    protected static function declaredRelationships(JsonResource $resource, Request $request): array
+    {
+        if (! ($element = static::underlyingResource($resource))) {
+            return [];
+        }
+
+        try {
+            // Calling the method also covers resources that declare a `$relationships` property,
+            // since the base implementation reads that property for us.
+            return static::namesFromDeclaration($element->toRelationships($request));
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * Names of the attributes the resource declares.
+     *
+     * @return string[]
+     */
+    protected static function attributeNames(JsonResource $resource, Request $request): array
+    {
+        if (! ($element = static::underlyingResource($resource))) {
+            return [];
+        }
+
+        try {
+            return static::namesFromDeclaration($element->toAttributes($request));
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * The JSON:API `type` of the resource.
+     */
+    protected static function resourceType(JsonResource $resource, Request $request): ?string
+    {
+        if (! ($element = static::underlyingResource($resource))) {
+            return null;
+        }
+
+        try {
+            return $element->resolveResourceType(JsonApiRequest::createFrom($request));
+        } catch (\Throwable) {
+            // `resolveResourceType()` throws when it can't figure out a type for the resource.
+            return null;
+        }
+    }
+
+    /**
+     * The relationships the resource declares, mapped to the resource class handling each one.
+     *
+     * @return array<string, class-string>
+     */
+    protected static function declaredRelationshipResources(JsonApiResource $element, Request $request): array
+    {
+        try {
+            $declaration = $element->toRelationships($request);
+        } catch (\Throwable) {
+            return [];
+        }
+
+        $resources = [];
+        foreach (static::declarationToArray($declaration) as $key => $value) {
+            // Only the `['author' => AuthorResource::class]` style names a resource class;
+            // `['tags']` (int key) leaves the framework to derive everything from the model.
+            if (is_string($key) && is_string($value) && static::isJsonApiResourceClass($value)) {
+                $resources[$key] = $value;
+            }
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Relationships and attributes live on the individual resource, not on the collection wrapping it.
+     */
+    protected static function underlyingResource(JsonResource $resource): ?JsonApiResource
+    {
+        if (! static::isSupported()) {
+            return null;
+        }
+
+        if ($resource instanceof JsonApiResource) {
+            return $resource;
+        }
+
+        if ($resource instanceof JsonApiResourceCollection) {
+            $first = $resource->collection->first();
+
+            return $first instanceof JsonApiResource ? $first : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * `toRelationships()` and `toAttributes()` both accept two key styles:
+     * `['author' => AuthorResource::class]` (name in the key) and `['tags']` (name in the value).
+     *
+     * @return string[]
+     */
+    protected static function namesFromDeclaration(mixed $declaration): array
+    {
+        $names = [];
+        foreach (static::declarationToArray($declaration) as $key => $value) {
+            $name = is_int($key) ? $value : $key;
+            if (is_string($name) && $name !== '') {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * `toRelationships()` and `toAttributes()` may hand back an Arrayable or a JsonSerializable
+     * rather than a plain array, the same way the framework's own resolvers accept them.
+     */
+    protected static function declarationToArray(mixed $declaration): array
+    {
+        if ($declaration instanceof Arrayable) {
+            $declaration = $declaration->toArray();
+        } elseif ($declaration instanceof \JsonSerializable) {
+            $declaration = $declaration->jsonSerialize();
+        }
+
+        return is_array($declaration) ? $declaration : [];
+    }
+
+    protected static function addParameter(ExtractedEndpointData $endpointData, string $name, Parameter $parameter): bool
+    {
+        if (isset($endpointData->queryParameters[$name])) {
+            return false;
+        }
+
+        $endpointData->queryParameters[$name] = $parameter;
+
+        return true;
+    }
+
+    /**
+     * @param  string[]  $items
+     */
+    protected static function asCodeList(array $items): string
+    {
+        return implode(', ', array_map(fn ($item) => "`{$item}`", $items));
+    }
+}

--- a/src/Extracting/Strategies/Responses/UseApiResourceTags.php
+++ b/src/Extracting/Strategies/Responses/UseApiResourceTags.php
@@ -8,6 +8,7 @@ use Knuckles\Scribe\Extracting\DatabaseTransactionHelpers;
 use Knuckles\Scribe\Extracting\InstantiatesExampleModels;
 use Knuckles\Scribe\Extracting\RouteDocBlocker;
 use Knuckles\Scribe\Extracting\Shared\ApiResourceResponseTools;
+use Knuckles\Scribe\Extracting\Shared\JsonApiResourceTools;
 use Knuckles\Scribe\Extracting\Strategies\Strategy;
 use Knuckles\Scribe\Tools\AnnotationParser as a;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
@@ -52,21 +53,28 @@ class UseApiResourceTags extends Strategy
         $modelInstantiator = fn () => $this->instantiateExampleModel($modelClass, $factoryStates, $relations);
 
         $this->startDbTransaction();
-        $content = ApiResourceResponseTools::fetch(
+        $response = ApiResourceResponseTools::fetchResponse(
             $apiResourceClass,
             $isCollection,
             $modelInstantiator,
             $endpointData,
             $pagination,
             $additionalData,
+            $relations,
+            JsonApiResourceTools::shouldDocumentQueryParameters($this->config),
         );
         $this->endDbTransaction();
+
+        if (is_null($response)) {
+            return null;
+        }
 
         return [
             [
                 'status' => $statusCode ?: 200,
                 'description' => $description,
-                'content' => $content,
+                'content' => $response->getContent(),
+                'headers' => JsonApiResourceTools::responseHeaders($apiResourceClass, $response),
             ],
         ];
     }

--- a/src/Extracting/Strategies/Responses/UseResponseAttributes.php
+++ b/src/Extracting/Strategies/Responses/UseResponseAttributes.php
@@ -11,6 +11,7 @@ use Knuckles\Scribe\Extracting\DatabaseTransactionHelpers;
 use Knuckles\Scribe\Extracting\InstantiatesExampleModels;
 use Knuckles\Scribe\Extracting\ParamHelpers;
 use Knuckles\Scribe\Extracting\Shared\ApiResourceResponseTools;
+use Knuckles\Scribe\Extracting\Shared\JsonApiResourceTools;
 use Knuckles\Scribe\Extracting\Shared\TransformerResponseTools;
 use Knuckles\Scribe\Extracting\Strategies\PhpAttributeStrategy;
 use Knuckles\Scribe\Tools\ConsoleOutputUtils as c;
@@ -40,12 +41,17 @@ class UseResponseAttributes extends PhpAttributeStrategy
         $responses = [];
         foreach ([...$attributesOnController, ...$attributesOnFormRequest, ...$attributesOnMethod] as $attributeInstance) {
             // @phpstan-ignore-next-line
-            $responses[] = match (true) {
+            $response = match (true) {
                 $attributeInstance instanceof Response => $attributeInstance->toArray(),
                 $attributeInstance instanceof ResponseFromFile => $attributeInstance->toArray(),
                 $attributeInstance instanceof ResponseFromApiResource => $this->getApiResourceResponse($attributeInstance),
                 $attributeInstance instanceof ResponseFromTransformer => $this->getTransformerResponse($attributeInstance),
             };
+
+            // The resource may have failed to render (eg a JSON:API resource with no model).
+            if (! is_null($response)) {
+                $responses[] = $response;
+            }
         }
 
         return $responses;
@@ -76,20 +82,27 @@ class UseResponseAttributes extends PhpAttributeStrategy
         }
 
         $this->startDbTransaction();
-        $content = ApiResourceResponseTools::fetch(
+        $response = ApiResourceResponseTools::fetchResponse(
             $attributeInstance->name,
             $attributeInstance->isCollection(),
             $modelInstantiator,
             $this->endpointData,
             $pagination,
             $attributeInstance->additional,
+            $attributeInstance->with,
+            JsonApiResourceTools::shouldDocumentQueryParameters($this->config),
         );
         $this->endDbTransaction();
+
+        if (is_null($response)) {
+            return null;
+        }
 
         return [
             'status' => $attributeInstance->status,
             'description' => $attributeInstance->description,
-            'content' => $content,
+            'content' => $response->getContent(),
+            'headers' => JsonApiResourceTools::responseHeaders($attributeInstance->name, $response),
         ];
     }
 

--- a/tests/BaseLaravelTest.php
+++ b/tests/BaseLaravelTest.php
@@ -5,6 +5,7 @@ namespace Knuckles\Scribe\Tests;
 use Illuminate\Foundation\Application;
 use Knuckles\Scribe\Config;
 use Knuckles\Scribe\Config\AuthIn;
+use Knuckles\Scribe\Extracting\Shared\JsonApiResourceTools;
 use Knuckles\Scribe\Extracting\Strategies;
 use Knuckles\Scribe\ScribeServiceProvider;
 use Orchestra\Testbench\TestCase;
@@ -106,6 +107,13 @@ class BaseLaravelTest extends TestCase
         return [
             ScribeServiceProvider::class,
         ];
+    }
+
+    protected function skipIfNoJsonApiResources(): void
+    {
+        if (! JsonApiResourceTools::isSupported()) {
+            $this->markTestSkipped('JSON:API resources require Laravel 12.45 or later.');
+        }
     }
 
     protected function setConfig($configValues): void

--- a/tests/Fixtures/TestEmptyJsonApiResource.php
+++ b/tests/Fixtures/TestEmptyJsonApiResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+/**
+ * A JSON:API resource with no model to back it. JSON:API responses need an id, so Scribe
+ * can't render this one — it should warn rather than take the whole generation down.
+ */
+class TestEmptyJsonApiResource extends JsonApiResource
+{
+    public function toAttributes(Request $request): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/TestJsonApiController.php
+++ b/tests/Fixtures/TestJsonApiController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+/**
+ * Only routed from tests that skipped themselves if JSON:API resources are unavailable.
+ * The resource class names here are plain docblock strings, so nothing in this file
+ * autoloads a JSON:API class on versions that don't have them.
+ */
+class TestJsonApiController
+{
+    /**
+     * A JSON:API post.
+     *
+     * @apiResource \Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource
+     *
+     * @apiResourceModel \Knuckles\Scribe\Tests\Fixtures\TestPost with=tags
+     */
+    public function showPost() {}
+
+    /**
+     * @apiResource \Knuckles\Scribe\Tests\Fixtures\TestEmptyJsonApiResource
+     */
+    public function resourceWithoutAModel() {}
+}

--- a/tests/Fixtures/TestOrderJsonApiResource.php
+++ b/tests/Fixtures/TestOrderJsonApiResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+/**
+ * @mixin \Knuckles\Scribe\Tests\Fixtures\TestOrder
+ */
+class TestOrderJsonApiResource extends JsonApiResource
+{
+    public function toType(Request $request): string
+    {
+        return 'orders';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'status_id' => $this->status_id,
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'status' => TestOrderStatusJsonApiResource::class,
+        ];
+    }
+}

--- a/tests/Fixtures/TestOrderOwnerJsonApiResource.php
+++ b/tests/Fixtures/TestOrderOwnerJsonApiResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+/**
+ * @mixin \Knuckles\Scribe\Tests\Fixtures\TestOrderOwner
+ */
+class TestOrderOwnerJsonApiResource extends JsonApiResource
+{
+    public function toType(Request $request): string
+    {
+        return 'order_owners';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'order_id' => $this->order_id,
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'order' => TestOrderJsonApiResource::class,
+        ];
+    }
+}

--- a/tests/Fixtures/TestOrderStatusJsonApiResource.php
+++ b/tests/Fixtures/TestOrderStatusJsonApiResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+/**
+ * @mixin \Knuckles\Scribe\Tests\Fixtures\TestOrderStatus
+ */
+class TestOrderStatusJsonApiResource extends JsonApiResource
+{
+    public function toType(Request $request): string
+    {
+        return 'order_statuses';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+        ];
+    }
+}

--- a/tests/Fixtures/TestPostJsonApiResource.php
+++ b/tests/Fixtures/TestPostJsonApiResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+/**
+ * @mixin \Knuckles\Scribe\Tests\Fixtures\TestPost
+ */
+class TestPostJsonApiResource extends JsonApiResource
+{
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'title' => $this->title,
+            'body' => $this->body,
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'tags' => TestTagJsonApiResource::class,
+        ];
+    }
+}

--- a/tests/Fixtures/TestPostJsonApiResourceWithProperties.php
+++ b/tests/Fixtures/TestPostJsonApiResourceWithProperties.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+/**
+ * Declares its attributes and relationships as properties rather than by overriding
+ * `toAttributes()`/`toRelationships()`, and using the int-key style for both.
+ *
+ * @mixin \Knuckles\Scribe\Tests\Fixtures\TestPost
+ */
+class TestPostJsonApiResourceWithProperties extends JsonApiResource
+{
+    protected array $attributes = ['title', 'body'];
+
+    protected array $relationships = ['tags'];
+}

--- a/tests/Fixtures/TestTagJsonApiResource.php
+++ b/tests/Fixtures/TestTagJsonApiResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Fixtures;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+class TestTagJsonApiResource extends JsonApiResource
+{
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+        ];
+    }
+}

--- a/tests/GenerateDocumentation/JsonApiOutputTest.php
+++ b/tests/GenerateDocumentation/JsonApiOutputTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\GenerateDocumentation;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Route as RouteFacade;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Knuckles\Scribe\Tests\BaseLaravelTest;
+use Knuckles\Scribe\Tests\Fixtures\TestJsonApiController;
+use Knuckles\Scribe\Tests\TestHelpers;
+use Knuckles\Scribe\Tools\Utils;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * End-to-end output for Laravel's JSON:API resources (12.45+).
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+class JsonApiOutputTest extends BaseLaravelTest
+{
+    use TestHelpers;
+
+    private const POST_TYPE = 'test_post_json_apis';
+
+    private const TAG_TYPE = 'test_tag_json_apis';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Must come before anything touches a fixture extending JsonApiResource.
+        $this->skipIfNoJsonApiResources();
+
+        $this->createSchema();
+    }
+
+    protected function tearDown(): void
+    {
+        Utils::deleteDirectoryAndContents('public/docs');
+        Utils::deleteDirectoryAndContents('.scribe');
+
+        parent::tearDown();
+    }
+
+    public function test_documents_the_json_api_content_type_and_query_parameters_in_the_openapi_spec()
+    {
+        RouteFacade::get('/api/posts/{id}', [TestJsonApiController::class, 'showPost']);
+        $this->setConfig(['openapi.enabled' => true]);
+
+        $this->generate();
+
+        $operation = Yaml::parseFile($this->openapiOutputPath())['paths']['/api/posts/{id}']['get'];
+
+        $this->assertArrayHasKey(
+            'application/vnd.api+json',
+            $operation['responses'][200]['content']
+        );
+
+        $parameters = collect($operation['parameters'])->keyBy('name');
+
+        $this->assertStringContainsString('`tags`', $parameters['include']['description']);
+        $this->assertArrayNotHasKey('enum', $parameters['include']['schema']);
+        $this->assertEquals('tags', $parameters['include']['example']);
+
+        $this->assertStringContainsString('`title`, `body`', $parameters['fields['.self::POST_TYPE.']']['description']);
+    }
+
+    public function test_sends_the_include_parameter_in_example_requests()
+    {
+        RouteFacade::get('/api/posts/{id}', [TestJsonApiController::class, 'showPost']);
+
+        $this->generate();
+
+        $this->assertFileContainsString($this->bladeOutputPath(), '?include=tags"');
+        $this->assertFileContainsString($this->bladeOutputPath(), '--header "Accept: application/vnd.api+json"');
+    }
+
+    public function test_documents_a_sparse_fieldset_per_resource_type_in_the_parameters_table()
+    {
+        RouteFacade::get('/api/posts/{id}', [TestJsonApiController::class, 'showPost']);
+
+        $this->generate();
+
+        // The main resource, plus the resource of the relationship the example model was loaded with.
+        $this->assertFileContainsString($this->bladeOutputPath(), 'fields['.self::POST_TYPE.']');
+        $this->assertFileContainsString($this->bladeOutputPath(), 'fields['.self::TAG_TYPE.']');
+    }
+
+    public function test_does_not_take_the_whole_generation_down_when_a_resource_has_no_model()
+    {
+        RouteFacade::get('/api/broken', [TestJsonApiController::class, 'resourceWithoutAModel']);
+        RouteFacade::get('/api/posts/{id}', [TestJsonApiController::class, 'showPost']);
+
+        $output = $this->generate();
+
+        $this->assertStringContainsString("Couldn't render your JSON:API resource", $output);
+        // The other endpoint still made it into the docs.
+        $this->assertFileContainsString($this->bladeOutputPath(), 'A JSON:API post');
+    }
+
+    protected function openapiOutputPath(): string
+    {
+        return Storage::disk('local')->path('scribe/openapi.yaml');
+    }
+
+    protected function bladeOutputPath(): string
+    {
+        return \Illuminate\Support\Facades\View::getFinder()->find('scribe/index');
+    }
+
+    protected function createSchema(): void
+    {
+        Schema::create('test_posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('body');
+            $table->timestamps();
+        });
+
+        Schema::create('test_tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('taggables', function (Blueprint $table) {
+            $table->id();
+            $table->string('test_tag_id');
+            $table->string('taggable_type');
+            $table->string('taggable_id');
+            $table->string('priority');
+        });
+    }
+}

--- a/tests/Strategies/Responses/JsonApiResourceTest.php
+++ b/tests/Strategies/Responses/JsonApiResourceTest.php
@@ -1,0 +1,442 @@
+<?php
+
+namespace Knuckles\Scribe\Tests\Strategies\Responses;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Schema;
+use Knuckles\Camel\Extraction\ExtractedEndpointData;
+use Knuckles\Scribe\Attributes\ResponseFromApiResource;
+use Knuckles\Scribe\Extracting\Strategies\Responses\UseApiResourceTags;
+use Knuckles\Scribe\Extracting\Strategies\Responses\UseResponseAttributes;
+use Knuckles\Scribe\Tests\BaseLaravelTest;
+use Knuckles\Scribe\Tests\Fixtures\TestController;
+use Knuckles\Scribe\Tests\Fixtures\TestEmptyJsonApiResource;
+use Knuckles\Scribe\Tests\Fixtures\TestPost;
+use Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource;
+use Knuckles\Scribe\Tools\DocumentationConfig;
+use Mpociot\Reflection\DocBlock\Tag;
+
+/**
+ * Laravel's JSON:API resources (`Illuminate\Http\Resources\JsonApi`), added in 12.45.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+class JsonApiResourceTest extends BaseLaravelTest
+{
+    /**
+     * Both types are derived by the framework from the resource class name.
+     */
+    private const POST_TYPE = 'test_post_json_apis';
+
+    private const TAG_TYPE = 'test_tag_json_apis';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Must come before anything touches a fixture extending JsonApiResource.
+        $this->skipIfNoJsonApiResources();
+
+        $this->setConfig(['database_connections_to_transact' => []]);
+        $this->createSchema();
+    }
+
+    public function test_does_not_include_relationships_the_example_model_was_not_loaded_with()
+    {
+        $content = $this->getContent([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost'),
+        ]);
+
+        $this->assertEquals([
+            'id' => '1',
+            'type' => self::POST_TYPE,
+            'attributes' => ['title' => 'Test title', 'body' => 'random body'],
+        ], $content['data']);
+        $this->assertArrayNotHasKey('relationships', $content['data']);
+        $this->assertArrayNotHasKey('included', $content);
+    }
+
+    public function test_includes_the_relationships_the_example_model_was_loaded_with()
+    {
+        $content = $this->getContent([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags'),
+        ]);
+
+        $this->assertEquals(
+            ['tags' => ['data' => [['id' => '1', 'type' => self::TAG_TYPE]]]],
+            $content['data']['relationships']
+        );
+        $this->assertEquals(
+            [['id' => '1', 'type' => self::TAG_TYPE, 'attributes' => ['name' => 'tag 1']]],
+            $content['included']
+        );
+    }
+
+    public function test_reads_relationships_and_attributes_declared_as_properties()
+    {
+        $content = $this->getContent([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResourceWithProperties'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags'),
+        ]);
+
+        // Both are declared with int keys (`['tags']`), so the name lives in the value.
+        $this->assertEquals(['title' => 'Test title', 'body' => 'random body'], $content['data']['attributes']);
+        // No resource class was given for the relationship, so the framework types it off the model.
+        $this->assertEquals(['tags' => ['data' => [['id' => '1', 'type' => 'test_tags']]]], $content['data']['relationships']);
+        $this->assertCount(1, $content['included']);
+    }
+
+    public function test_includes_relationships_in_collections()
+    {
+        $content = $this->getContent([
+            new Tag('apiResourceCollection', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags'),
+        ]);
+
+        $this->assertCount(2, $content['data']);
+        foreach ($content['data'] as $item) {
+            $this->assertEquals(['tags' => ['data' => [['id' => '1', 'type' => self::TAG_TYPE]]]], $item['relationships']);
+        }
+        $this->assertNotEmpty($content['included']);
+    }
+
+    public function test_includes_relationships_in_paginated_collections()
+    {
+        $content = $this->getContent([
+            new Tag('apiResourceCollection', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags paginate=1'),
+        ]);
+
+        $this->assertCount(1, $content['data']);
+        $this->assertEquals(['tags' => ['data' => [['id' => '1', 'type' => self::TAG_TYPE]]]], $content['data'][0]['relationships']);
+        $this->assertNotEmpty($content['included']);
+        $this->assertArrayHasKey('links', $content);
+        $this->assertArrayHasKey('meta', $content);
+    }
+
+    public function test_keeps_additional_data_alongside_included()
+    {
+        $content = $this->getContent([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags'),
+            new Tag('apiResourceAdditional', 'a=b'),
+        ]);
+
+        $this->assertEquals('b', $content['a']);
+        $this->assertNotEmpty($content['included']);
+    }
+
+    public function test_documents_the_json_api_content_type_of_the_response()
+    {
+        $results = $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost'),
+        ]);
+
+        $this->assertEquals(['content-type' => 'application/vnd.api+json'], $results[0]['headers']);
+    }
+
+    public function test_documents_the_include_query_parameter()
+    {
+        $endpointData = $this->makeEndpointData();
+        $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags'),
+        ], $endpointData);
+
+        $include = $endpointData->queryParameters['include'];
+        $this->assertStringContainsString('`tags`', $include->description);
+        $this->assertStringContainsString('dot notation', $include->description);
+        $this->assertEmpty($include->enumValues);
+        $this->assertEquals('tags', $include->example);
+        $this->assertEquals('tags', $endpointData->cleanQueryParameters['include']);
+    }
+
+    public function test_does_not_give_the_include_query_parameter_an_example_when_no_relations_were_loaded()
+    {
+        $endpointData = $this->makeEndpointData();
+        $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost'),
+        ], $endpointData);
+
+        // Documented in the parameters table, but left out of the example requests, so those
+        // stay consistent with the example response, which has no relationships in it.
+        $this->assertStringContainsString('`tags`', $endpointData->queryParameters['include']->description);
+        $this->assertNull($endpointData->queryParameters['include']->example);
+        $this->assertArrayNotHasKey('include', $endpointData->cleanQueryParameters);
+    }
+
+    public function test_documents_the_sparse_fieldset_query_parameter()
+    {
+        $endpointData = $this->makeEndpointData();
+        $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost'),
+        ], $endpointData);
+
+        $name = 'fields['.self::POST_TYPE.']';
+        $this->assertStringContainsString('`title`, `body`', $endpointData->queryParameters[$name]->description);
+        // No example: unlike `include`, a sparse fieldset doesn't change the example response,
+        // so it stays out of the example requests (same rule the package's `No-example` uses).
+        $this->assertNull($endpointData->queryParameters[$name]->example);
+        $this->assertArrayNotHasKey('fields', $endpointData->cleanQueryParameters);
+    }
+
+    public function test_documents_a_sparse_fieldset_for_the_types_of_relationships_that_were_loaded()
+    {
+        $endpointData = $this->makeEndpointData();
+        $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags'),
+        ], $endpointData);
+
+        // Here the related type is the one the framework derives from the resource class name;
+        // an overridden `toType()` is covered by the nested test below.
+        $name = 'fields['.self::TAG_TYPE.']';
+        $this->assertArrayHasKey($name, $endpointData->queryParameters);
+        $this->assertStringContainsString('`name`', $endpointData->queryParameters[$name]->description);
+        $this->assertNull($endpointData->queryParameters[$name]->example);
+    }
+
+    public function test_documents_a_sparse_fieldset_for_every_type_in_a_nested_relation()
+    {
+        $this->createOrderSchema();
+
+        $endpointData = $this->makeEndpointData();
+        $results = $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestOrderOwnerJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestOrderOwner with=order.status'),
+        ], $endpointData);
+
+        $content = json_decode($results[0]['content'], true);
+        $this->assertEquals(['orders', 'order_statuses'], array_column($content['included'], 'type'));
+
+        // One fieldset per type in that response: the owner, its order, and the order's status.
+        $this->assertEquals([
+            'include',
+            'fields[order_owners]',
+            'fields[orders]',
+            'fields[order_statuses]',
+        ], array_keys($endpointData->queryParameters));
+        $this->assertStringContainsString(
+            '`name`', $endpointData->queryParameters['fields[order_statuses]']->description
+        );
+
+        $this->assertEquals('order.status', $endpointData->queryParameters['include']->example);
+        $this->assertStringContainsString('`order`', $endpointData->queryParameters['include']->description);
+    }
+
+    public function test_does_not_document_a_sparse_fieldset_for_relationships_that_were_not_loaded()
+    {
+        $endpointData = $this->makeEndpointData();
+        $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost'),
+        ], $endpointData);
+
+        // Without the relation loaded there's no model to read the related attribute names off,
+        // and the relationship isn't in the example response either.
+        $this->assertArrayHasKey('fields['.self::POST_TYPE.']', $endpointData->queryParameters);
+        $this->assertArrayNotHasKey('fields['.self::TAG_TYPE.']', $endpointData->queryParameters);
+    }
+
+    public function test_does_not_overwrite_query_parameters_the_user_documented()
+    {
+        $endpointData = $this->makeEndpointData();
+        $endpointData->queryParameters['include'] = new \Knuckles\Camel\Extraction\Parameter([
+            'name' => 'include', 'description' => 'Mine', 'example' => 'mine',
+        ]);
+
+        $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags'),
+        ], $endpointData);
+
+        $this->assertEquals('Mine', $endpointData->queryParameters['include']->description);
+        $this->assertEquals('mine', $endpointData->queryParameters['include']->example);
+    }
+
+    public function test_can_turn_off_query_parameter_documentation()
+    {
+        $endpointData = $this->makeEndpointData();
+        $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostJsonApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags'),
+        ], $endpointData, ['json_api' => ['document_query_parameters' => false]]);
+
+        $this->assertEmpty($endpointData->queryParameters);
+    }
+
+    public function test_warns_instead_of_crashing_when_there_is_no_model_for_the_resource()
+    {
+        // A JSON:API response needs an id, and Scribe passes an empty array when it can't find a
+        // model, which used to blow up with a TypeError — an Error, not an Exception, so it took
+        // the whole generation down instead of just this endpoint.
+        // See https://github.com/knuckleswtf/scribe/issues/652.
+        $boundRequest = app('request');
+        $results = $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestEmptyJsonApiResource'),
+        ]);
+
+        $this->assertNull($results);
+        // Rendering threw halfway through, so the request we bound for it must still be unbound,
+        // or every endpoint extracted after this one would be handed it.
+        $this->assertSame($boundRequest, app('request'));
+    }
+
+    public function test_does_not_touch_regular_api_resources()
+    {
+        $endpointData = $this->makeEndpointData();
+        $results = $this->fetch([
+            new Tag('apiResource', '\Knuckles\Scribe\Tests\Fixtures\TestPostApiResource'),
+            new Tag('apiResourceModel', '\Knuckles\Scribe\Tests\Fixtures\TestPost with=tags'),
+        ], $endpointData);
+
+        $this->assertEquals(json_encode([
+            'data' => [
+                'id' => 1,
+                'title' => 'Test title',
+                'body' => 'random body',
+                'tags' => [['id' => 1, 'name' => 'tag 1', 'priority' => 'high']],
+            ],
+        ]), $results[0]['content']);
+        $this->assertEmpty($results[0]['headers']);
+        $this->assertEmpty($endpointData->queryParameters);
+        $this->assertEmpty($endpointData->headers);
+    }
+
+    public function test_supports_the_response_from_api_resource_attribute()
+    {
+        $endpointData = $this->attributeEndpoint('postWithTags');
+        $results = (new UseResponseAttributes(new DocumentationConfig))($endpointData, []);
+
+        $content = json_decode($results[0]['content'], true);
+        $this->assertEquals(
+            ['tags' => ['data' => [['id' => '1', 'type' => self::TAG_TYPE]]]],
+            $content['data']['relationships']
+        );
+        $this->assertNotEmpty($content['included']);
+        // `additional()` data is merged in alongside `included`, not swallowed by it.
+        $this->assertEquals(['total' => 10], $content['meta']);
+        $this->assertEquals(['content-type' => 'application/vnd.api+json'], $results[0]['headers']);
+        $this->assertEquals('tags', $endpointData->queryParameters['include']->example);
+    }
+
+    public function test_the_response_from_api_resource_attribute_warns_when_there_is_no_model()
+    {
+        $results = (new UseResponseAttributes(new DocumentationConfig))($this->attributeEndpoint('noModel'), []);
+
+        $this->assertEmpty($results);
+    }
+
+    /**
+     * @param  Tag[]  $tags
+     */
+    protected function fetch(array $tags, ?ExtractedEndpointData $endpointData = null, array $config = []): ?array
+    {
+        $strategy = new UseApiResourceTags(new DocumentationConfig($config));
+
+        return $strategy->getApiResourceResponseFromTags(
+            $strategy->getApiResourceTag($tags), $tags, $endpointData ?: $this->makeEndpointData()
+        );
+    }
+
+    /**
+     * @param  Tag[]  $tags
+     */
+    protected function getContent(array $tags): array
+    {
+        return json_decode($this->fetch($tags)[0]['content'], true);
+    }
+
+    protected function attributeEndpoint(string $method): ExtractedEndpointData
+    {
+        $endpoint = new class extends ExtractedEndpointData
+        {
+            public function __construct(array $parameters = []) {}
+        };
+        $endpoint->controller = new \ReflectionClass(JsonApiAttributesTestController::class);
+        $endpoint->method = $endpoint->controller->getMethod($method);
+        $endpoint->route = new Route(['GET'], '/somethingRandom', ['uses' => [JsonApiAttributesTestController::class, $method]]);
+
+        return $endpoint;
+    }
+
+    protected function makeEndpointData(): ExtractedEndpointData
+    {
+        return ExtractedEndpointData::fromRoute(
+            new Route(['GET'], '/somethingRandom', ['uses' => [TestController::class, 'dummy']])
+        );
+    }
+
+    protected function createSchema(): void
+    {
+        Schema::create('test_posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('body');
+            $table->timestamps();
+        });
+
+        Schema::create('test_tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('taggables', function (Blueprint $table) {
+            $table->id();
+            $table->string('test_tag_id');
+            $table->string('taggable_type');
+            $table->string('taggable_id');
+            $table->string('priority');
+        });
+    }
+
+    /**
+     * An owner -> order -> status chain, for the tests that need a nested relation.
+     */
+    protected function createOrderSchema(): void
+    {
+        Schema::create('test_order_statuses', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+
+        Schema::create('test_orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('status_id')->nullable();
+            $table->foreignId('delivery_id')->nullable();
+        });
+
+        Schema::create('test_order_owners', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->nullable();
+            $table->foreignId('status_id')->nullable();
+        });
+    }
+}
+
+/**
+ * Only ever instantiated from tests that skipped themselves if JSON:API resources are unavailable.
+ * The resource class names below are `::class` constants, so nothing here autoloads on older versions.
+ */
+class JsonApiAttributesTestController
+{
+    #[ResponseFromApiResource(
+        TestPostJsonApiResource::class,
+        TestPost::class,
+        with: ['tags'],
+        additional: ['meta' => ['total' => 10]],
+    )]
+    public function postWithTags() {}
+
+    #[ResponseFromApiResource(TestEmptyJsonApiResource::class)]
+    public function noModel() {}
+}


### PR DESCRIPTION
This PR adds support for Laravel's JSON:API resources. Closes #1073

### Design decisions

**Nothing new to learn: `with` is what drives it.** If you already write `@apiResourceModel App\Models\Post with=tags` (or `with: ['tags']` on the attribute), those relations now show up as `relationships` + `included` in the example response, and the example request gets `?include=tags` to match. No extra `include:` field to fill in — the two lists are always the same thing.

**Without `with`, the example response stays what it is today.** No relations are guessed for you, so nothing new appears in the body — the relationships the resource declares are listed in the docs for the `include` parameter instead of being silently baked into the response.

**`include` and `fields[<type>]` are documented for you**, from the relationships and attributes the resource declares. Anything you wrote yourself (say, an `@queryParam include`) wins, and the new `json_api.document_query_parameters` config key turns the whole thing off if you'd rather not have them.

**The available relationships are listed in the parameter description.** Same for `fields[<type>]`.

**The example requests send `Accept: application/vnd.api+json`.** A value you picked yourself wins, with one exception: the generic `application/json` that the shipped `config/scribe.php` puts there via `StaticData` gets upgraded, since on a JSON:API endpoint it's a leftover default rather than a choice.

**Nested relations in `with` are followed all the way down.** `with: ['comments.author']` puts every level into the response's `included`, so every level gets its own `fields[<type>]` too.

**A resource with no model no longer takes the whole run down.** You get a warning naming the endpoint, that one response is skipped, and generation continues.

### Examples

<details>
<summary>Relations from <code>with</code> show up in the response, and in the example request as <code>?include=author,tags</code></summary>
<code>#[ResponseFromApiResource(name: PostResource::class, model: Post::class, with: ['author', 'tags'])]</code>
<img width="1128" height="772" alt="image" src="https://github.com/user-attachments/assets/c3e1d7be-ec0f-444d-8ff2-a0452bd7f907" />


</details>


<details>
<summary>A nested relation is followed to the end, so every type along the way gets its own <code>fields[…]</code></summary>
<code>#[ResponseFromApiResource(name: PostResource::class, model: Post::class, with: ['comments.author', 'tags'])]</code>

<img width="1123" height="813" alt="image" src="https://github.com/user-attachments/assets/6851ba54-2ca5-4eb2-80ce-70ba790ce175" />


</details>


<details>
<summary>Without <code>with</code> the response is unchanged, and the declared relationships are listed on the <code>include</code> parameter instead</summary>
<code>#[ResponseFromApiResource(name: PostResource::class, model: Post::class)]</code>

<img width="1119" height="673" alt="image" src="https://github.com/user-attachments/assets/4e1a2585-68c5-4b3f-a55f-3a953476752d" />

</details>

### Compatibility

Guarded by `class_exists()` everywhere, and the tests skip via `markTestSkipped()` in `setUp()` before the fixtures are ever autoloaded.

### Known limitations

- **`fetch()` was kept as a wrapper** over the new `fetchResponse()`, with its return type unchanged — it's a public static method that third-party strategies may well be using. The new `$with` / `$documentJsonApiQueryParameters` arguments were appended with defaults, and the documenting flag defaults to `false` so existing `fetch()` callers don't suddenly start writing into `$endpointData->queryParameters`.
- **`type` is derived from the class name** by the framework (`classBasename()->basename('Resource')->snake()->pluralStudly()`), unless the resource overrides `toType()`.
- **`fields[<type>]` is only documented for relationships listed in `with`** — the attribute list of a related resource is only readable once the relation is actually loaded on the example model. Relationships declared with an int key (`['tags']`) or a Closure are skipped, since the resource class isn't statically known there;
- **`@responseField` paths need the JSON:API prefix** — `title` lives at `data.attributes.title`. Not something this PR changes (the envelope is the resource's own doing, before and after), just worth knowing when moving an endpoint over to a JSON:API resource. It won't break outright either: there's a fallback to the short name.

### Changes

- **`src/Extracting/Shared/JsonApiResourceTools.php`** (new) — detection, reading declared relationships/attributes, resolving resource types, and writing the `include` / `fields[<type>]` parameters, the `Accept` request header and the response headers.
- **`src/Extracting/Shared/ApiResourceResponseTools.php`** — added `fetchResponse()` returning the full `JsonResponse`; the synthetic request now carries query parameters; `\Throwable` guard around instantiation and rendering, so a resource with no model warns and skips instead of aborting the run; the `request` container binding is now restored in a `finally`.
- **`src/Extracting/Strategies/Responses/UseApiResourceTags.php`**, **`UseResponseAttributes.php`** — pass `with` through, fill in `headers`, skip the response when rendering failed.
- **`config/scribe.php`** — `json_api.document_query_parameters`.
- **`phpstan.neon`** — ignore `class.notFound` in `JsonApiResourceTools.php` with `reportUnmatched: false`, so running the matrix locally on 9–11 doesn't get false errors.
- **tests** — `tests/Strategies/Responses/JsonApiResourceTest.php`, `tests/GenerateDocumentation/JsonApiOutputTest.php`, plus `BaseLaravelTest::skipIfNoJsonApiResources()` and JSON:API fixtures.
