### PR TITLE
Fix 204 responses still including a content schema

### DIFF
--- a/src/Extracting/ParamHelpers.php
+++ b/src/Extracting/ParamHelpers.php
@@ -5,7 +5,6 @@ namespace Knuckles\Scribe\Extracting;
 use Faker\Factory;
 use Faker\Generator;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait ParamHelpers

--- a/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
+++ b/src/Writing/OpenApiSpecGenerators/BaseGenerator.php
@@ -352,7 +352,7 @@ class BaseGenerator extends OpenApiGenerator
             $code = $response->status; // OpenAPI spec requires status codes to be integers
             // OpenAPI groups responses by status code
             // Only one response type per status code, so only the last one will be used
-            if ($code === '204') {
+            if ($code === 204) {
                 // Must not add content for 204
                 $responses[$code] = [
                     'description' => $this->getResponseDescription($response),

--- a/tests/Unit/OpenAPISpecWriterTest.php
+++ b/tests/Unit/OpenAPISpecWriterTest.php
@@ -655,6 +655,30 @@ class OpenAPISpecWriterTest extends BaseUnitTest
         ], $results['paths']['/path2']['put']['responses']);
     }
 
+    public function test_204_responses_never_include_a_content_schema()
+    {
+        $endpointData = $this->createMockEndpointData([
+            'uri' => '/books/{id}',
+            'httpMethods' => ['DELETE'],
+            'responses' => [
+                [
+                    'status' => 204,
+                    'description' => '',
+                    'content' => '{"id": 1, "title": "Some title"}',
+                ],
+            ],
+        ]);
+        $groups = [$this->createGroup([$endpointData])];
+
+        $results = $this->generate($groups);
+
+        $this->assertEquals([
+            '204' => [
+                'description' => '',
+            ],
+        ], $results['paths']['/books/{id}']['delete']['responses']);
+    }
+
     public function test_applies_required_flag_for_nested_response_fields_with_dot_notation()
     {
         $endpointData = $this->createMockEndpointData([


### PR DESCRIPTION
## Problem

Responses documented with status `204` still get a full `content` schema in the generated OpenAPI spec, instead of the expected empty response.

```php
#[ResponseFromApiResource(BookResource::class, Book::class, 204)]
// or
#[Response(status: 204)]
public function destroy(Book $book)
{
    $book->delete();

    return response()->noContent();
}
```

Generated `openapi.yaml` (current, incorrect):

```yaml
responses:
  204:
    description: ''
    content:
      application/json:
        schema:
          type: object
          properties:
            id: { type: integer, example: 1 }
            title: { type: string, example: 'Some title' }
            # ...the whole resource/model, or a generic {type: object, nullable: true}
```

Expected (per the OpenAPI spec, a `204` response has no body):

```yaml
responses:
  204:
    description: ''
```

## Root cause

In `BaseGenerator::generateEndpointResponsesSpec()`:

```php
$code = $response->status; // OpenAPI spec requires status codes to be integers
if ($code === '204') {
    // Must not add content for 204
    ...
}
```

`Knuckles\Camel\Extraction\Response::$status` is declared as a strictly-typed `int` (and is cast with `(int)` in its constructor), so `$code` is always an `int`. Comparing it with `===` against the string `'204'` is therefore always `false`.


## Note

This branch also includes an unrelated one-line commit removing an unused import in src/Extracting/ParamHelpers.php. It was failing my branch's CI. Happy to drop it from this PR if you'd rather handle it separately.